### PR TITLE
CI/CD: Create GitHub action to assign issues to contributors if they comment on an issue saying "Hold my beer, I got this"

### DIFF
--- a/.github/workflows/take.yml
+++ b/.github/workflows/take.yml
@@ -1,0 +1,15 @@
+name: Assign issue to contributor
+on:
+  issue_comment:
+    types: [created, edited]
+
+
+jobs:
+  assign:
+    name: Take an issue
+    runs-on: ubuntu-latest
+    steps:
+     - name: take the issue
+       uses: kowshik-noor/take-action@beer-comment
+       env:
+        GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
I added a workflow that will assign an issue to any contributor if they comment on an issue saying, "Hold my beer, I got this." I did this by linking the workflow to [a slightly modified version of Brian Douglas's action.](https://github.com/kowshik-noor/take-action/tree/beer-comment) 