### PR TITLE
Implement restriction on number of requests/second that can be made

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pandas==1.4.1
 numpy==1.22.2
 requests==2.27.1
 openpyxl
+ratelimit==2.2.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,4 +30,5 @@ install_requires=
     numpy
     requests
     openpyxl
+    ratelimit
     

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setuptools.setup(
         "pandas; python_version>='3'",
         "requests; python_version>='3'",
         "openpyxl; python_version>='3'",
+        "ratelimit; python_version>='3'"
     ],
     python_requires=">=3.6",
     classifiers=[

--- a/src/ozone/ozone.py
+++ b/src/ozone/ozone.py
@@ -2,9 +2,14 @@ import pandas
 import numpy
 import requests
 import json
+from ratelimit import limits, sleep_and_retry
 from .urls import URLs
 
 from typing import Any, Dict, List, Union, Tuple
+
+# 1000 calls per second is the limit allowed by API
+CALLS = 1000
+RATE_LIMIT = 1
 
 
 class Ozone:
@@ -42,6 +47,8 @@ class Ozone:
             if json.loads(r.content)["status"] != "ok":
                 print("Warning: Token may be invalid!")
 
+    @sleep_and_retry
+    @limits(calls=CALLS, period=RATE_LIMIT)
     def _make_api_request(self, url: str) -> requests.Response:
         """Make an API request
 


### PR DESCRIPTION
in solving this issue i relied on the infamous package ratelimit, considering how efficient and clean it makes the code.
i had to look up the website API to see the quota imposed by it and as it turns out it allows up to 1000 requests per
second.
i also added this package to the project dependencies  in the following three files:

1. requirements.txt
2. setup.cfg
3. setup.py
