### PR TITLE
Add link to PyPI page in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ I want to make it easy to get your hands on accurate air quality data for your p
 pip install ozon3
 ```
 
+You can find more information on the PyPI page for Ozone [here](https://pypi.org/project/ozon3/).
+
 ## Getting your API token :atom:
 
 To use Ozone, you must first request and get a your own unique API token 🎫. This is required to access for the underlying API to work 👮🏼‍♂️.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ I want to make it easy to get your hands on accurate air quality data for your p
 pip install ozon3
 ```
 
-You can find more information on the PyPI page for Ozone [here](https://pypi.org/project/ozon3/).
+You can find more information on the PyPI page for Ozone [here](https://pypi.org/project/ozon3/) (called as Ozon3 on PyPI).
 
 ## Getting your API token :atom:
 


### PR DESCRIPTION
I've added a line to the README which includes a link to the PyPI page in the pip installation section. I made a mistake of using the wrong git commit message type at first so I corrected that as well.