### PR TITLE
feat: Add capability to scrape historical data

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ numpy==1.22.2
 requests==2.27.1
 openpyxl
 ratelimit==2.2.1
+selenium==4.1.2
+webdriver-manager==3.5.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,4 +31,6 @@ install_requires=
     requests
     openpyxl
     ratelimit
+    selenium
+    webdriver-manager
     

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,9 @@ setuptools.setup(
         "requests; python_version>='3'",
         "openpyxl; python_version>='3'",
         "ratelimit; python_version>='3'"
+        "selenium; python_version>='3'"
+        "webdriver-manager; python_version>='3'"
+
     ],
     python_requires=">=3.6",
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,8 @@ setuptools.setup(
         "pandas; python_version>='3'",
         "requests; python_version>='3'",
         "openpyxl; python_version>='3'",
-        "ratelimit; python_version>='3'"
-        "selenium; python_version>='3'"
+        "ratelimit; python_version>='3'",
+        "selenium; python_version>='3'",
         "webdriver-manager; python_version>='3'"
 
     ],

--- a/src/ozone/ozone.py
+++ b/src/ozone/ozone.py
@@ -4,7 +4,7 @@ import requests
 import json
 from ratelimit import limits, sleep_and_retry
 from .urls import URLs
-
+from .scraping import AirHistoryScraper, AirDataHistory
 from typing import Any, Dict, List, Union, Tuple
 
 # 1000 calls per second is the limit allowed by API
@@ -240,6 +240,16 @@ class Ozone:
         for city in cities:
             df = self.get_city_air(city, df, params)
         df.reset_index(inplace=True, drop=True)
+        return self._format_output(data_format, df)
+
+    def get_historical_data(self, search_query: str,
+                            data_format: str = None) -> pandas.DataFrame:
+        scraper: AirHistoryScraper = AirHistoryScraper()
+        all_tables: List[AirDataHistory] = scraper.execute(search_query=search_query)
+
+        header: List[str] = [table.air for table in all_tables]
+        data_rows: List[Tuple[int]] = [row for row in zip(*all_tables)]
+        df = pandas.DataFrame(data_rows, columns=header)
         return self._format_output(data_format, df)
 
 

--- a/src/ozone/scraping.py
+++ b/src/ozone/scraping.py
@@ -1,0 +1,191 @@
+from typing import Any, Dict, List, Union, Tuple
+import datetime
+import calendar
+import itertools
+import time
+import os
+import re
+
+from selenium import webdriver
+from webdriver_manager.firefox import GeckoDriverManager
+from selenium.webdriver.firefox.options import Options
+from selenium.webdriver.common.by import By
+from selenium.webdriver.remote.webelement import WebElement
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.common.keys import Keys
+
+
+def create_selenium_web_driver(headless: bool, verbosity: bool):
+    if verbosity:
+        os.environ['WDM_LOG_LEVEL'] = '0'
+
+    opts = Options()
+    opts.add_argument("--headless") if headless else None
+
+    browser = webdriver.Firefox(executable_path=GeckoDriverManager().install(), options=opts)
+    browser.maximize_window()
+    return browser
+
+
+# model wide object for use by other scrapers
+_SELENIUM_WEB_DRIVER = create_selenium_web_driver(headless=True, verbosity=True)
+
+
+class DateOutOfRange(Exception):
+    def __init__(self, message):
+        super().__init__(message)
+
+
+class AirDataHistory:
+
+    def __init__(self, data: List[int], air_type: str, start_date: datetime.datetime, end_date: datetime.datetime):
+        self.start_date: datetime.datetime = start_date
+        self.end_date: datetime.datetime = end_date
+        self.current_date: datetime.datetime = start_date
+        self.data: List[int] = data
+        self._air: str = air_type
+        if (self.end_date - self.start_date).days + 1 != len(data):
+            raise ValueError(" data values must be equal to the number of days")
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.current_date > self.end_date:
+            raise StopIteration
+
+        value = self.get_air_quality(self.current_date)
+        self.current_date += datetime.timedelta(days=1)
+        return value
+
+    @property
+    def air(self):
+        return self._air
+
+    def get_air_quality(self, date: datetime.datetime) -> int:
+        """Get air quality value at specific date
+        Args:
+            date (datetime.datetime): The date to obtain data value for
+
+        Returns:
+            int: The air quality value at the specified date
+        """
+
+        if not (self.start_date <= date <= self.end_date):
+            raise DateOutOfRange(f'Date passed as argument is not in valid range: '
+                                 f'[{self.start_date} --> {self.end_date}] ')
+
+        index = (date - self.start_date).days
+        return self.data[index]
+
+
+class AirHistoryScraper:
+    _main_url: str = 'https://aqicn.org/data-platform/register/'
+    allowed_gases = ["PM2.5",
+                     "PM10",
+                     "O3",
+                     "NO2",
+                     "SO2",
+                     "CO"]
+    _year_regular_expression = re.compile(r"^[1-3][0-9]{3}$")
+
+    def __init__(self, web_driver: webdriver.Firefox = _SELENIUM_WEB_DRIVER):
+        self.browser: webdriver.Firefox = web_driver
+        self.browser.get(self._main_url)
+        self.history_data: List[AirDataHistory] = []
+
+    def handle_search_form(self, search_query: str):
+        search_form = self.browser.find_element(By.XPATH, "//input[@class='prompt'][@placeholder='station or city']")
+        search_form.send_keys(search_query)
+
+        results = WebDriverWait(self.browser, 10).until(
+            EC.presence_of_all_elements_located((By.CLASS_NAME, "result")))
+
+        search_form.send_keys(Keys.ARROW_DOWN)
+        time.sleep(2)
+        search_form.send_keys(Keys.ENTER)
+        time.sleep(2)
+
+    def get_table_and_buttons(self):
+        sections = WebDriverWait(self.browser, 10).until(
+            EC.presence_of_all_elements_located((By.XPATH, "//div[@class='histui raised segment']")))
+
+        # locate historical data section
+        historical_section = sections[2]
+        gases_header = historical_section.find_element(By.XPATH, ".//ul")
+
+        # locate control buttons ( found at top of table, are used to control table)
+        buttons = gases_header.find_elements(by=By.XPATH, value=".//*")
+        air_button = buttons[0]
+
+        # scroll the buttons into view for ability to click
+        desired_y = (air_button.size['height'] / 2) + air_button.location['y']
+        window_h = self.browser.execute_script('return window.innerHeight')
+        window_y = self.browser.execute_script('return window.pageYOffset')
+        current_y = (window_h / 2) + window_y
+        scroll_y_by = desired_y - current_y
+        self.browser.execute_script("window.scrollBy(0, arguments[0]);", scroll_y_by)
+
+        # locate table
+        table = historical_section.find_element(By.XPATH, ".//table")
+
+        return table, buttons
+
+    def extract_from_table(self, table: WebElement, buttons: List[WebElement]):
+        start_date = None
+
+        end_year = datetime.datetime.now().year
+        end_month = datetime.datetime.now().month
+        end_date = datetime.datetime(end_year, end_month, calendar.monthrange(end_year, end_month)[1])
+
+        data = {"PM2.5": [],
+                "PM10": [],
+                "O3": [],
+                "NO2": [],
+                "SO2": [],
+                "CO": []}
+
+        filtered_buttons = [button for button in buttons if button.text in self.allowed_gases]
+        for button in filtered_buttons:
+            print(f"fetching data for {button.text}")
+            button.click()
+            #time.sleep(2)
+            table_rows = table.find_elements(By.XPATH, ".//tr[@style='display: table-row;']")
+            if not start_date:
+                year_rows = [table_row.text for table_row in table_rows if re.match(self._year_regular_expression,
+                                                                                    table_row.text)]
+                start_date = datetime.datetime(int(year_rows[len(year_rows) - 1]), 1, 1)
+
+            filtered_table_rows = [table_row for table_row in table_rows if not re.match(self._year_regular_expression,
+                                                                                         table_row.text)]
+            for row in filtered_table_rows:
+                cols = row.find_element(By.XPATH, ".//td[@class='squares']")
+                values = cols.find_elements(By.XPATH, ".//*[name()='svg']/*[name()='text']")
+                values = [int(value.text) if value.text != '-' else None for value in values]
+                data[button.text].append(values)
+
+        return data, start_date, end_date
+
+    def execute(self, search_query: str)-> List[AirDataHistory]:
+        """
+
+        :param search_query:
+        :return:
+        """
+        self.handle_search_form(search_query)
+        table, buttons = self.get_table_and_buttons()
+        data, start_date, end_date = self.extract_from_table(table, buttons)
+
+        for air_type, table in data.items():
+            flattened_table = list(itertools.chain(*table))
+            self.history_data.append(AirDataHistory(flattened_table, air_type, start_date, end_date))
+
+        return self.history_data
+
+
+scraper = AirHistoryScraper()
+data = scraper.execute("London")
+for item in zip(*data):
+    print(item)
+

--- a/src/ozone/scraping.py
+++ b/src/ozone/scraping.py
@@ -15,6 +15,8 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.keys import Keys
 
+from .urls import URLs
+
 
 def create_selenium_web_driver(headless: bool, verbosity: bool):
     if verbosity:
@@ -81,7 +83,7 @@ class AirDataHistory:
 
 
 class AirHistoryScraper:
-    _main_url: str = 'https://aqicn.org/data-platform/register/'
+    _main_url: str = URLs.historical_data_url
     allowed_gases = ["PM2.5",
                      "PM10",
                      "O3",
@@ -182,10 +184,4 @@ class AirHistoryScraper:
             self.history_data.append(AirDataHistory(flattened_table, air_type, start_date, end_date))
 
         return self.history_data
-
-
-scraper = AirHistoryScraper()
-data = scraper.execute("London")
-for item in zip(*data):
-    print(item)
 

--- a/src/ozone/scraping.py
+++ b/src/ozone/scraping.py
@@ -28,7 +28,7 @@ def create_selenium_web_driver(headless: bool, verbosity: bool):
     return browser
 
 
-# model wide object for use by other scrapers
+# model level object available for use by other scrapers
 _SELENIUM_WEB_DRIVER = create_selenium_web_driver(headless=True, verbosity=True)
 
 

--- a/src/ozone/scraping.py
+++ b/src/ozone/scraping.py
@@ -40,6 +40,11 @@ class DateOutOfRange(Exception):
 
 
 class AirDataHistory:
+    """
+    A class which encapsulates the historical table data retrieved by scraping and is
+    specific for any gas: ["PM2.5", "PM10", "O3", "NO2", "SO2", "CO"]
+
+    """
 
     def __init__(self, data: List[int], air_type: str, start_date: datetime.datetime, end_date: datetime.datetime):
         self.start_date: datetime.datetime = start_date
@@ -170,11 +175,15 @@ class AirHistoryScraper:
         return data, start_date, end_date
 
     def execute(self, search_query: str)-> List[AirDataHistory]:
+        """ initiates the scraping process for historical data
+            Args:
+                search_query (str): The query location
+
+            Returns:
+                List[AirDataHistory]: a list of AirDataHistory objects
         """
 
-        :param search_query:
-        :return:
-        """
+        print("fetching historical data please wait...")
         self.handle_search_form(search_query)
         table, buttons = self.get_table_and_buttons()
         data, start_date, end_date = self.extract_from_table(table, buttons)

--- a/src/ozone/urls.py
+++ b/src/ozone/urls.py
@@ -9,6 +9,9 @@ class URLs:
     # For search for air quality measuring stations in area.
     find_stations_url: str = f"{_base_url}search/"
 
+    # For historical data scraping
+    historical_data_url: str = 'https://aqicn.org/data-platform/register/'
+
 
 if __name__ == "__main__":
     pass


### PR DESCRIPTION
i would like to explain few points regarding some choices that i made:

1.  The reason i implemented the scraping code in a different model "scraping" is to not clutter the Ozone package main model which should be left for the main functionality of the API itself, i did however add the get_historical_data method to the Ozone class because it is part of the API now (by API i mean the interface that we provide to consumers of the package and not the website API).  Also adding a model specifically for scraping will prove handy in future in case any further scraping features need to be implemented.
2. i added a basic class (AirDataHistory) which encapsulates the data for a single table scraped by the scraper, this class offers useful functionality like for example getting data at certain date or between two dates (the latter will be added shortly), which can be useful if the user is only interested in data across a certain time span
3. The AirDataHistory represents the table data scraped for a specific type of gas, ex: PM2.5 or O3. hence we will have multiple instances of this class for each gas 
4.  i made the selenium web-driver instance global as in model wise, so it can be used by other scrapers as it is needed.

i tested the code a lot on my machine with no errors, however because we are using selenium i reckon we might come across some bugs if the web browser versions differs,  so it needs to be tested before we merge this pull request.