### PR TITLE
Add tests suite

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,7 @@ mypy
 flake8
 black
 pre-commit
+
+pytest==7.1.1
+pytest-recording==0.12.0
+python-decouple==3.6

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,7 +2,7 @@
 
 Directories:
 
-1. `cassettes/`: Location of vcrpy and pytest-vcr cassettes.
+1. `cassettes/`: Location of vcrpy and pytest-recording cassettes.
 
 Files:
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,11 @@
+# Test directory -- file structure
+
+Directories:
+
+1. `cassettes/`: Location of vcrpy and pytest-vcr cassettes.
+
+Files:
+
+1. `conftest.py`: Location of pytest global and configuration fixtures.
+2. `utils.py`: Location of global Python helper objects (i.e. constants and `Ozone` instance) to use in tests.
+3. `test_*.py`: Test files, each file is testing one public method.

--- a/tests/README.md
+++ b/tests/README.md
@@ -9,3 +9,49 @@ Files:
 1. `conftest.py`: Location of pytest global and configuration fixtures.
 2. `utils.py`: Location of global Python helper objects (i.e. constants and `Ozone` instance) to use in tests.
 3. `test_*.py`: Test files, each file is testing one public method.
+
+# Setting up and running tests
+
+After setting development environment as pointed out in CONTRIBUTING.md, you should already have all necessary testing packages installed. To run all tests, invoke this command from the root directory.
+
+```sh
+pytest
+```
+
+# Updating tests
+
+Generally, tests should correspond to the necessary specification/expectation of Ozone users. Tests will help us identify if our code is still in line with such expectations.
+
+Tests should be updated when e.g.:
+- There is a new functionality. In this case, add necessary tests accordingly.
+- There is a change in existing functionality that is in line with the expectation of Ozone users. In this case, the tests become outdated and need to be updated.
+- There is a new bug or previously unencountered or undocumented behavior. Add them to the existing tests to make sure the same bug will never slip past again in the future.
+
+# About the cassettes and pytest-recording
+
+This test suite is testing Ozone's functionality, so interaction with outside sources need to be mocked. Ozone uses pytest-recording plugin that uses vcrpy under the hood to record request-response pairs. These request-response pairs are stored as `.yaml` files in `tests/cassettes` directory.
+
+The `test/cassettes` directory is organized as follows:
+
+- Each folder per one test file.
+- Each `.yaml` file per one test function.
+
+For the purposes of this test suite, these request-response pairs are **assumed** to be all correct. In the event that WAQI API changes their specifications (unlikely), these request-response pairs need to be re-recorded. See the next section.
+
+# Adding or updating cassettes
+
+By default, pytest-recording will only use existing cassettes for testing, and will raise error if there's a new interaction that is not contained in existing cassettes. This prevents "accidentally" making a request that is not already been mocked.
+
+This default behavior can be overridden by giving a `record-mode` argument when invoking `pytest`:
+
+- `pytest --record-mode=once` to write new cassettes but not new request-response pairs within existing cassettes.
+- `pytest --record-mode=new_episodes` to write new interactions, even when there's an existing cassette.
+- `pytest --record-mode=rewrite` to rewrite all existing cassettes.
+- `pytest --record-mode=all` to record all interactions again.
+- `pytest --record-mode=none`(default) to only use existing cassettes and raise error if there's a new request that is not recorded in the existing cassettes.
+
+> To have more confidence that the tests will not go over the wire, the `--block-network` flag can also be passed to block all network access.
+
+For more information about pytest-recording:
+- [pytest-recording homepage](https://github.com/kiwicom/pytest-recording)
+- [VCRpy documentation about record modes](https://vcrpy.readthedocs.io/en/latest/usage.html#record-modes)

--- a/tests/cassettes/ozone_init.yaml
+++ b/tests/cassettes/ozone_init.yaml
@@ -1,0 +1,76 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Thu, 21 Apr 2022 01:06:54 GMT
+      Location:
+      - /feed/london/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":57,"idx":5724,"attributions":[{"url":"http://uk-air.defra.gov.uk/","name":"UK-AIR,
+        air quality information resource - Defra, UK","logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"url":"https://londonair.org.uk/","name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","logo":"UK-London-Kings-College.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[51.5073509,-0.1277583],"name":"London","url":"https://aqicn.org/city/london","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":2.6},"h":{"v":78},"no2":{"v":14.8},"o3":{"v":26.6},"p":{"v":1015},"pm10":{"v":26},"pm25":{"v":57},"so2":{"v":0.6},"t":{"v":8.3},"w":{"v":3.6}},"time":{"s":"2022-04-21
+        00:00:00","tz":"+01:00","v":1650499200,"iso":"2022-04-21T00:00:00+01:00"},"forecast":{"daily":{"o3":[{"avg":19,"day":"2022-04-18","max":33,"min":8},{"avg":17,"day":"2022-04-19","max":34,"min":2},{"avg":25,"day":"2022-04-20","max":39,"min":14},{"avg":27,"day":"2022-04-21","max":36,"min":14},{"avg":23,"day":"2022-04-22","max":28,"min":17},{"avg":29,"day":"2022-04-23","max":37,"min":21},{"avg":36,"day":"2022-04-24","max":36,"min":32}],"pm10":[{"avg":18,"day":"2022-04-18","max":26,"min":10},{"avg":23,"day":"2022-04-19","max":31,"min":13},{"avg":19,"day":"2022-04-20","max":36,"min":10},{"avg":19,"day":"2022-04-21","max":28,"min":11},{"avg":18,"day":"2022-04-22","max":20,"min":14},{"avg":20,"day":"2022-04-23","max":23,"min":17},{"avg":16,"day":"2022-04-24","max":17,"min":16}],"pm25":[{"avg":47,"day":"2022-04-18","max":74,"min":23},{"avg":64,"day":"2022-04-19","max":81,"min":45},{"avg":59,"day":"2022-04-20","max":94,"min":33},{"avg":58,"day":"2022-04-21","max":79,"min":37},{"avg":56,"day":"2022-04-22","max":62,"min":46},{"avg":62,"day":"2022-04-23","max":70,"min":52},{"avg":53,"day":"2022-04-24","max":53,"min":52}],"uvi":[{"avg":1,"day":"2022-04-19","max":3,"min":0},{"avg":1,"day":"2022-04-20","max":4,"min":0},{"avg":1,"day":"2022-04-21","max":4,"min":0},{"avg":1,"day":"2022-04-22","max":3,"min":0},{"avg":1,"day":"2022-04-23","max":3,"min":0},{"avg":0,"day":"2022-04-24","max":2,"min":0},{"avg":0,"day":"2022-04-25","max":1,"min":0}]}},"debug":{"sync":"2022-04-21T09:24:45+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:06:54 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "123.812\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2269'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_city_air/test_bad_city.yaml
+++ b/tests/cassettes/test_get_city_air/test_bad_city.yaml
@@ -1,0 +1,138 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//a%20definitely%20nonexistent%20city/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Thu, 21 Apr 2022 01:07:03 GMT
+      Location:
+      - /feed/a%20definitely%20nonexistent%20city/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/a%20definitely%20nonexistent%20city/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"error","data":"Unknown station"}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:07:03 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "137.712\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '43'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed///?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Thu, 21 Apr 2022 01:07:04 GMT
+      Location:
+      - /feed/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"error","message":"404"}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:07:04 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      content-length:
+      - '34'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_city_air/test_bad_data_format.yaml
+++ b/tests/cassettes/test_get_city_air/test_bad_data_format.yaml
@@ -1,0 +1,76 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Thu, 21 Apr 2022 01:07:05 GMT
+      Location:
+      - /feed/london/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":57,"idx":5724,"attributions":[{"url":"http://uk-air.defra.gov.uk/","name":"UK-AIR,
+        air quality information resource - Defra, UK","logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"url":"https://londonair.org.uk/","name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","logo":"UK-London-Kings-College.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[51.5073509,-0.1277583],"name":"London","url":"https://aqicn.org/city/london","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":2.6},"h":{"v":78},"no2":{"v":14.8},"o3":{"v":26.6},"p":{"v":1015},"pm10":{"v":26},"pm25":{"v":57},"so2":{"v":0.6},"t":{"v":8.3},"w":{"v":3.6}},"time":{"s":"2022-04-21
+        00:00:00","tz":"+01:00","v":1650499200,"iso":"2022-04-21T00:00:00+01:00"},"forecast":{"daily":{"o3":[{"avg":19,"day":"2022-04-18","max":33,"min":8},{"avg":17,"day":"2022-04-19","max":34,"min":2},{"avg":25,"day":"2022-04-20","max":39,"min":14},{"avg":27,"day":"2022-04-21","max":36,"min":14},{"avg":23,"day":"2022-04-22","max":28,"min":17},{"avg":29,"day":"2022-04-23","max":37,"min":21},{"avg":36,"day":"2022-04-24","max":36,"min":32}],"pm10":[{"avg":18,"day":"2022-04-18","max":26,"min":10},{"avg":23,"day":"2022-04-19","max":31,"min":13},{"avg":19,"day":"2022-04-20","max":36,"min":10},{"avg":19,"day":"2022-04-21","max":28,"min":11},{"avg":18,"day":"2022-04-22","max":20,"min":14},{"avg":20,"day":"2022-04-23","max":23,"min":17},{"avg":16,"day":"2022-04-24","max":17,"min":16}],"pm25":[{"avg":47,"day":"2022-04-18","max":74,"min":23},{"avg":64,"day":"2022-04-19","max":81,"min":45},{"avg":59,"day":"2022-04-20","max":94,"min":33},{"avg":58,"day":"2022-04-21","max":79,"min":37},{"avg":56,"day":"2022-04-22","max":62,"min":46},{"avg":62,"day":"2022-04-23","max":70,"min":52},{"avg":53,"day":"2022-04-24","max":53,"min":52}],"uvi":[{"avg":1,"day":"2022-04-19","max":3,"min":0},{"avg":1,"day":"2022-04-20","max":4,"min":0},{"avg":1,"day":"2022-04-21","max":4,"min":0},{"avg":1,"day":"2022-04-22","max":3,"min":0},{"avg":1,"day":"2022-04-23","max":3,"min":0},{"avg":0,"day":"2022-04-24","max":2,"min":0},{"avg":0,"day":"2022-04-25","max":1,"min":0}]}},"debug":{"sync":"2022-04-21T09:24:45+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:07:06 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "156.044\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2269'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_city_air/test_column_expected_contents.yaml
+++ b/tests/cassettes/test_get_city_air/test_column_expected_contents.yaml
@@ -1,0 +1,76 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Thu, 21 Apr 2022 01:06:57 GMT
+      Location:
+      - /feed/london/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":57,"idx":5724,"attributions":[{"url":"http://uk-air.defra.gov.uk/","name":"UK-AIR,
+        air quality information resource - Defra, UK","logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"url":"https://londonair.org.uk/","name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","logo":"UK-London-Kings-College.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[51.5073509,-0.1277583],"name":"London","url":"https://aqicn.org/city/london","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":2.6},"h":{"v":78},"no2":{"v":14.8},"o3":{"v":26.6},"p":{"v":1015},"pm10":{"v":26},"pm25":{"v":57},"so2":{"v":0.6},"t":{"v":8.3},"w":{"v":3.6}},"time":{"s":"2022-04-21
+        00:00:00","tz":"+01:00","v":1650499200,"iso":"2022-04-21T00:00:00+01:00"},"forecast":{"daily":{"o3":[{"avg":19,"day":"2022-04-18","max":33,"min":8},{"avg":17,"day":"2022-04-19","max":34,"min":2},{"avg":25,"day":"2022-04-20","max":39,"min":14},{"avg":27,"day":"2022-04-21","max":36,"min":14},{"avg":23,"day":"2022-04-22","max":28,"min":17},{"avg":29,"day":"2022-04-23","max":37,"min":21},{"avg":36,"day":"2022-04-24","max":36,"min":32}],"pm10":[{"avg":18,"day":"2022-04-18","max":26,"min":10},{"avg":23,"day":"2022-04-19","max":31,"min":13},{"avg":19,"day":"2022-04-20","max":36,"min":10},{"avg":19,"day":"2022-04-21","max":28,"min":11},{"avg":18,"day":"2022-04-22","max":20,"min":14},{"avg":20,"day":"2022-04-23","max":23,"min":17},{"avg":16,"day":"2022-04-24","max":17,"min":16}],"pm25":[{"avg":47,"day":"2022-04-18","max":74,"min":23},{"avg":64,"day":"2022-04-19","max":81,"min":45},{"avg":59,"day":"2022-04-20","max":94,"min":33},{"avg":58,"day":"2022-04-21","max":79,"min":37},{"avg":56,"day":"2022-04-22","max":62,"min":46},{"avg":62,"day":"2022-04-23","max":70,"min":52},{"avg":53,"day":"2022-04-24","max":53,"min":52}],"uvi":[{"avg":1,"day":"2022-04-19","max":3,"min":0},{"avg":1,"day":"2022-04-20","max":4,"min":0},{"avg":1,"day":"2022-04-21","max":4,"min":0},{"avg":1,"day":"2022-04-22","max":3,"min":0},{"avg":1,"day":"2022-04-23","max":3,"min":0},{"avg":0,"day":"2022-04-24","max":2,"min":0},{"avg":0,"day":"2022-04-25","max":1,"min":0}]}},"debug":{"sync":"2022-04-21T09:24:45+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:06:57 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "64.921\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2269'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_city_air/test_column_types.yaml
+++ b/tests/cassettes/test_get_city_air/test_column_types.yaml
@@ -1,0 +1,76 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Thu, 21 Apr 2022 01:06:58 GMT
+      Location:
+      - /feed/london/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":57,"idx":5724,"attributions":[{"url":"http://uk-air.defra.gov.uk/","name":"UK-AIR,
+        air quality information resource - Defra, UK","logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"url":"https://londonair.org.uk/","name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","logo":"UK-London-Kings-College.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[51.5073509,-0.1277583],"name":"London","url":"https://aqicn.org/city/london","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":2.6},"h":{"v":78},"no2":{"v":14.8},"o3":{"v":26.6},"p":{"v":1015},"pm10":{"v":26},"pm25":{"v":57},"so2":{"v":0.6},"t":{"v":8.3},"w":{"v":3.6}},"time":{"s":"2022-04-21
+        00:00:00","tz":"+01:00","v":1650499200,"iso":"2022-04-21T00:00:00+01:00"},"forecast":{"daily":{"o3":[{"avg":19,"day":"2022-04-18","max":33,"min":8},{"avg":17,"day":"2022-04-19","max":34,"min":2},{"avg":25,"day":"2022-04-20","max":39,"min":14},{"avg":27,"day":"2022-04-21","max":36,"min":14},{"avg":23,"day":"2022-04-22","max":28,"min":17},{"avg":29,"day":"2022-04-23","max":37,"min":21},{"avg":36,"day":"2022-04-24","max":36,"min":32}],"pm10":[{"avg":18,"day":"2022-04-18","max":26,"min":10},{"avg":23,"day":"2022-04-19","max":31,"min":13},{"avg":19,"day":"2022-04-20","max":36,"min":10},{"avg":19,"day":"2022-04-21","max":28,"min":11},{"avg":18,"day":"2022-04-22","max":20,"min":14},{"avg":20,"day":"2022-04-23","max":23,"min":17},{"avg":16,"day":"2022-04-24","max":17,"min":16}],"pm25":[{"avg":47,"day":"2022-04-18","max":74,"min":23},{"avg":64,"day":"2022-04-19","max":81,"min":45},{"avg":59,"day":"2022-04-20","max":94,"min":33},{"avg":58,"day":"2022-04-21","max":79,"min":37},{"avg":56,"day":"2022-04-22","max":62,"min":46},{"avg":62,"day":"2022-04-23","max":70,"min":52},{"avg":53,"day":"2022-04-24","max":53,"min":52}],"uvi":[{"avg":1,"day":"2022-04-19","max":3,"min":0},{"avg":1,"day":"2022-04-20","max":4,"min":0},{"avg":1,"day":"2022-04-21","max":4,"min":0},{"avg":1,"day":"2022-04-22","max":3,"min":0},{"avg":1,"day":"2022-04-23","max":3,"min":0},{"avg":0,"day":"2022-04-24","max":2,"min":0},{"avg":0,"day":"2022-04-25","max":1,"min":0}]}},"debug":{"sync":"2022-04-21T09:24:45+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:06:59 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "61.161\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2269'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_city_air/test_correct_data_format.yaml
+++ b/tests/cassettes/test_get_city_air/test_correct_data_format.yaml
@@ -1,0 +1,224 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Thu, 21 Apr 2022 01:07:11 GMT
+      Location:
+      - /feed/london/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":57,"idx":5724,"attributions":[{"url":"http://uk-air.defra.gov.uk/","name":"UK-AIR,
+        air quality information resource - Defra, UK","logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"url":"https://londonair.org.uk/","name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","logo":"UK-London-Kings-College.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[51.5073509,-0.1277583],"name":"London","url":"https://aqicn.org/city/london","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":2.6},"h":{"v":78},"no2":{"v":14.8},"o3":{"v":26.6},"p":{"v":1015},"pm10":{"v":26},"pm25":{"v":57},"so2":{"v":0.6},"t":{"v":8.3},"w":{"v":3.6}},"time":{"s":"2022-04-21
+        00:00:00","tz":"+01:00","v":1650499200,"iso":"2022-04-21T00:00:00+01:00"},"forecast":{"daily":{"o3":[{"avg":19,"day":"2022-04-18","max":33,"min":8},{"avg":17,"day":"2022-04-19","max":34,"min":2},{"avg":25,"day":"2022-04-20","max":39,"min":14},{"avg":27,"day":"2022-04-21","max":36,"min":14},{"avg":23,"day":"2022-04-22","max":28,"min":17},{"avg":29,"day":"2022-04-23","max":37,"min":21},{"avg":36,"day":"2022-04-24","max":36,"min":32}],"pm10":[{"avg":18,"day":"2022-04-18","max":26,"min":10},{"avg":23,"day":"2022-04-19","max":31,"min":13},{"avg":19,"day":"2022-04-20","max":36,"min":10},{"avg":19,"day":"2022-04-21","max":28,"min":11},{"avg":18,"day":"2022-04-22","max":20,"min":14},{"avg":20,"day":"2022-04-23","max":23,"min":17},{"avg":16,"day":"2022-04-24","max":17,"min":16}],"pm25":[{"avg":47,"day":"2022-04-18","max":74,"min":23},{"avg":64,"day":"2022-04-19","max":81,"min":45},{"avg":59,"day":"2022-04-20","max":94,"min":33},{"avg":58,"day":"2022-04-21","max":79,"min":37},{"avg":56,"day":"2022-04-22","max":62,"min":46},{"avg":62,"day":"2022-04-23","max":70,"min":52},{"avg":53,"day":"2022-04-24","max":53,"min":52}],"uvi":[{"avg":1,"day":"2022-04-19","max":3,"min":0},{"avg":1,"day":"2022-04-20","max":4,"min":0},{"avg":1,"day":"2022-04-21","max":4,"min":0},{"avg":1,"day":"2022-04-22","max":3,"min":0},{"avg":1,"day":"2022-04-23","max":3,"min":0},{"avg":0,"day":"2022-04-24","max":2,"min":0},{"avg":0,"day":"2022-04-25","max":1,"min":0}]}},"debug":{"sync":"2022-04-21T09:24:45+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:07:11 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "105.151\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2269'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Thu, 21 Apr 2022 01:07:13 GMT
+      Location:
+      - /feed/london/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":57,"idx":5724,"attributions":[{"url":"http://uk-air.defra.gov.uk/","name":"UK-AIR,
+        air quality information resource - Defra, UK","logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"url":"https://londonair.org.uk/","name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","logo":"UK-London-Kings-College.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[51.5073509,-0.1277583],"name":"London","url":"https://aqicn.org/city/london","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":2.6},"h":{"v":78},"no2":{"v":14.8},"o3":{"v":26.6},"p":{"v":1015},"pm10":{"v":26},"pm25":{"v":57},"so2":{"v":0.6},"t":{"v":8.3},"w":{"v":3.6}},"time":{"s":"2022-04-21
+        00:00:00","tz":"+01:00","v":1650499200,"iso":"2022-04-21T00:00:00+01:00"},"forecast":{"daily":{"o3":[{"avg":19,"day":"2022-04-18","max":33,"min":8},{"avg":17,"day":"2022-04-19","max":34,"min":2},{"avg":25,"day":"2022-04-20","max":39,"min":14},{"avg":27,"day":"2022-04-21","max":36,"min":14},{"avg":23,"day":"2022-04-22","max":28,"min":17},{"avg":29,"day":"2022-04-23","max":37,"min":21},{"avg":36,"day":"2022-04-24","max":36,"min":32}],"pm10":[{"avg":18,"day":"2022-04-18","max":26,"min":10},{"avg":23,"day":"2022-04-19","max":31,"min":13},{"avg":19,"day":"2022-04-20","max":36,"min":10},{"avg":19,"day":"2022-04-21","max":28,"min":11},{"avg":18,"day":"2022-04-22","max":20,"min":14},{"avg":20,"day":"2022-04-23","max":23,"min":17},{"avg":16,"day":"2022-04-24","max":17,"min":16}],"pm25":[{"avg":47,"day":"2022-04-18","max":74,"min":23},{"avg":64,"day":"2022-04-19","max":81,"min":45},{"avg":59,"day":"2022-04-20","max":94,"min":33},{"avg":58,"day":"2022-04-21","max":79,"min":37},{"avg":56,"day":"2022-04-22","max":62,"min":46},{"avg":62,"day":"2022-04-23","max":70,"min":52},{"avg":53,"day":"2022-04-24","max":53,"min":52}],"uvi":[{"avg":1,"day":"2022-04-19","max":3,"min":0},{"avg":1,"day":"2022-04-20","max":4,"min":0},{"avg":1,"day":"2022-04-21","max":4,"min":0},{"avg":1,"day":"2022-04-22","max":3,"min":0},{"avg":1,"day":"2022-04-23","max":3,"min":0},{"avg":0,"day":"2022-04-24","max":2,"min":0},{"avg":0,"day":"2022-04-25","max":1,"min":0}]}},"debug":{"sync":"2022-04-21T09:24:45+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:07:13 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "88.792\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2269'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Thu, 21 Apr 2022 01:07:16 GMT
+      Location:
+      - /feed/london/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":57,"idx":5724,"attributions":[{"url":"http://uk-air.defra.gov.uk/","name":"UK-AIR,
+        air quality information resource - Defra, UK","logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"url":"https://londonair.org.uk/","name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","logo":"UK-London-Kings-College.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[51.5073509,-0.1277583],"name":"London","url":"https://aqicn.org/city/london","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":2.6},"h":{"v":78},"no2":{"v":14.8},"o3":{"v":26.6},"p":{"v":1015},"pm10":{"v":26},"pm25":{"v":57},"so2":{"v":0.6},"t":{"v":8.3},"w":{"v":3.6}},"time":{"s":"2022-04-21
+        00:00:00","tz":"+01:00","v":1650499200,"iso":"2022-04-21T00:00:00+01:00"},"forecast":{"daily":{"o3":[{"avg":19,"day":"2022-04-18","max":33,"min":8},{"avg":17,"day":"2022-04-19","max":34,"min":2},{"avg":25,"day":"2022-04-20","max":39,"min":14},{"avg":27,"day":"2022-04-21","max":36,"min":14},{"avg":23,"day":"2022-04-22","max":28,"min":17},{"avg":29,"day":"2022-04-23","max":37,"min":21},{"avg":36,"day":"2022-04-24","max":36,"min":32}],"pm10":[{"avg":18,"day":"2022-04-18","max":26,"min":10},{"avg":23,"day":"2022-04-19","max":31,"min":13},{"avg":19,"day":"2022-04-20","max":36,"min":10},{"avg":19,"day":"2022-04-21","max":28,"min":11},{"avg":18,"day":"2022-04-22","max":20,"min":14},{"avg":20,"day":"2022-04-23","max":23,"min":17},{"avg":16,"day":"2022-04-24","max":17,"min":16}],"pm25":[{"avg":47,"day":"2022-04-18","max":74,"min":23},{"avg":64,"day":"2022-04-19","max":81,"min":45},{"avg":59,"day":"2022-04-20","max":94,"min":33},{"avg":58,"day":"2022-04-21","max":79,"min":37},{"avg":56,"day":"2022-04-22","max":62,"min":46},{"avg":62,"day":"2022-04-23","max":70,"min":52},{"avg":53,"day":"2022-04-24","max":53,"min":52}],"uvi":[{"avg":1,"day":"2022-04-19","max":3,"min":0},{"avg":1,"day":"2022-04-20","max":4,"min":0},{"avg":1,"day":"2022-04-21","max":4,"min":0},{"avg":1,"day":"2022-04-22","max":3,"min":0},{"avg":1,"day":"2022-04-23","max":3,"min":0},{"avg":0,"day":"2022-04-24","max":2,"min":0},{"avg":0,"day":"2022-04-25","max":1,"min":0}]}},"debug":{"sync":"2022-04-21T09:24:45+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:07:16 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "85.971\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2269'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_city_air/test_excluded_params.yaml
+++ b/tests/cassettes/test_get_city_air/test_excluded_params.yaml
@@ -1,0 +1,76 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Thu, 21 Apr 2022 01:07:00 GMT
+      Location:
+      - /feed/london/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":57,"idx":5724,"attributions":[{"url":"http://uk-air.defra.gov.uk/","name":"UK-AIR,
+        air quality information resource - Defra, UK","logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"url":"https://londonair.org.uk/","name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","logo":"UK-London-Kings-College.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[51.5073509,-0.1277583],"name":"London","url":"https://aqicn.org/city/london","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":2.6},"h":{"v":78},"no2":{"v":14.8},"o3":{"v":26.6},"p":{"v":1015},"pm10":{"v":26},"pm25":{"v":57},"so2":{"v":0.6},"t":{"v":8.3},"w":{"v":3.6}},"time":{"s":"2022-04-21
+        00:00:00","tz":"+01:00","v":1650499200,"iso":"2022-04-21T00:00:00+01:00"},"forecast":{"daily":{"o3":[{"avg":19,"day":"2022-04-18","max":33,"min":8},{"avg":17,"day":"2022-04-19","max":34,"min":2},{"avg":25,"day":"2022-04-20","max":39,"min":14},{"avg":27,"day":"2022-04-21","max":36,"min":14},{"avg":23,"day":"2022-04-22","max":28,"min":17},{"avg":29,"day":"2022-04-23","max":37,"min":21},{"avg":36,"day":"2022-04-24","max":36,"min":32}],"pm10":[{"avg":18,"day":"2022-04-18","max":26,"min":10},{"avg":23,"day":"2022-04-19","max":31,"min":13},{"avg":19,"day":"2022-04-20","max":36,"min":10},{"avg":19,"day":"2022-04-21","max":28,"min":11},{"avg":18,"day":"2022-04-22","max":20,"min":14},{"avg":20,"day":"2022-04-23","max":23,"min":17},{"avg":16,"day":"2022-04-24","max":17,"min":16}],"pm25":[{"avg":47,"day":"2022-04-18","max":74,"min":23},{"avg":64,"day":"2022-04-19","max":81,"min":45},{"avg":59,"day":"2022-04-20","max":94,"min":33},{"avg":58,"day":"2022-04-21","max":79,"min":37},{"avg":56,"day":"2022-04-22","max":62,"min":46},{"avg":62,"day":"2022-04-23","max":70,"min":52},{"avg":53,"day":"2022-04-24","max":53,"min":52}],"uvi":[{"avg":1,"day":"2022-04-19","max":3,"min":0},{"avg":1,"day":"2022-04-20","max":4,"min":0},{"avg":1,"day":"2022-04-21","max":4,"min":0},{"avg":1,"day":"2022-04-22","max":3,"min":0},{"avg":1,"day":"2022-04-23","max":3,"min":0},{"avg":0,"day":"2022-04-24","max":2,"min":0},{"avg":0,"day":"2022-04-25","max":1,"min":0}]}},"debug":{"sync":"2022-04-21T09:24:45+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:07:00 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "171.714\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2269'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_city_air/test_nonexistent_requested_params.yaml
+++ b/tests/cassettes/test_get_city_air/test_nonexistent_requested_params.yaml
@@ -1,0 +1,76 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Thu, 21 Apr 2022 01:07:01 GMT
+      Location:
+      - /feed/london/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":57,"idx":5724,"attributions":[{"url":"http://uk-air.defra.gov.uk/","name":"UK-AIR,
+        air quality information resource - Defra, UK","logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"url":"https://londonair.org.uk/","name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","logo":"UK-London-Kings-College.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[51.5073509,-0.1277583],"name":"London","url":"https://aqicn.org/city/london","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":2.6},"h":{"v":78},"no2":{"v":14.8},"o3":{"v":26.6},"p":{"v":1015},"pm10":{"v":26},"pm25":{"v":57},"so2":{"v":0.6},"t":{"v":8.3},"w":{"v":3.6}},"time":{"s":"2022-04-21
+        00:00:00","tz":"+01:00","v":1650499200,"iso":"2022-04-21T00:00:00+01:00"},"forecast":{"daily":{"o3":[{"avg":19,"day":"2022-04-18","max":33,"min":8},{"avg":17,"day":"2022-04-19","max":34,"min":2},{"avg":25,"day":"2022-04-20","max":39,"min":14},{"avg":27,"day":"2022-04-21","max":36,"min":14},{"avg":23,"day":"2022-04-22","max":28,"min":17},{"avg":29,"day":"2022-04-23","max":37,"min":21},{"avg":36,"day":"2022-04-24","max":36,"min":32}],"pm10":[{"avg":18,"day":"2022-04-18","max":26,"min":10},{"avg":23,"day":"2022-04-19","max":31,"min":13},{"avg":19,"day":"2022-04-20","max":36,"min":10},{"avg":19,"day":"2022-04-21","max":28,"min":11},{"avg":18,"day":"2022-04-22","max":20,"min":14},{"avg":20,"day":"2022-04-23","max":23,"min":17},{"avg":16,"day":"2022-04-24","max":17,"min":16}],"pm25":[{"avg":47,"day":"2022-04-18","max":74,"min":23},{"avg":64,"day":"2022-04-19","max":81,"min":45},{"avg":59,"day":"2022-04-20","max":94,"min":33},{"avg":58,"day":"2022-04-21","max":79,"min":37},{"avg":56,"day":"2022-04-22","max":62,"min":46},{"avg":62,"day":"2022-04-23","max":70,"min":52},{"avg":53,"day":"2022-04-24","max":53,"min":52}],"uvi":[{"avg":1,"day":"2022-04-19","max":3,"min":0},{"avg":1,"day":"2022-04-20","max":4,"min":0},{"avg":1,"day":"2022-04-21","max":4,"min":0},{"avg":1,"day":"2022-04-22","max":3,"min":0},{"avg":1,"day":"2022-04-23","max":3,"min":0},{"avg":0,"day":"2022-04-24","max":2,"min":0},{"avg":0,"day":"2022-04-25","max":1,"min":0}]}},"debug":{"sync":"2022-04-21T09:24:45+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:07:02 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "71.602\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2269'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_city_air/test_return_value_and_format.yaml
+++ b/tests/cassettes/test_get_city_air/test_return_value_and_format.yaml
@@ -1,0 +1,76 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Thu, 21 Apr 2022 01:06:55 GMT
+      Location:
+      - /feed/london/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":57,"idx":5724,"attributions":[{"url":"http://uk-air.defra.gov.uk/","name":"UK-AIR,
+        air quality information resource - Defra, UK","logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"url":"https://londonair.org.uk/","name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","logo":"UK-London-Kings-College.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[51.5073509,-0.1277583],"name":"London","url":"https://aqicn.org/city/london","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":2.6},"h":{"v":78},"no2":{"v":14.8},"o3":{"v":26.6},"p":{"v":1015},"pm10":{"v":26},"pm25":{"v":57},"so2":{"v":0.6},"t":{"v":8.3},"w":{"v":3.6}},"time":{"s":"2022-04-21
+        00:00:00","tz":"+01:00","v":1650499200,"iso":"2022-04-21T00:00:00+01:00"},"forecast":{"daily":{"o3":[{"avg":19,"day":"2022-04-18","max":33,"min":8},{"avg":17,"day":"2022-04-19","max":34,"min":2},{"avg":25,"day":"2022-04-20","max":39,"min":14},{"avg":27,"day":"2022-04-21","max":36,"min":14},{"avg":23,"day":"2022-04-22","max":28,"min":17},{"avg":29,"day":"2022-04-23","max":37,"min":21},{"avg":36,"day":"2022-04-24","max":36,"min":32}],"pm10":[{"avg":18,"day":"2022-04-18","max":26,"min":10},{"avg":23,"day":"2022-04-19","max":31,"min":13},{"avg":19,"day":"2022-04-20","max":36,"min":10},{"avg":19,"day":"2022-04-21","max":28,"min":11},{"avg":18,"day":"2022-04-22","max":20,"min":14},{"avg":20,"day":"2022-04-23","max":23,"min":17},{"avg":16,"day":"2022-04-24","max":17,"min":16}],"pm25":[{"avg":47,"day":"2022-04-18","max":74,"min":23},{"avg":64,"day":"2022-04-19","max":81,"min":45},{"avg":59,"day":"2022-04-20","max":94,"min":33},{"avg":58,"day":"2022-04-21","max":79,"min":37},{"avg":56,"day":"2022-04-22","max":62,"min":46},{"avg":62,"day":"2022-04-23","max":70,"min":52},{"avg":53,"day":"2022-04-24","max":53,"min":52}],"uvi":[{"avg":1,"day":"2022-04-19","max":3,"min":0},{"avg":1,"day":"2022-04-20","max":4,"min":0},{"avg":1,"day":"2022-04-21","max":4,"min":0},{"avg":1,"day":"2022-04-22","max":3,"min":0},{"avg":1,"day":"2022-04-23","max":3,"min":0},{"avg":0,"day":"2022-04-24","max":2,"min":0},{"avg":0,"day":"2022-04-25","max":1,"min":0}]}},"debug":{"sync":"2022-04-21T09:24:45+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:06:56 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "64.221\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2269'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_city_forecast/test_bad_city_input.yaml
+++ b/tests/cassettes/test_get_city_forecast/test_bad_city_input.yaml
@@ -1,0 +1,138 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//a%20definitely%20nonexistent%20city/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Thu, 21 Apr 2022 01:07:20 GMT
+      Location:
+      - /feed/a%20definitely%20nonexistent%20city/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/a%20definitely%20nonexistent%20city/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"error","data":"Unknown station"}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:07:21 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "126.902\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '43'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed///?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Thu, 21 Apr 2022 01:07:22 GMT
+      Location:
+      - /feed/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"error","message":"404"}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:07:22 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      content-length:
+      - '34'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_city_forecast/test_bad_data_format_input.yaml
+++ b/tests/cassettes/test_get_city_forecast/test_bad_data_format_input.yaml
@@ -1,0 +1,76 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Thu, 21 Apr 2022 01:07:23 GMT
+      Location:
+      - /feed/london/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":57,"idx":5724,"attributions":[{"url":"http://uk-air.defra.gov.uk/","name":"UK-AIR,
+        air quality information resource - Defra, UK","logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"url":"https://londonair.org.uk/","name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","logo":"UK-London-Kings-College.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[51.5073509,-0.1277583],"name":"London","url":"https://aqicn.org/city/london","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":2.6},"h":{"v":78},"no2":{"v":14.8},"o3":{"v":26.6},"p":{"v":1015},"pm10":{"v":26},"pm25":{"v":57},"so2":{"v":0.6},"t":{"v":8.3},"w":{"v":3.6}},"time":{"s":"2022-04-21
+        00:00:00","tz":"+01:00","v":1650499200,"iso":"2022-04-21T00:00:00+01:00"},"forecast":{"daily":{"o3":[{"avg":19,"day":"2022-04-18","max":33,"min":8},{"avg":17,"day":"2022-04-19","max":34,"min":2},{"avg":25,"day":"2022-04-20","max":39,"min":14},{"avg":27,"day":"2022-04-21","max":36,"min":14},{"avg":23,"day":"2022-04-22","max":28,"min":17},{"avg":29,"day":"2022-04-23","max":37,"min":21},{"avg":36,"day":"2022-04-24","max":36,"min":32}],"pm10":[{"avg":18,"day":"2022-04-18","max":26,"min":10},{"avg":23,"day":"2022-04-19","max":31,"min":13},{"avg":19,"day":"2022-04-20","max":36,"min":10},{"avg":19,"day":"2022-04-21","max":28,"min":11},{"avg":18,"day":"2022-04-22","max":20,"min":14},{"avg":20,"day":"2022-04-23","max":23,"min":17},{"avg":16,"day":"2022-04-24","max":17,"min":16}],"pm25":[{"avg":47,"day":"2022-04-18","max":74,"min":23},{"avg":64,"day":"2022-04-19","max":81,"min":45},{"avg":59,"day":"2022-04-20","max":94,"min":33},{"avg":58,"day":"2022-04-21","max":79,"min":37},{"avg":56,"day":"2022-04-22","max":62,"min":46},{"avg":62,"day":"2022-04-23","max":70,"min":52},{"avg":53,"day":"2022-04-24","max":53,"min":52}],"uvi":[{"avg":1,"day":"2022-04-19","max":3,"min":0},{"avg":1,"day":"2022-04-20","max":4,"min":0},{"avg":1,"day":"2022-04-21","max":4,"min":0},{"avg":1,"day":"2022-04-22","max":3,"min":0},{"avg":1,"day":"2022-04-23","max":3,"min":0},{"avg":0,"day":"2022-04-24","max":2,"min":0},{"avg":0,"day":"2022-04-25","max":1,"min":0}]}},"debug":{"sync":"2022-04-21T09:24:45+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:07:23 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "92.852\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2269'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_city_forecast/test_correct_data_format_input.yaml
+++ b/tests/cassettes/test_get_city_forecast/test_correct_data_format_input.yaml
@@ -1,0 +1,224 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Thu, 21 Apr 2022 01:07:25 GMT
+      Location:
+      - /feed/london/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":57,"idx":5724,"attributions":[{"url":"http://uk-air.defra.gov.uk/","name":"UK-AIR,
+        air quality information resource - Defra, UK","logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"url":"https://londonair.org.uk/","name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","logo":"UK-London-Kings-College.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[51.5073509,-0.1277583],"name":"London","url":"https://aqicn.org/city/london","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":2.6},"h":{"v":78},"no2":{"v":14.8},"o3":{"v":26.6},"p":{"v":1015},"pm10":{"v":26},"pm25":{"v":57},"so2":{"v":0.6},"t":{"v":8.3},"w":{"v":3.6}},"time":{"s":"2022-04-21
+        00:00:00","tz":"+01:00","v":1650499200,"iso":"2022-04-21T00:00:00+01:00"},"forecast":{"daily":{"o3":[{"avg":19,"day":"2022-04-18","max":33,"min":8},{"avg":17,"day":"2022-04-19","max":34,"min":2},{"avg":25,"day":"2022-04-20","max":39,"min":14},{"avg":27,"day":"2022-04-21","max":36,"min":14},{"avg":23,"day":"2022-04-22","max":28,"min":17},{"avg":29,"day":"2022-04-23","max":37,"min":21},{"avg":36,"day":"2022-04-24","max":36,"min":32}],"pm10":[{"avg":18,"day":"2022-04-18","max":26,"min":10},{"avg":23,"day":"2022-04-19","max":31,"min":13},{"avg":19,"day":"2022-04-20","max":36,"min":10},{"avg":19,"day":"2022-04-21","max":28,"min":11},{"avg":18,"day":"2022-04-22","max":20,"min":14},{"avg":20,"day":"2022-04-23","max":23,"min":17},{"avg":16,"day":"2022-04-24","max":17,"min":16}],"pm25":[{"avg":47,"day":"2022-04-18","max":74,"min":23},{"avg":64,"day":"2022-04-19","max":81,"min":45},{"avg":59,"day":"2022-04-20","max":94,"min":33},{"avg":58,"day":"2022-04-21","max":79,"min":37},{"avg":56,"day":"2022-04-22","max":62,"min":46},{"avg":62,"day":"2022-04-23","max":70,"min":52},{"avg":53,"day":"2022-04-24","max":53,"min":52}],"uvi":[{"avg":1,"day":"2022-04-19","max":3,"min":0},{"avg":1,"day":"2022-04-20","max":4,"min":0},{"avg":1,"day":"2022-04-21","max":4,"min":0},{"avg":1,"day":"2022-04-22","max":3,"min":0},{"avg":1,"day":"2022-04-23","max":3,"min":0},{"avg":0,"day":"2022-04-24","max":2,"min":0},{"avg":0,"day":"2022-04-25","max":1,"min":0}]}},"debug":{"sync":"2022-04-21T09:24:45+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:07:25 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "128.982\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2269'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Thu, 21 Apr 2022 01:07:26 GMT
+      Location:
+      - /feed/london/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":57,"idx":5724,"attributions":[{"url":"http://uk-air.defra.gov.uk/","name":"UK-AIR,
+        air quality information resource - Defra, UK","logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"url":"https://londonair.org.uk/","name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","logo":"UK-London-Kings-College.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[51.5073509,-0.1277583],"name":"London","url":"https://aqicn.org/city/london","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":2.6},"h":{"v":78},"no2":{"v":14.8},"o3":{"v":26.6},"p":{"v":1015},"pm10":{"v":26},"pm25":{"v":57},"so2":{"v":0.6},"t":{"v":8.3},"w":{"v":3.6}},"time":{"s":"2022-04-21
+        00:00:00","tz":"+01:00","v":1650499200,"iso":"2022-04-21T00:00:00+01:00"},"forecast":{"daily":{"o3":[{"avg":19,"day":"2022-04-18","max":33,"min":8},{"avg":17,"day":"2022-04-19","max":34,"min":2},{"avg":25,"day":"2022-04-20","max":39,"min":14},{"avg":27,"day":"2022-04-21","max":36,"min":14},{"avg":23,"day":"2022-04-22","max":28,"min":17},{"avg":29,"day":"2022-04-23","max":37,"min":21},{"avg":36,"day":"2022-04-24","max":36,"min":32}],"pm10":[{"avg":18,"day":"2022-04-18","max":26,"min":10},{"avg":23,"day":"2022-04-19","max":31,"min":13},{"avg":19,"day":"2022-04-20","max":36,"min":10},{"avg":19,"day":"2022-04-21","max":28,"min":11},{"avg":18,"day":"2022-04-22","max":20,"min":14},{"avg":20,"day":"2022-04-23","max":23,"min":17},{"avg":16,"day":"2022-04-24","max":17,"min":16}],"pm25":[{"avg":47,"day":"2022-04-18","max":74,"min":23},{"avg":64,"day":"2022-04-19","max":81,"min":45},{"avg":59,"day":"2022-04-20","max":94,"min":33},{"avg":58,"day":"2022-04-21","max":79,"min":37},{"avg":56,"day":"2022-04-22","max":62,"min":46},{"avg":62,"day":"2022-04-23","max":70,"min":52},{"avg":53,"day":"2022-04-24","max":53,"min":52}],"uvi":[{"avg":1,"day":"2022-04-19","max":3,"min":0},{"avg":1,"day":"2022-04-20","max":4,"min":0},{"avg":1,"day":"2022-04-21","max":4,"min":0},{"avg":1,"day":"2022-04-22","max":3,"min":0},{"avg":1,"day":"2022-04-23","max":3,"min":0},{"avg":0,"day":"2022-04-24","max":2,"min":0},{"avg":0,"day":"2022-04-25","max":1,"min":0}]}},"debug":{"sync":"2022-04-21T09:24:45+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:07:26 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "151.792\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2269'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Thu, 21 Apr 2022 01:07:27 GMT
+      Location:
+      - /feed/london/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":57,"idx":5724,"attributions":[{"url":"http://uk-air.defra.gov.uk/","name":"UK-AIR,
+        air quality information resource - Defra, UK","logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"url":"https://londonair.org.uk/","name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","logo":"UK-London-Kings-College.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[51.5073509,-0.1277583],"name":"London","url":"https://aqicn.org/city/london","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":2.6},"h":{"v":78},"no2":{"v":14.8},"o3":{"v":26.6},"p":{"v":1015},"pm10":{"v":26},"pm25":{"v":57},"so2":{"v":0.6},"t":{"v":8.3},"w":{"v":3.6}},"time":{"s":"2022-04-21
+        00:00:00","tz":"+01:00","v":1650499200,"iso":"2022-04-21T00:00:00+01:00"},"forecast":{"daily":{"o3":[{"avg":19,"day":"2022-04-18","max":33,"min":8},{"avg":17,"day":"2022-04-19","max":34,"min":2},{"avg":25,"day":"2022-04-20","max":39,"min":14},{"avg":27,"day":"2022-04-21","max":36,"min":14},{"avg":23,"day":"2022-04-22","max":28,"min":17},{"avg":29,"day":"2022-04-23","max":37,"min":21},{"avg":36,"day":"2022-04-24","max":36,"min":32}],"pm10":[{"avg":18,"day":"2022-04-18","max":26,"min":10},{"avg":23,"day":"2022-04-19","max":31,"min":13},{"avg":19,"day":"2022-04-20","max":36,"min":10},{"avg":19,"day":"2022-04-21","max":28,"min":11},{"avg":18,"day":"2022-04-22","max":20,"min":14},{"avg":20,"day":"2022-04-23","max":23,"min":17},{"avg":16,"day":"2022-04-24","max":17,"min":16}],"pm25":[{"avg":47,"day":"2022-04-18","max":74,"min":23},{"avg":64,"day":"2022-04-19","max":81,"min":45},{"avg":59,"day":"2022-04-20","max":94,"min":33},{"avg":58,"day":"2022-04-21","max":79,"min":37},{"avg":56,"day":"2022-04-22","max":62,"min":46},{"avg":62,"day":"2022-04-23","max":70,"min":52},{"avg":53,"day":"2022-04-24","max":53,"min":52}],"uvi":[{"avg":1,"day":"2022-04-19","max":3,"min":0},{"avg":1,"day":"2022-04-20","max":4,"min":0},{"avg":1,"day":"2022-04-21","max":4,"min":0},{"avg":1,"day":"2022-04-22","max":3,"min":0},{"avg":1,"day":"2022-04-23","max":3,"min":0},{"avg":0,"day":"2022-04-24","max":2,"min":0},{"avg":0,"day":"2022-04-25","max":1,"min":0}]}},"debug":{"sync":"2022-04-21T09:24:45+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:07:28 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "80.732\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2269'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_city_forecast/test_index_and_column_types.yaml
+++ b/tests/cassettes/test_get_city_forecast/test_index_and_column_types.yaml
@@ -1,0 +1,76 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Thu, 21 Apr 2022 01:07:19 GMT
+      Location:
+      - /feed/london/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":57,"idx":5724,"attributions":[{"url":"http://uk-air.defra.gov.uk/","name":"UK-AIR,
+        air quality information resource - Defra, UK","logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"url":"https://londonair.org.uk/","name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","logo":"UK-London-Kings-College.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[51.5073509,-0.1277583],"name":"London","url":"https://aqicn.org/city/london","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":2.6},"h":{"v":78},"no2":{"v":14.8},"o3":{"v":26.6},"p":{"v":1015},"pm10":{"v":26},"pm25":{"v":57},"so2":{"v":0.6},"t":{"v":8.3},"w":{"v":3.6}},"time":{"s":"2022-04-21
+        00:00:00","tz":"+01:00","v":1650499200,"iso":"2022-04-21T00:00:00+01:00"},"forecast":{"daily":{"o3":[{"avg":19,"day":"2022-04-18","max":33,"min":8},{"avg":17,"day":"2022-04-19","max":34,"min":2},{"avg":25,"day":"2022-04-20","max":39,"min":14},{"avg":27,"day":"2022-04-21","max":36,"min":14},{"avg":23,"day":"2022-04-22","max":28,"min":17},{"avg":29,"day":"2022-04-23","max":37,"min":21},{"avg":36,"day":"2022-04-24","max":36,"min":32}],"pm10":[{"avg":18,"day":"2022-04-18","max":26,"min":10},{"avg":23,"day":"2022-04-19","max":31,"min":13},{"avg":19,"day":"2022-04-20","max":36,"min":10},{"avg":19,"day":"2022-04-21","max":28,"min":11},{"avg":18,"day":"2022-04-22","max":20,"min":14},{"avg":20,"day":"2022-04-23","max":23,"min":17},{"avg":16,"day":"2022-04-24","max":17,"min":16}],"pm25":[{"avg":47,"day":"2022-04-18","max":74,"min":23},{"avg":64,"day":"2022-04-19","max":81,"min":45},{"avg":59,"day":"2022-04-20","max":94,"min":33},{"avg":58,"day":"2022-04-21","max":79,"min":37},{"avg":56,"day":"2022-04-22","max":62,"min":46},{"avg":62,"day":"2022-04-23","max":70,"min":52},{"avg":53,"day":"2022-04-24","max":53,"min":52}],"uvi":[{"avg":1,"day":"2022-04-19","max":3,"min":0},{"avg":1,"day":"2022-04-20","max":4,"min":0},{"avg":1,"day":"2022-04-21","max":4,"min":0},{"avg":1,"day":"2022-04-22","max":3,"min":0},{"avg":1,"day":"2022-04-23","max":3,"min":0},{"avg":0,"day":"2022-04-24","max":2,"min":0},{"avg":0,"day":"2022-04-25","max":1,"min":0}]}},"debug":{"sync":"2022-04-21T09:24:45+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:07:19 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "142.852\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2269'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_city_forecast/test_return_value_and_format.yaml
+++ b/tests/cassettes/test_get_city_forecast/test_return_value_and_format.yaml
@@ -1,0 +1,76 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Thu, 21 Apr 2022 01:07:17 GMT
+      Location:
+      - /feed/london/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":57,"idx":5724,"attributions":[{"url":"http://uk-air.defra.gov.uk/","name":"UK-AIR,
+        air quality information resource - Defra, UK","logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"url":"https://londonair.org.uk/","name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","logo":"UK-London-Kings-College.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[51.5073509,-0.1277583],"name":"London","url":"https://aqicn.org/city/london","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":2.6},"h":{"v":78},"no2":{"v":14.8},"o3":{"v":26.6},"p":{"v":1015},"pm10":{"v":26},"pm25":{"v":57},"so2":{"v":0.6},"t":{"v":8.3},"w":{"v":3.6}},"time":{"s":"2022-04-21
+        00:00:00","tz":"+01:00","v":1650499200,"iso":"2022-04-21T00:00:00+01:00"},"forecast":{"daily":{"o3":[{"avg":19,"day":"2022-04-18","max":33,"min":8},{"avg":17,"day":"2022-04-19","max":34,"min":2},{"avg":25,"day":"2022-04-20","max":39,"min":14},{"avg":27,"day":"2022-04-21","max":36,"min":14},{"avg":23,"day":"2022-04-22","max":28,"min":17},{"avg":29,"day":"2022-04-23","max":37,"min":21},{"avg":36,"day":"2022-04-24","max":36,"min":32}],"pm10":[{"avg":18,"day":"2022-04-18","max":26,"min":10},{"avg":23,"day":"2022-04-19","max":31,"min":13},{"avg":19,"day":"2022-04-20","max":36,"min":10},{"avg":19,"day":"2022-04-21","max":28,"min":11},{"avg":18,"day":"2022-04-22","max":20,"min":14},{"avg":20,"day":"2022-04-23","max":23,"min":17},{"avg":16,"day":"2022-04-24","max":17,"min":16}],"pm25":[{"avg":47,"day":"2022-04-18","max":74,"min":23},{"avg":64,"day":"2022-04-19","max":81,"min":45},{"avg":59,"day":"2022-04-20","max":94,"min":33},{"avg":58,"day":"2022-04-21","max":79,"min":37},{"avg":56,"day":"2022-04-22","max":62,"min":46},{"avg":62,"day":"2022-04-23","max":70,"min":52},{"avg":53,"day":"2022-04-24","max":53,"min":52}],"uvi":[{"avg":1,"day":"2022-04-19","max":3,"min":0},{"avg":1,"day":"2022-04-20","max":4,"min":0},{"avg":1,"day":"2022-04-21","max":4,"min":0},{"avg":1,"day":"2022-04-22","max":3,"min":0},{"avg":1,"day":"2022-04-23","max":3,"min":0},{"avg":0,"day":"2022-04-24","max":2,"min":0},{"avg":0,"day":"2022-04-25","max":1,"min":0}]}},"debug":{"sync":"2022-04-21T09:24:45+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:07:18 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "144.794\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2269'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_city_station_options/test_columns.yaml
+++ b/tests/cassettes/test_get_city_station_options/test_columns.yaml
@@ -1,0 +1,82 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://search.waqi.info/nsearch/station/ukraine
+  response:
+    body:
+      string: "{\"dt\":\"12.582701ms\",\"term\":\"ukraine\",\"results\":[{\"s\":{\"a\":\"124\",\"t\":[\"2022-04-21
+        05:00:00\",\"+03:00\"],\"n\":[\"SteelDrum, Lviv\",\"vul.Kleparivska 18\"],\"u\":\"ukraine/lviv/steeldrum\"},\"n\":[\"SteelDrum,
+        Lviv, Ukraine\"],\"score\":6,\"x\":11795,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"86\",\"t\":[\"2022-04-21
+        04:00:00\",\"+03:00\"],\"n\":[\"Berezhans\\\\'ka Street, 3, Ternopil\"]},\"n\":[\"Berezhans'ka
+        Street, 3, Ternopil, Ukraine\"],\"score\":6,\"x\":11660,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"65\",\"t\":[\"2022-04-21
+        04:00:00\",\"+03:00\"],\"n\":[\"Velyka Diivska Street, 4, Dnipro\"],\"u\":\"ukraine/dnipro/velyka-diivska-street--4\"},\"n\":[\"Velyka
+        Diivska Street, 4, Dnipro, Ukraine\"],\"score\":6,\"x\":11770,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"58\",\"t\":[\"2022-04-21
+        04:00:00\",\"+03:00\"],\"n\":[\"Vokzalna Square, 2, Dnipro\"],\"u\":\"ukraine/dnipro/vokzalna-square--2\"},\"n\":[\"Vokzalna
+        Square, 2, Dnipro, Ukraine\"],\"score\":6,\"x\":11622,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"56\",\"t\":[\"2022-04-21
+        05:00:00\",\"+03:00\"],\"n\":[\"Televiziyna Street, Novooleksandrivka\"],\"u\":\"ukraine/novooleksandrivka/televiziyna-street/arendnyy-lane\"},\"n\":[\"Televiziyna
+        Street, Novooleksandrivka, Ukraine\"],\"score\":6,\"x\":11664,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"55\",\"t\":[\"2022-04-21
+        04:00:00\",\"+03:00\"],\"n\":[\"prospekt Miru, 20, Shepetivka\",\"Luftdaten
+        #25838\"],\"u\":\"ukraine/shepetivka/prospekt-miru--20\"},\"n\":[\"prospekt
+        Miru, 20, Shepetivka, Ukraine\"],\"score\":6,\"x\":11885,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"54\",\"t\":[\"2022-04-20
+        22:00:00\",\"+03:00\"],\"n\":[\"ecorada2, Kryvoy Roh\",\"vul.Futbolna\"],\"u\":\"ukraine/kryvoy-roh/ecorada2\"},\"n\":[\"ecorada2,
+        Kryvoy Roh, Ukraine\"],\"score\":6,\"x\":11718,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"51\",\"t\":[\"2022-04-21
+        05:00:00\",\"+03:00\"],\"n\":[\"Urban Space 100, Ivano-Frankivsk\",\"\u0432\u0443\u043B.\u0413\u0440\u0443\u0448\u0435\u0432\u0441\u044C\u043A\u043E\u0433\u043E\"],\"u\":\"ukraine/ivano-frankivsk/urban-space-100\"},\"n\":[\"Urban
+        Space 100, Ivano-Frankivsk, Ukraine\"],\"score\":6,\"x\":11680,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"46\",\"t\":[\"2022-04-21
+        04:00:00\",\"+03:00\"],\"n\":[\"Alma-Atinska vulicya, 1, Chernivci\",\"Luftdaten
+        #26750\"],\"u\":\"ukraine/chernivci/alma-atinska-vulicya--1\"},\"n\":[\"Alma-Atinska
+        vulicya, 1, Chernivci, Ukraine\"],\"score\":6,\"x\":11875,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"40\",\"t\":[\"2022-04-21
+        04:00:00\",\"+03:00\"],\"n\":[\"50 Rok\u0456v Peremogy Street, Surs\\\\'ko-Lytovs\\\\'ke\"]},\"n\":[\"50
+        Rok\u0456v Peremogy Street, Surs'ko-Lytovs'ke, Ukraine\"],\"score\":6,\"x\":11627,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"38\",\"t\":[\"2022-04-21
+        03:00:00\",\"+03:00\"],\"n\":[\"bulvar Perova, 48, Kiyiv\"],\"u\":\"ukraine/kiyiv/bulvar-perova--48\"},\"n\":[\"bulvar
+        Perova, 48, Kiyiv, Ukraine\"],\"score\":6,\"x\":11884,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"35\",\"t\":[\"2022-04-20
+        22:00:00\",\"+03:00\"],\"n\":[\"Pobeda-6, Geroev Avenue, 40, Dnipro\"],\"u\":\"ukraine/dnipro/pobeda-6--geroev-avenue--40\"},\"n\":[\"Pobeda-6,
+        Geroev Avenue, 40, Dnipro, Ukraine\"],\"score\":6,\"x\":11431,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"31\",\"t\":[\"2022-04-21
+        04:00:00\",\"+03:00\"],\"n\":[\"Vulytsya Pavla Nirinberha, 4-6, Dnipro\"],\"u\":\"ukraine/dnipro/vulytsya-pavla-nirinberha--4-6\"},\"n\":[\"Vulytsya
+        Pavla Nirinberha, 4-6, Dnipro, Ukraine\"],\"score\":6,\"x\":11623,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"18\",\"t\":[\"2022-04-21
+        05:00:00\",\"+03:00\"],\"n\":[\"ecorada1, Kryvyi Rih\",\"\u0427\u0435\u0441\u044C\u043A\u0430\"],\"u\":\"ukraine/kryvyi-rih/ecorada1\"},\"n\":[\"ecorada1,
+        Kryvyi Rih, Ukraine\"],\"score\":6,\"x\":11689,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"-\",\"t\":null,\"n\":[\"MANLab,
+        Kyiv\",\"Yuriya Illyenka, 63\"],\"u\":\"ukraine/kyiv/manlab\"},\"n\":[\"MANLab,
+        Kyiv, Ukraine\"],\"score\":6,\"x\":11723,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"-\",\"t\":[\"2019-11-10
+        12:00:00\",\"+03:00\"],\"n\":[\"Zayats, Zaporizhzhya\",\"Charivna\"],\"u\":\"ukraine/zaporizhzhya/zayats\"},\"n\":[\"Zayats,
+        Zaporizhzhya, Ukraine\"],\"score\":6,\"x\":11743,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"-\",\"t\":[\"2020-08-30
+        15:00:00\",\"+03:00\"],\"n\":[\"TsUM, Ivano-Frankivsk\",\"\u0432\u0443\u043B.\u0414\u043D\u0456\u0441\u0442\u0440\u043E\u0432\u043A\u0441\u044C\u043A\u0430\"],\"u\":\"ukraine/ivano-frankivsk/tsum\"},\"n\":[\"TsUM,
+        Ivano-Frankivsk, Ukraine\"],\"score\":6,\"x\":11683,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"-\",\"t\":[\"2019-10-07
+        14:00:00\",\"+03:00\"],\"n\":[\"Topolia-2, 23, Dnipro\"],\"u\":\"ukraine/dnipro/topolia-2--23\"},\"n\":[\"Topolia-2,
+        23, Dnipro, Ukraine\"],\"score\":6,\"x\":11728,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"-\",\"t\":[\"2022-03-30
+        02:00:00\",\"+03:00\"],\"n\":[\"APS 3001, Mikolayivka\"],\"u\":\"ukraine/mikolayivka/aps-3001\"},\"n\":[\"APS
+        3001, Mikolayivka, Ukraine\"],\"score\":6,\"x\":11879,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"-\",\"t\":[\"2020-10-13
+        18:00:00\",\"+03:00\"],\"n\":[\"MEREZhA-868, Hlibivka\",\"Dzhyntamo-Bryz\"],\"u\":\"ukraine/hlibivka/merezha-868\"},\"n\":[\"MEREZhA-868,
+        Hlibivka, Ukraine\"],\"score\":6,\"x\":11792,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"}]}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:07:31 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      X-Gen-Time:
+      - 12.688106ms
+      X-Powered-By:
+      - waqi-search/1.2
+      content-length:
+      - '4643'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_city_station_options/test_no_output_directory.yaml
+++ b/tests/cassettes/test_get_city_station_options/test_no_output_directory.yaml
@@ -1,0 +1,82 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://search.waqi.info/nsearch/station/ukraine
+  response:
+    body:
+      string: "{\"dt\":\"21.930572ms\",\"term\":\"ukraine\",\"results\":[{\"s\":{\"a\":\"124\",\"t\":[\"2022-04-21
+        05:00:00\",\"+03:00\"],\"n\":[\"SteelDrum, Lviv\",\"vul.Kleparivska 18\"],\"u\":\"ukraine/lviv/steeldrum\"},\"n\":[\"SteelDrum,
+        Lviv, Ukraine\"],\"score\":6,\"x\":11795,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"86\",\"t\":[\"2022-04-21
+        04:00:00\",\"+03:00\"],\"n\":[\"Berezhans\\\\'ka Street, 3, Ternopil\"]},\"n\":[\"Berezhans'ka
+        Street, 3, Ternopil, Ukraine\"],\"score\":6,\"x\":11660,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"65\",\"t\":[\"2022-04-21
+        04:00:00\",\"+03:00\"],\"n\":[\"Velyka Diivska Street, 4, Dnipro\"],\"u\":\"ukraine/dnipro/velyka-diivska-street--4\"},\"n\":[\"Velyka
+        Diivska Street, 4, Dnipro, Ukraine\"],\"score\":6,\"x\":11770,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"58\",\"t\":[\"2022-04-21
+        04:00:00\",\"+03:00\"],\"n\":[\"Vokzalna Square, 2, Dnipro\"],\"u\":\"ukraine/dnipro/vokzalna-square--2\"},\"n\":[\"Vokzalna
+        Square, 2, Dnipro, Ukraine\"],\"score\":6,\"x\":11622,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"56\",\"t\":[\"2022-04-21
+        05:00:00\",\"+03:00\"],\"n\":[\"Televiziyna Street, Novooleksandrivka\"],\"u\":\"ukraine/novooleksandrivka/televiziyna-street/arendnyy-lane\"},\"n\":[\"Televiziyna
+        Street, Novooleksandrivka, Ukraine\"],\"score\":6,\"x\":11664,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"55\",\"t\":[\"2022-04-21
+        04:00:00\",\"+03:00\"],\"n\":[\"prospekt Miru, 20, Shepetivka\",\"Luftdaten
+        #25838\"],\"u\":\"ukraine/shepetivka/prospekt-miru--20\"},\"n\":[\"prospekt
+        Miru, 20, Shepetivka, Ukraine\"],\"score\":6,\"x\":11885,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"54\",\"t\":[\"2022-04-20
+        22:00:00\",\"+03:00\"],\"n\":[\"ecorada2, Kryvoy Roh\",\"vul.Futbolna\"],\"u\":\"ukraine/kryvoy-roh/ecorada2\"},\"n\":[\"ecorada2,
+        Kryvoy Roh, Ukraine\"],\"score\":6,\"x\":11718,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"51\",\"t\":[\"2022-04-21
+        05:00:00\",\"+03:00\"],\"n\":[\"Urban Space 100, Ivano-Frankivsk\",\"\u0432\u0443\u043B.\u0413\u0440\u0443\u0448\u0435\u0432\u0441\u044C\u043A\u043E\u0433\u043E\"],\"u\":\"ukraine/ivano-frankivsk/urban-space-100\"},\"n\":[\"Urban
+        Space 100, Ivano-Frankivsk, Ukraine\"],\"score\":6,\"x\":11680,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"46\",\"t\":[\"2022-04-21
+        04:00:00\",\"+03:00\"],\"n\":[\"Alma-Atinska vulicya, 1, Chernivci\",\"Luftdaten
+        #26750\"],\"u\":\"ukraine/chernivci/alma-atinska-vulicya--1\"},\"n\":[\"Alma-Atinska
+        vulicya, 1, Chernivci, Ukraine\"],\"score\":6,\"x\":11875,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"40\",\"t\":[\"2022-04-21
+        04:00:00\",\"+03:00\"],\"n\":[\"50 Rok\u0456v Peremogy Street, Surs\\\\'ko-Lytovs\\\\'ke\"]},\"n\":[\"50
+        Rok\u0456v Peremogy Street, Surs'ko-Lytovs'ke, Ukraine\"],\"score\":6,\"x\":11627,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"38\",\"t\":[\"2022-04-21
+        03:00:00\",\"+03:00\"],\"n\":[\"bulvar Perova, 48, Kiyiv\"],\"u\":\"ukraine/kiyiv/bulvar-perova--48\"},\"n\":[\"bulvar
+        Perova, 48, Kiyiv, Ukraine\"],\"score\":6,\"x\":11884,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"35\",\"t\":[\"2022-04-20
+        22:00:00\",\"+03:00\"],\"n\":[\"Pobeda-6, Geroev Avenue, 40, Dnipro\"],\"u\":\"ukraine/dnipro/pobeda-6--geroev-avenue--40\"},\"n\":[\"Pobeda-6,
+        Geroev Avenue, 40, Dnipro, Ukraine\"],\"score\":6,\"x\":11431,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"31\",\"t\":[\"2022-04-21
+        04:00:00\",\"+03:00\"],\"n\":[\"Vulytsya Pavla Nirinberha, 4-6, Dnipro\"],\"u\":\"ukraine/dnipro/vulytsya-pavla-nirinberha--4-6\"},\"n\":[\"Vulytsya
+        Pavla Nirinberha, 4-6, Dnipro, Ukraine\"],\"score\":6,\"x\":11623,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"18\",\"t\":[\"2022-04-21
+        05:00:00\",\"+03:00\"],\"n\":[\"ecorada1, Kryvyi Rih\",\"\u0427\u0435\u0441\u044C\u043A\u0430\"],\"u\":\"ukraine/kryvyi-rih/ecorada1\"},\"n\":[\"ecorada1,
+        Kryvyi Rih, Ukraine\"],\"score\":6,\"x\":11689,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"-\",\"t\":null,\"n\":[\"MANLab,
+        Kyiv\",\"Yuriya Illyenka, 63\"],\"u\":\"ukraine/kyiv/manlab\"},\"n\":[\"MANLab,
+        Kyiv, Ukraine\"],\"score\":6,\"x\":11723,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"-\",\"t\":[\"2022-03-30
+        02:00:00\",\"+03:00\"],\"n\":[\"APS 1001, Kramatorsk\"],\"u\":\"ukraine/kramatorsk/aps-1001\"},\"n\":[\"APS
+        1001, Kramatorsk, Ukraine\"],\"score\":6,\"x\":11876,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"-\",\"t\":[\"2020-10-13
+        18:00:00\",\"+03:00\"],\"n\":[\"MEREZhA-868, Hlibivka\",\"Dzhyntamo-Bryz\"],\"u\":\"ukraine/hlibivka/merezha-868\"},\"n\":[\"MEREZhA-868,
+        Hlibivka, Ukraine\"],\"score\":6,\"x\":11792,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"-\",\"t\":[\"2019-10-07
+        14:00:00\",\"+03:00\"],\"n\":[\"Topolia-2, 23, Dnipro\"],\"u\":\"ukraine/dnipro/topolia-2--23\"},\"n\":[\"Topolia-2,
+        23, Dnipro, Ukraine\"],\"score\":6,\"x\":11728,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"-\",\"t\":[\"2020-08-30
+        15:00:00\",\"+03:00\"],\"n\":[\"TsUM, Ivano-Frankivsk\",\"\u0432\u0443\u043B.\u0414\u043D\u0456\u0441\u0442\u0440\u043E\u0432\u043A\u0441\u044C\u043A\u0430\"],\"u\":\"ukraine/ivano-frankivsk/tsum\"},\"n\":[\"TsUM,
+        Ivano-Frankivsk, Ukraine\"],\"score\":6,\"x\":11683,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"-\",\"t\":[\"2022-03-30
+        02:00:00\",\"+03:00\"],\"n\":[\"APS 3001, Mikolayivka\"],\"u\":\"ukraine/mikolayivka/aps-3001\"},\"n\":[\"APS
+        3001, Mikolayivka, Ukraine\"],\"score\":6,\"x\":11879,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"}]}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:07:34 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      X-Gen-Time:
+      - 22.171793ms
+      X-Powered-By:
+      - waqi-search/1.2
+      content-length:
+      - '4632'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_city_station_options/test_nonexistent_city.yaml
+++ b/tests/cassettes/test_get_city_station_options/test_nonexistent_city.yaml
@@ -1,0 +1,40 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://search.waqi.info/nsearch/station/gibberish_nonexistent_place_name
+  response:
+    body:
+      string: '{"dt":"5.244025ms","term":"gibberish_nonexistent_place_name","results":[]}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:07:33 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      X-Gen-Time:
+      - 5.298954ms
+      X-Powered-By:
+      - waqi-search/1.2
+      content-length:
+      - '74'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_city_station_options/test_return_value_and_format.yaml
+++ b/tests/cassettes/test_get_city_station_options/test_return_value_and_format.yaml
@@ -1,0 +1,82 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://search.waqi.info/nsearch/station/ukraine
+  response:
+    body:
+      string: "{\"dt\":\"25.793691ms\",\"term\":\"ukraine\",\"results\":[{\"s\":{\"a\":\"124\",\"t\":[\"2022-04-21
+        05:00:00\",\"+03:00\"],\"n\":[\"SteelDrum, Lviv\",\"vul.Kleparivska 18\"],\"u\":\"ukraine/lviv/steeldrum\"},\"n\":[\"SteelDrum,
+        Lviv, Ukraine\"],\"score\":6,\"x\":11795,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"86\",\"t\":[\"2022-04-21
+        04:00:00\",\"+03:00\"],\"n\":[\"Berezhans\\\\'ka Street, 3, Ternopil\"]},\"n\":[\"Berezhans'ka
+        Street, 3, Ternopil, Ukraine\"],\"score\":6,\"x\":11660,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"65\",\"t\":[\"2022-04-21
+        04:00:00\",\"+03:00\"],\"n\":[\"Velyka Diivska Street, 4, Dnipro\"],\"u\":\"ukraine/dnipro/velyka-diivska-street--4\"},\"n\":[\"Velyka
+        Diivska Street, 4, Dnipro, Ukraine\"],\"score\":6,\"x\":11770,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"58\",\"t\":[\"2022-04-21
+        04:00:00\",\"+03:00\"],\"n\":[\"Vokzalna Square, 2, Dnipro\"],\"u\":\"ukraine/dnipro/vokzalna-square--2\"},\"n\":[\"Vokzalna
+        Square, 2, Dnipro, Ukraine\"],\"score\":6,\"x\":11622,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"56\",\"t\":[\"2022-04-21
+        05:00:00\",\"+03:00\"],\"n\":[\"Televiziyna Street, Novooleksandrivka\"],\"u\":\"ukraine/novooleksandrivka/televiziyna-street/arendnyy-lane\"},\"n\":[\"Televiziyna
+        Street, Novooleksandrivka, Ukraine\"],\"score\":6,\"x\":11664,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"55\",\"t\":[\"2022-04-21
+        04:00:00\",\"+03:00\"],\"n\":[\"prospekt Miru, 20, Shepetivka\",\"Luftdaten
+        #25838\"],\"u\":\"ukraine/shepetivka/prospekt-miru--20\"},\"n\":[\"prospekt
+        Miru, 20, Shepetivka, Ukraine\"],\"score\":6,\"x\":11885,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"54\",\"t\":[\"2022-04-20
+        22:00:00\",\"+03:00\"],\"n\":[\"ecorada2, Kryvoy Roh\",\"vul.Futbolna\"],\"u\":\"ukraine/kryvoy-roh/ecorada2\"},\"n\":[\"ecorada2,
+        Kryvoy Roh, Ukraine\"],\"score\":6,\"x\":11718,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"51\",\"t\":[\"2022-04-21
+        05:00:00\",\"+03:00\"],\"n\":[\"Urban Space 100, Ivano-Frankivsk\",\"\u0432\u0443\u043B.\u0413\u0440\u0443\u0448\u0435\u0432\u0441\u044C\u043A\u043E\u0433\u043E\"],\"u\":\"ukraine/ivano-frankivsk/urban-space-100\"},\"n\":[\"Urban
+        Space 100, Ivano-Frankivsk, Ukraine\"],\"score\":6,\"x\":11680,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"46\",\"t\":[\"2022-04-21
+        04:00:00\",\"+03:00\"],\"n\":[\"Alma-Atinska vulicya, 1, Chernivci\",\"Luftdaten
+        #26750\"],\"u\":\"ukraine/chernivci/alma-atinska-vulicya--1\"},\"n\":[\"Alma-Atinska
+        vulicya, 1, Chernivci, Ukraine\"],\"score\":6,\"x\":11875,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"40\",\"t\":[\"2022-04-21
+        04:00:00\",\"+03:00\"],\"n\":[\"50 Rok\u0456v Peremogy Street, Surs\\\\'ko-Lytovs\\\\'ke\"]},\"n\":[\"50
+        Rok\u0456v Peremogy Street, Surs'ko-Lytovs'ke, Ukraine\"],\"score\":6,\"x\":11627,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"38\",\"t\":[\"2022-04-21
+        03:00:00\",\"+03:00\"],\"n\":[\"bulvar Perova, 48, Kiyiv\"],\"u\":\"ukraine/kiyiv/bulvar-perova--48\"},\"n\":[\"bulvar
+        Perova, 48, Kiyiv, Ukraine\"],\"score\":6,\"x\":11884,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"35\",\"t\":[\"2022-04-20
+        22:00:00\",\"+03:00\"],\"n\":[\"Pobeda-6, Geroev Avenue, 40, Dnipro\"],\"u\":\"ukraine/dnipro/pobeda-6--geroev-avenue--40\"},\"n\":[\"Pobeda-6,
+        Geroev Avenue, 40, Dnipro, Ukraine\"],\"score\":6,\"x\":11431,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"31\",\"t\":[\"2022-04-21
+        04:00:00\",\"+03:00\"],\"n\":[\"Vulytsya Pavla Nirinberha, 4-6, Dnipro\"],\"u\":\"ukraine/dnipro/vulytsya-pavla-nirinberha--4-6\"},\"n\":[\"Vulytsya
+        Pavla Nirinberha, 4-6, Dnipro, Ukraine\"],\"score\":6,\"x\":11623,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"18\",\"t\":[\"2022-04-21
+        05:00:00\",\"+03:00\"],\"n\":[\"ecorada1, Kryvyi Rih\",\"\u0427\u0435\u0441\u044C\u043A\u0430\"],\"u\":\"ukraine/kryvyi-rih/ecorada1\"},\"n\":[\"ecorada1,
+        Kryvyi Rih, Ukraine\"],\"score\":6,\"x\":11689,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"-\",\"t\":null,\"n\":[\"MANLab,
+        Kyiv\",\"Yuriya Illyenka, 63\"],\"u\":\"ukraine/kyiv/manlab\"},\"n\":[\"MANLab,
+        Kyiv, Ukraine\"],\"score\":6,\"x\":11723,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"-\",\"t\":null,\"n\":[\"Boryspil-1,
+        Boryspil\",\"Kyivskyi Shlyakh 79\"],\"u\":\"ukraine/boryspil/boryspil-1\"},\"n\":[\"Boryspil-1,
+        Boryspil, Ukraine\"],\"score\":6,\"x\":11744,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"-\",\"t\":[\"2020-08-30
+        15:00:00\",\"+03:00\"],\"n\":[\"TsUM, Ivano-Frankivsk\",\"\u0432\u0443\u043B.\u0414\u043D\u0456\u0441\u0442\u0440\u043E\u0432\u043A\u0441\u044C\u043A\u0430\"],\"u\":\"ukraine/ivano-frankivsk/tsum\"},\"n\":[\"TsUM,
+        Ivano-Frankivsk, Ukraine\"],\"score\":6,\"x\":11683,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"-\",\"t\":[\"2020-10-13
+        18:00:00\",\"+03:00\"],\"n\":[\"MEREZhA-868, Hlibivka\",\"Dzhyntamo-Bryz\"],\"u\":\"ukraine/hlibivka/merezha-868\"},\"n\":[\"MEREZhA-868,
+        Hlibivka, Ukraine\"],\"score\":6,\"x\":11792,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"-\",\"t\":[\"2019-10-07
+        14:00:00\",\"+03:00\"],\"n\":[\"Topolia-2, 23, Dnipro\"],\"u\":\"ukraine/dnipro/topolia-2--23\"},\"n\":[\"Topolia-2,
+        23, Dnipro, Ukraine\"],\"score\":6,\"x\":11728,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"-\",\"t\":[\"2022-03-30
+        02:00:00\",\"+03:00\"],\"n\":[\"APS 3001, Mikolayivka\"],\"u\":\"ukraine/mikolayivka/aps-3001\"},\"n\":[\"APS
+        3001, Mikolayivka, Ukraine\"],\"score\":6,\"x\":11879,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"}]}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:07:29 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      X-Gen-Time:
+      - 25.943125ms
+      X-Powered-By:
+      - waqi-search/1.2
+      content-length:
+      - '4626'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_city_station_options/test_score_column.yaml
+++ b/tests/cassettes/test_get_city_station_options/test_score_column.yaml
@@ -1,0 +1,82 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://search.waqi.info/nsearch/station/ukraine
+  response:
+    body:
+      string: "{\"dt\":\"13.208602ms\",\"term\":\"ukraine\",\"results\":[{\"s\":{\"a\":\"124\",\"t\":[\"2022-04-21
+        05:00:00\",\"+03:00\"],\"n\":[\"SteelDrum, Lviv\",\"vul.Kleparivska 18\"],\"u\":\"ukraine/lviv/steeldrum\"},\"n\":[\"SteelDrum,
+        Lviv, Ukraine\"],\"score\":6,\"x\":11795,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"86\",\"t\":[\"2022-04-21
+        04:00:00\",\"+03:00\"],\"n\":[\"Berezhans\\\\'ka Street, 3, Ternopil\"]},\"n\":[\"Berezhans'ka
+        Street, 3, Ternopil, Ukraine\"],\"score\":6,\"x\":11660,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"65\",\"t\":[\"2022-04-21
+        04:00:00\",\"+03:00\"],\"n\":[\"Velyka Diivska Street, 4, Dnipro\"],\"u\":\"ukraine/dnipro/velyka-diivska-street--4\"},\"n\":[\"Velyka
+        Diivska Street, 4, Dnipro, Ukraine\"],\"score\":6,\"x\":11770,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"58\",\"t\":[\"2022-04-21
+        04:00:00\",\"+03:00\"],\"n\":[\"Vokzalna Square, 2, Dnipro\"],\"u\":\"ukraine/dnipro/vokzalna-square--2\"},\"n\":[\"Vokzalna
+        Square, 2, Dnipro, Ukraine\"],\"score\":6,\"x\":11622,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"56\",\"t\":[\"2022-04-21
+        05:00:00\",\"+03:00\"],\"n\":[\"Televiziyna Street, Novooleksandrivka\"],\"u\":\"ukraine/novooleksandrivka/televiziyna-street/arendnyy-lane\"},\"n\":[\"Televiziyna
+        Street, Novooleksandrivka, Ukraine\"],\"score\":6,\"x\":11664,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"55\",\"t\":[\"2022-04-21
+        04:00:00\",\"+03:00\"],\"n\":[\"prospekt Miru, 20, Shepetivka\",\"Luftdaten
+        #25838\"],\"u\":\"ukraine/shepetivka/prospekt-miru--20\"},\"n\":[\"prospekt
+        Miru, 20, Shepetivka, Ukraine\"],\"score\":6,\"x\":11885,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"54\",\"t\":[\"2022-04-20
+        22:00:00\",\"+03:00\"],\"n\":[\"ecorada2, Kryvoy Roh\",\"vul.Futbolna\"],\"u\":\"ukraine/kryvoy-roh/ecorada2\"},\"n\":[\"ecorada2,
+        Kryvoy Roh, Ukraine\"],\"score\":6,\"x\":11718,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"51\",\"t\":[\"2022-04-21
+        05:00:00\",\"+03:00\"],\"n\":[\"Urban Space 100, Ivano-Frankivsk\",\"\u0432\u0443\u043B.\u0413\u0440\u0443\u0448\u0435\u0432\u0441\u044C\u043A\u043E\u0433\u043E\"],\"u\":\"ukraine/ivano-frankivsk/urban-space-100\"},\"n\":[\"Urban
+        Space 100, Ivano-Frankivsk, Ukraine\"],\"score\":6,\"x\":11680,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"46\",\"t\":[\"2022-04-21
+        04:00:00\",\"+03:00\"],\"n\":[\"Alma-Atinska vulicya, 1, Chernivci\",\"Luftdaten
+        #26750\"],\"u\":\"ukraine/chernivci/alma-atinska-vulicya--1\"},\"n\":[\"Alma-Atinska
+        vulicya, 1, Chernivci, Ukraine\"],\"score\":6,\"x\":11875,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"40\",\"t\":[\"2022-04-21
+        04:00:00\",\"+03:00\"],\"n\":[\"50 Rok\u0456v Peremogy Street, Surs\\\\'ko-Lytovs\\\\'ke\"]},\"n\":[\"50
+        Rok\u0456v Peremogy Street, Surs'ko-Lytovs'ke, Ukraine\"],\"score\":6,\"x\":11627,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"38\",\"t\":[\"2022-04-21
+        03:00:00\",\"+03:00\"],\"n\":[\"bulvar Perova, 48, Kiyiv\"],\"u\":\"ukraine/kiyiv/bulvar-perova--48\"},\"n\":[\"bulvar
+        Perova, 48, Kiyiv, Ukraine\"],\"score\":6,\"x\":11884,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"35\",\"t\":[\"2022-04-20
+        22:00:00\",\"+03:00\"],\"n\":[\"Pobeda-6, Geroev Avenue, 40, Dnipro\"],\"u\":\"ukraine/dnipro/pobeda-6--geroev-avenue--40\"},\"n\":[\"Pobeda-6,
+        Geroev Avenue, 40, Dnipro, Ukraine\"],\"score\":6,\"x\":11431,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"31\",\"t\":[\"2022-04-21
+        04:00:00\",\"+03:00\"],\"n\":[\"Vulytsya Pavla Nirinberha, 4-6, Dnipro\"],\"u\":\"ukraine/dnipro/vulytsya-pavla-nirinberha--4-6\"},\"n\":[\"Vulytsya
+        Pavla Nirinberha, 4-6, Dnipro, Ukraine\"],\"score\":6,\"x\":11623,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"18\",\"t\":[\"2022-04-21
+        05:00:00\",\"+03:00\"],\"n\":[\"ecorada1, Kryvyi Rih\",\"\u0427\u0435\u0441\u044C\u043A\u0430\"],\"u\":\"ukraine/kryvyi-rih/ecorada1\"},\"n\":[\"ecorada1,
+        Kryvyi Rih, Ukraine\"],\"score\":6,\"x\":11689,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"-\",\"t\":[\"2022-03-30
+        02:00:00\",\"+03:00\"],\"n\":[\"APS 1001, Kramatorsk\"],\"u\":\"ukraine/kramatorsk/aps-1001\"},\"n\":[\"APS
+        1001, Kramatorsk, Ukraine\"],\"score\":6,\"x\":11876,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"-\",\"t\":[\"2019-11-10
+        12:00:00\",\"+03:00\"],\"n\":[\"Zayats, Zaporizhzhya\",\"Charivna\"],\"u\":\"ukraine/zaporizhzhya/zayats\"},\"n\":[\"Zayats,
+        Zaporizhzhya, Ukraine\"],\"score\":6,\"x\":11743,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"-\",\"t\":[\"2020-08-30
+        15:00:00\",\"+03:00\"],\"n\":[\"TsUM, Ivano-Frankivsk\",\"\u0432\u0443\u043B.\u0414\u043D\u0456\u0441\u0442\u0440\u043E\u0432\u043A\u0441\u044C\u043A\u0430\"],\"u\":\"ukraine/ivano-frankivsk/tsum\"},\"n\":[\"TsUM,
+        Ivano-Frankivsk, Ukraine\"],\"score\":6,\"x\":11683,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"-\",\"t\":[\"2019-10-07
+        14:00:00\",\"+03:00\"],\"n\":[\"Topolia-2, 23, Dnipro\"],\"u\":\"ukraine/dnipro/topolia-2--23\"},\"n\":[\"Topolia-2,
+        23, Dnipro, Ukraine\"],\"score\":6,\"x\":11728,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"-\",\"t\":[\"2022-03-30
+        02:00:00\",\"+03:00\"],\"n\":[\"APS 3001, Mikolayivka\"],\"u\":\"ukraine/mikolayivka/aps-3001\"},\"n\":[\"APS
+        3001, Mikolayivka, Ukraine\"],\"score\":6,\"x\":11879,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"-\",\"t\":[\"2020-10-13
+        18:00:00\",\"+03:00\"],\"n\":[\"MEREZhA-868, Hlibivka\",\"Dzhyntamo-Bryz\"],\"u\":\"ukraine/hlibivka/merezha-868\"},\"n\":[\"MEREZhA-868,
+        Hlibivka, Ukraine\"],\"score\":6,\"x\":11792,\"c\":\"UA\",\"z\":0,\"$\":\"realtime\"}]}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:07:32 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      X-Gen-Time:
+      - 13.349102ms
+      X-Powered-By:
+      - waqi-search/1.2
+      content-length:
+      - '4673'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_coordinate_air/test_bad_coordinates.yaml
+++ b/tests/cassettes/test_get_coordinate_air/test_bad_coordinates.yaml
@@ -1,0 +1,217 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:not%20a%20lat;not%20a%20lon/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Thu, 21 Apr 2022 01:07:44 GMT
+      Location:
+      - /feed/geo:not%20a%20lat;not%20a%20lon/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:not%20a%20lat;not%20a%20lon/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"error","data":"Invalid geo position - Can not parse ''not
+        a lat,not a lon''"}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:07:44 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "99.592\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '86'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:None;None/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Thu, 21 Apr 2022 01:07:45 GMT
+      Location:
+      - /feed/geo:None;None/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:None;None/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"error","data":"Invalid geo position - Can not parse ''None,None''"}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:07:45 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "78.482\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '76'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:nan;nan/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Thu, 21 Apr 2022 01:07:46 GMT
+      Location:
+      - /feed/geo:nan;nan/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:nan;nan/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: "{\"status\":\"ok\",\"data\":{\"aqi\":999,\"idx\":3439,\"attributions\":[{\"url\":\"http://sthjt.shanxi.gov.cn/\",\"name\":\"Shanxi
+        Province Environmental Monitoring Center (\u5C71\u897F\u7701\u73AF\u5883\u76D1\u6D4B\u4E2D\u5FC3\u7AD9\u7F51\u7AD9\u9996\u9875)\"},{\"url\":\"https://waqi.info/\",\"name\":\"World
+        Air Quality Index Project\"}],\"city\":{\"geo\":[40.0758,113.2994],\"name\":\"Yungang
+        Hotel, Datong (\u5927\u540C\u4E91\u5188\u5BBE\u9986)\",\"url\":\"https://aqicn.org/city/china/datong/yungangbinguan\",\"location\":\"\"},\"dominentpol\":\"pm10\",\"iaqi\":{\"co\":{\"v\":4.6},\"dew\":{\"v\":-10},\"h\":{\"v\":15},\"no2\":{\"v\":11.9},\"o3\":{\"v\":23.6},\"p\":{\"v\":881.1},\"pm10\":{\"v\":999},\"pm25\":{\"v\":261},\"r\":{\"v\":99.6},\"so2\":{\"v\":5.6},\"t\":{\"v\":16.8},\"w\":{\"v\":4}},\"time\":{\"s\":\"2022-04-21
+        08:00:00\",\"tz\":\"+08:00\",\"v\":1650528000,\"iso\":\"2022-04-21T08:00:00+08:00\"},\"forecast\":{\"daily\":{\"o3\":[{\"avg\":8,\"day\":\"2022-04-19\",\"max\":21,\"min\":2},{\"avg\":18,\"day\":\"2022-04-20\",\"max\":29,\"min\":9},{\"avg\":17,\"day\":\"2022-04-21\",\"max\":22,\"min\":10},{\"avg\":8,\"day\":\"2022-04-22\",\"max\":22,\"min\":2},{\"avg\":18,\"day\":\"2022-04-23\",\"max\":26,\"min\":9},{\"avg\":4,\"day\":\"2022-04-24\",\"max\":18,\"min\":1},{\"avg\":1,\"day\":\"2022-04-25\",\"max\":1,\"min\":1},{\"avg\":1,\"day\":\"2022-04-26\",\"max\":1,\"min\":1}],\"pm10\":[{\"avg\":20,\"day\":\"2022-04-19\",\"max\":28,\"min\":10},{\"avg\":38,\"day\":\"2022-04-20\",\"max\":46,\"min\":19},{\"avg\":253,\"day\":\"2022-04-21\",\"max\":396,\"min\":46},{\"avg\":45,\"day\":\"2022-04-22\",\"max\":58,\"min\":19},{\"avg\":208,\"day\":\"2022-04-23\",\"max\":396,\"min\":55},{\"avg\":396,\"day\":\"2022-04-24\",\"max\":396,\"min\":396},{\"avg\":330,\"day\":\"2022-04-25\",\"max\":396,\"min\":174},{\"avg\":144,\"day\":\"2022-04-26\",\"max\":396,\"min\":21},{\"avg\":68,\"day\":\"2022-04-27\",\"max\":116,\"min\":28}],\"pm25\":[{\"avg\":55,\"day\":\"2022-04-19\",\"max\":89,\"min\":21},{\"avg\":66,\"day\":\"2022-04-20\",\"max\":68,\"min\":40},{\"avg\":181,\"day\":\"2022-04-21\",\"max\":252,\"min\":68},{\"avg\":75,\"day\":\"2022-04-22\",\"max\":89,\"min\":42},{\"avg\":177,\"day\":\"2022-04-23\",\"max\":252,\"min\":76},{\"avg\":252,\"day\":\"2022-04-24\",\"max\":252,\"min\":252},{\"avg\":225,\"day\":\"2022-04-25\",\"max\":252,\"min\":174},{\"avg\":123,\"day\":\"2022-04-26\",\"max\":252,\"min\":42},{\"avg\":105,\"day\":\"2022-04-27\",\"max\":159,\"min\":68}],\"uvi\":[{\"avg\":1,\"day\":\"2022-04-19\",\"max\":7,\"min\":0},{\"avg\":1,\"day\":\"2022-04-20\",\"max\":7,\"min\":0},{\"avg\":1,\"day\":\"2022-04-21\",\"max\":6,\"min\":0},{\"avg\":1,\"day\":\"2022-04-22\",\"max\":7,\"min\":0},{\"avg\":1,\"day\":\"2022-04-23\",\"max\":7,\"min\":0},{\"avg\":1,\"day\":\"2022-04-24\",\"max\":7,\"min\":0},{\"avg\":2,\"day\":\"2022-04-25\",\"max\":7,\"min\":0}]}},\"debug\":{\"sync\":\"2022-04-21T09:30:25+09:00\"}}}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:07:47 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "975.818\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2421'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_coordinate_air/test_bad_data_format.yaml
+++ b/tests/cassettes/test_get_coordinate_air/test_bad_data_format.yaml
@@ -1,0 +1,76 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:51.51;-0.13/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Thu, 21 Apr 2022 01:07:48 GMT
+      Location:
+      - /feed/geo:51.51;-0.13/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:51.51;-0.13/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":57,"idx":5724,"attributions":[{"url":"http://uk-air.defra.gov.uk/","name":"UK-AIR,
+        air quality information resource - Defra, UK","logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"url":"https://londonair.org.uk/","name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","logo":"UK-London-Kings-College.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[51.5073509,-0.1277583],"name":"London","url":"https://aqicn.org/city/london","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":2.6},"h":{"v":78},"no2":{"v":14.8},"o3":{"v":26.6},"p":{"v":1015},"pm10":{"v":26},"pm25":{"v":57},"so2":{"v":0.6},"t":{"v":8.3},"w":{"v":3.6}},"time":{"s":"2022-04-21
+        00:00:00","tz":"+01:00","v":1650499200,"iso":"2022-04-21T00:00:00+01:00"},"forecast":{"daily":{"o3":[{"avg":19,"day":"2022-04-18","max":33,"min":8},{"avg":17,"day":"2022-04-19","max":34,"min":2},{"avg":25,"day":"2022-04-20","max":39,"min":14},{"avg":27,"day":"2022-04-21","max":36,"min":14},{"avg":23,"day":"2022-04-22","max":28,"min":17},{"avg":29,"day":"2022-04-23","max":37,"min":21},{"avg":36,"day":"2022-04-24","max":36,"min":32}],"pm10":[{"avg":18,"day":"2022-04-18","max":26,"min":10},{"avg":23,"day":"2022-04-19","max":31,"min":13},{"avg":19,"day":"2022-04-20","max":36,"min":10},{"avg":19,"day":"2022-04-21","max":28,"min":11},{"avg":18,"day":"2022-04-22","max":20,"min":14},{"avg":20,"day":"2022-04-23","max":23,"min":17},{"avg":16,"day":"2022-04-24","max":17,"min":16}],"pm25":[{"avg":47,"day":"2022-04-18","max":74,"min":23},{"avg":64,"day":"2022-04-19","max":81,"min":45},{"avg":59,"day":"2022-04-20","max":94,"min":33},{"avg":58,"day":"2022-04-21","max":79,"min":37},{"avg":56,"day":"2022-04-22","max":62,"min":46},{"avg":62,"day":"2022-04-23","max":70,"min":52},{"avg":53,"day":"2022-04-24","max":53,"min":52}],"uvi":[{"avg":1,"day":"2022-04-19","max":3,"min":0},{"avg":1,"day":"2022-04-20","max":4,"min":0},{"avg":1,"day":"2022-04-21","max":4,"min":0},{"avg":1,"day":"2022-04-22","max":3,"min":0},{"avg":1,"day":"2022-04-23","max":3,"min":0},{"avg":0,"day":"2022-04-24","max":2,"min":0},{"avg":0,"day":"2022-04-25","max":1,"min":0}]}},"debug":{"sync":"2022-04-21T09:24:45+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:07:48 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "214.254\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2269'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_coordinate_air/test_column_expected_contents.yaml
+++ b/tests/cassettes/test_get_coordinate_air/test_column_expected_contents.yaml
@@ -1,0 +1,76 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:51.51;-0.13/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Thu, 21 Apr 2022 01:07:37 GMT
+      Location:
+      - /feed/geo:51.51;-0.13/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:51.51;-0.13/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":57,"idx":5724,"attributions":[{"url":"http://uk-air.defra.gov.uk/","name":"UK-AIR,
+        air quality information resource - Defra, UK","logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"url":"https://londonair.org.uk/","name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","logo":"UK-London-Kings-College.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[51.5073509,-0.1277583],"name":"London","url":"https://aqicn.org/city/london","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":2.6},"h":{"v":78},"no2":{"v":14.8},"o3":{"v":26.6},"p":{"v":1015},"pm10":{"v":26},"pm25":{"v":57},"so2":{"v":0.6},"t":{"v":8.3},"w":{"v":3.6}},"time":{"s":"2022-04-21
+        00:00:00","tz":"+01:00","v":1650499200,"iso":"2022-04-21T00:00:00+01:00"},"forecast":{"daily":{"o3":[{"avg":19,"day":"2022-04-18","max":33,"min":8},{"avg":17,"day":"2022-04-19","max":34,"min":2},{"avg":25,"day":"2022-04-20","max":39,"min":14},{"avg":27,"day":"2022-04-21","max":36,"min":14},{"avg":23,"day":"2022-04-22","max":28,"min":17},{"avg":29,"day":"2022-04-23","max":37,"min":21},{"avg":36,"day":"2022-04-24","max":36,"min":32}],"pm10":[{"avg":18,"day":"2022-04-18","max":26,"min":10},{"avg":23,"day":"2022-04-19","max":31,"min":13},{"avg":19,"day":"2022-04-20","max":36,"min":10},{"avg":19,"day":"2022-04-21","max":28,"min":11},{"avg":18,"day":"2022-04-22","max":20,"min":14},{"avg":20,"day":"2022-04-23","max":23,"min":17},{"avg":16,"day":"2022-04-24","max":17,"min":16}],"pm25":[{"avg":47,"day":"2022-04-18","max":74,"min":23},{"avg":64,"day":"2022-04-19","max":81,"min":45},{"avg":59,"day":"2022-04-20","max":94,"min":33},{"avg":58,"day":"2022-04-21","max":79,"min":37},{"avg":56,"day":"2022-04-22","max":62,"min":46},{"avg":62,"day":"2022-04-23","max":70,"min":52},{"avg":53,"day":"2022-04-24","max":53,"min":52}],"uvi":[{"avg":1,"day":"2022-04-19","max":3,"min":0},{"avg":1,"day":"2022-04-20","max":4,"min":0},{"avg":1,"day":"2022-04-21","max":4,"min":0},{"avg":1,"day":"2022-04-22","max":3,"min":0},{"avg":1,"day":"2022-04-23","max":3,"min":0},{"avg":0,"day":"2022-04-24","max":2,"min":0},{"avg":0,"day":"2022-04-25","max":1,"min":0}]}},"debug":{"sync":"2022-04-21T09:24:45+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:07:37 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "232.924\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2269'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_coordinate_air/test_column_types.yaml
+++ b/tests/cassettes/test_get_coordinate_air/test_column_types.yaml
@@ -1,0 +1,76 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:51.51;-0.13/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Thu, 21 Apr 2022 01:07:39 GMT
+      Location:
+      - /feed/geo:51.51;-0.13/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:51.51;-0.13/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":57,"idx":5724,"attributions":[{"url":"http://uk-air.defra.gov.uk/","name":"UK-AIR,
+        air quality information resource - Defra, UK","logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"url":"https://londonair.org.uk/","name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","logo":"UK-London-Kings-College.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[51.5073509,-0.1277583],"name":"London","url":"https://aqicn.org/city/london","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":2.6},"h":{"v":78},"no2":{"v":14.8},"o3":{"v":26.6},"p":{"v":1015},"pm10":{"v":26},"pm25":{"v":57},"so2":{"v":0.6},"t":{"v":8.3},"w":{"v":3.6}},"time":{"s":"2022-04-21
+        00:00:00","tz":"+01:00","v":1650499200,"iso":"2022-04-21T00:00:00+01:00"},"forecast":{"daily":{"o3":[{"avg":19,"day":"2022-04-18","max":33,"min":8},{"avg":17,"day":"2022-04-19","max":34,"min":2},{"avg":25,"day":"2022-04-20","max":39,"min":14},{"avg":27,"day":"2022-04-21","max":36,"min":14},{"avg":23,"day":"2022-04-22","max":28,"min":17},{"avg":29,"day":"2022-04-23","max":37,"min":21},{"avg":36,"day":"2022-04-24","max":36,"min":32}],"pm10":[{"avg":18,"day":"2022-04-18","max":26,"min":10},{"avg":23,"day":"2022-04-19","max":31,"min":13},{"avg":19,"day":"2022-04-20","max":36,"min":10},{"avg":19,"day":"2022-04-21","max":28,"min":11},{"avg":18,"day":"2022-04-22","max":20,"min":14},{"avg":20,"day":"2022-04-23","max":23,"min":17},{"avg":16,"day":"2022-04-24","max":17,"min":16}],"pm25":[{"avg":47,"day":"2022-04-18","max":74,"min":23},{"avg":64,"day":"2022-04-19","max":81,"min":45},{"avg":59,"day":"2022-04-20","max":94,"min":33},{"avg":58,"day":"2022-04-21","max":79,"min":37},{"avg":56,"day":"2022-04-22","max":62,"min":46},{"avg":62,"day":"2022-04-23","max":70,"min":52},{"avg":53,"day":"2022-04-24","max":53,"min":52}],"uvi":[{"avg":1,"day":"2022-04-19","max":3,"min":0},{"avg":1,"day":"2022-04-20","max":4,"min":0},{"avg":1,"day":"2022-04-21","max":4,"min":0},{"avg":1,"day":"2022-04-22","max":3,"min":0},{"avg":1,"day":"2022-04-23","max":3,"min":0},{"avg":0,"day":"2022-04-24","max":2,"min":0},{"avg":0,"day":"2022-04-25","max":1,"min":0}]}},"debug":{"sync":"2022-04-21T09:24:45+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:07:39 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "301.665\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2269'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_coordinate_air/test_excluded_params.yaml
+++ b/tests/cassettes/test_get_coordinate_air/test_excluded_params.yaml
@@ -1,0 +1,76 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:51.51;-0.13/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Thu, 21 Apr 2022 01:07:40 GMT
+      Location:
+      - /feed/geo:51.51;-0.13/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:51.51;-0.13/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":57,"idx":5724,"attributions":[{"url":"http://uk-air.defra.gov.uk/","name":"UK-AIR,
+        air quality information resource - Defra, UK","logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"url":"https://londonair.org.uk/","name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","logo":"UK-London-Kings-College.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[51.5073509,-0.1277583],"name":"London","url":"https://aqicn.org/city/london","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":2.6},"h":{"v":78},"no2":{"v":14.8},"o3":{"v":26.6},"p":{"v":1015},"pm10":{"v":26},"pm25":{"v":57},"so2":{"v":0.6},"t":{"v":8.3},"w":{"v":3.6}},"time":{"s":"2022-04-21
+        00:00:00","tz":"+01:00","v":1650499200,"iso":"2022-04-21T00:00:00+01:00"},"forecast":{"daily":{"o3":[{"avg":19,"day":"2022-04-18","max":33,"min":8},{"avg":17,"day":"2022-04-19","max":34,"min":2},{"avg":25,"day":"2022-04-20","max":39,"min":14},{"avg":27,"day":"2022-04-21","max":36,"min":14},{"avg":23,"day":"2022-04-22","max":28,"min":17},{"avg":29,"day":"2022-04-23","max":37,"min":21},{"avg":36,"day":"2022-04-24","max":36,"min":32}],"pm10":[{"avg":18,"day":"2022-04-18","max":26,"min":10},{"avg":23,"day":"2022-04-19","max":31,"min":13},{"avg":19,"day":"2022-04-20","max":36,"min":10},{"avg":19,"day":"2022-04-21","max":28,"min":11},{"avg":18,"day":"2022-04-22","max":20,"min":14},{"avg":20,"day":"2022-04-23","max":23,"min":17},{"avg":16,"day":"2022-04-24","max":17,"min":16}],"pm25":[{"avg":47,"day":"2022-04-18","max":74,"min":23},{"avg":64,"day":"2022-04-19","max":81,"min":45},{"avg":59,"day":"2022-04-20","max":94,"min":33},{"avg":58,"day":"2022-04-21","max":79,"min":37},{"avg":56,"day":"2022-04-22","max":62,"min":46},{"avg":62,"day":"2022-04-23","max":70,"min":52},{"avg":53,"day":"2022-04-24","max":53,"min":52}],"uvi":[{"avg":1,"day":"2022-04-19","max":3,"min":0},{"avg":1,"day":"2022-04-20","max":4,"min":0},{"avg":1,"day":"2022-04-21","max":4,"min":0},{"avg":1,"day":"2022-04-22","max":3,"min":0},{"avg":1,"day":"2022-04-23","max":3,"min":0},{"avg":0,"day":"2022-04-24","max":2,"min":0},{"avg":0,"day":"2022-04-25","max":1,"min":0}]}},"debug":{"sync":"2022-04-21T09:24:45+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:07:40 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "386.087\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2269'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_coordinate_air/test_nonexistent_requested_params.yaml
+++ b/tests/cassettes/test_get_coordinate_air/test_nonexistent_requested_params.yaml
@@ -1,0 +1,76 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:51.51;-0.13/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Thu, 21 Apr 2022 01:07:41 GMT
+      Location:
+      - /feed/geo:51.51;-0.13/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:51.51;-0.13/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":57,"idx":5724,"attributions":[{"url":"http://uk-air.defra.gov.uk/","name":"UK-AIR,
+        air quality information resource - Defra, UK","logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"url":"https://londonair.org.uk/","name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","logo":"UK-London-Kings-College.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[51.5073509,-0.1277583],"name":"London","url":"https://aqicn.org/city/london","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":2.6},"h":{"v":78},"no2":{"v":14.8},"o3":{"v":26.6},"p":{"v":1015},"pm10":{"v":26},"pm25":{"v":57},"so2":{"v":0.6},"t":{"v":8.3},"w":{"v":3.6}},"time":{"s":"2022-04-21
+        00:00:00","tz":"+01:00","v":1650499200,"iso":"2022-04-21T00:00:00+01:00"},"forecast":{"daily":{"o3":[{"avg":19,"day":"2022-04-18","max":33,"min":8},{"avg":17,"day":"2022-04-19","max":34,"min":2},{"avg":25,"day":"2022-04-20","max":39,"min":14},{"avg":27,"day":"2022-04-21","max":36,"min":14},{"avg":23,"day":"2022-04-22","max":28,"min":17},{"avg":29,"day":"2022-04-23","max":37,"min":21},{"avg":36,"day":"2022-04-24","max":36,"min":32}],"pm10":[{"avg":18,"day":"2022-04-18","max":26,"min":10},{"avg":23,"day":"2022-04-19","max":31,"min":13},{"avg":19,"day":"2022-04-20","max":36,"min":10},{"avg":19,"day":"2022-04-21","max":28,"min":11},{"avg":18,"day":"2022-04-22","max":20,"min":14},{"avg":20,"day":"2022-04-23","max":23,"min":17},{"avg":16,"day":"2022-04-24","max":17,"min":16}],"pm25":[{"avg":47,"day":"2022-04-18","max":74,"min":23},{"avg":64,"day":"2022-04-19","max":81,"min":45},{"avg":59,"day":"2022-04-20","max":94,"min":33},{"avg":58,"day":"2022-04-21","max":79,"min":37},{"avg":56,"day":"2022-04-22","max":62,"min":46},{"avg":62,"day":"2022-04-23","max":70,"min":52},{"avg":53,"day":"2022-04-24","max":53,"min":52}],"uvi":[{"avg":1,"day":"2022-04-19","max":3,"min":0},{"avg":1,"day":"2022-04-20","max":4,"min":0},{"avg":1,"day":"2022-04-21","max":4,"min":0},{"avg":1,"day":"2022-04-22","max":3,"min":0},{"avg":1,"day":"2022-04-23","max":3,"min":0},{"avg":0,"day":"2022-04-24","max":2,"min":0},{"avg":0,"day":"2022-04-25","max":1,"min":0}]}},"debug":{"sync":"2022-04-21T09:24:45+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:07:42 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "208.024\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2269'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_coordinate_air/test_output_formats.yaml
+++ b/tests/cassettes/test_get_coordinate_air/test_output_formats.yaml
@@ -1,0 +1,224 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:51.51;-0.13/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Thu, 21 Apr 2022 01:07:49 GMT
+      Location:
+      - /feed/geo:51.51;-0.13/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:51.51;-0.13/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":57,"idx":5724,"attributions":[{"url":"http://uk-air.defra.gov.uk/","name":"UK-AIR,
+        air quality information resource - Defra, UK","logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"url":"https://londonair.org.uk/","name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","logo":"UK-London-Kings-College.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[51.5073509,-0.1277583],"name":"London","url":"https://aqicn.org/city/london","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":2.6},"h":{"v":78},"no2":{"v":14.8},"o3":{"v":26.6},"p":{"v":1015},"pm10":{"v":26},"pm25":{"v":57},"so2":{"v":0.6},"t":{"v":8.3},"w":{"v":3.6}},"time":{"s":"2022-04-21
+        00:00:00","tz":"+01:00","v":1650499200,"iso":"2022-04-21T00:00:00+01:00"},"forecast":{"daily":{"o3":[{"avg":19,"day":"2022-04-18","max":33,"min":8},{"avg":17,"day":"2022-04-19","max":34,"min":2},{"avg":25,"day":"2022-04-20","max":39,"min":14},{"avg":27,"day":"2022-04-21","max":36,"min":14},{"avg":23,"day":"2022-04-22","max":28,"min":17},{"avg":29,"day":"2022-04-23","max":37,"min":21},{"avg":36,"day":"2022-04-24","max":36,"min":32}],"pm10":[{"avg":18,"day":"2022-04-18","max":26,"min":10},{"avg":23,"day":"2022-04-19","max":31,"min":13},{"avg":19,"day":"2022-04-20","max":36,"min":10},{"avg":19,"day":"2022-04-21","max":28,"min":11},{"avg":18,"day":"2022-04-22","max":20,"min":14},{"avg":20,"day":"2022-04-23","max":23,"min":17},{"avg":16,"day":"2022-04-24","max":17,"min":16}],"pm25":[{"avg":47,"day":"2022-04-18","max":74,"min":23},{"avg":64,"day":"2022-04-19","max":81,"min":45},{"avg":59,"day":"2022-04-20","max":94,"min":33},{"avg":58,"day":"2022-04-21","max":79,"min":37},{"avg":56,"day":"2022-04-22","max":62,"min":46},{"avg":62,"day":"2022-04-23","max":70,"min":52},{"avg":53,"day":"2022-04-24","max":53,"min":52}],"uvi":[{"avg":1,"day":"2022-04-19","max":3,"min":0},{"avg":1,"day":"2022-04-20","max":4,"min":0},{"avg":1,"day":"2022-04-21","max":4,"min":0},{"avg":1,"day":"2022-04-22","max":3,"min":0},{"avg":1,"day":"2022-04-23","max":3,"min":0},{"avg":0,"day":"2022-04-24","max":2,"min":0},{"avg":0,"day":"2022-04-25","max":1,"min":0}]}},"debug":{"sync":"2022-04-21T09:24:45+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:07:49 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "358.706\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2269'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:51.51;-0.13/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Thu, 21 Apr 2022 01:07:50 GMT
+      Location:
+      - /feed/geo:51.51;-0.13/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:51.51;-0.13/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":57,"idx":5724,"attributions":[{"url":"http://uk-air.defra.gov.uk/","name":"UK-AIR,
+        air quality information resource - Defra, UK","logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"url":"https://londonair.org.uk/","name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","logo":"UK-London-Kings-College.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[51.5073509,-0.1277583],"name":"London","url":"https://aqicn.org/city/london","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":2.6},"h":{"v":78},"no2":{"v":14.8},"o3":{"v":26.6},"p":{"v":1015},"pm10":{"v":26},"pm25":{"v":57},"so2":{"v":0.6},"t":{"v":8.3},"w":{"v":3.6}},"time":{"s":"2022-04-21
+        00:00:00","tz":"+01:00","v":1650499200,"iso":"2022-04-21T00:00:00+01:00"},"forecast":{"daily":{"o3":[{"avg":19,"day":"2022-04-18","max":33,"min":8},{"avg":17,"day":"2022-04-19","max":34,"min":2},{"avg":25,"day":"2022-04-20","max":39,"min":14},{"avg":27,"day":"2022-04-21","max":36,"min":14},{"avg":23,"day":"2022-04-22","max":28,"min":17},{"avg":29,"day":"2022-04-23","max":37,"min":21},{"avg":36,"day":"2022-04-24","max":36,"min":32}],"pm10":[{"avg":18,"day":"2022-04-18","max":26,"min":10},{"avg":23,"day":"2022-04-19","max":31,"min":13},{"avg":19,"day":"2022-04-20","max":36,"min":10},{"avg":19,"day":"2022-04-21","max":28,"min":11},{"avg":18,"day":"2022-04-22","max":20,"min":14},{"avg":20,"day":"2022-04-23","max":23,"min":17},{"avg":16,"day":"2022-04-24","max":17,"min":16}],"pm25":[{"avg":47,"day":"2022-04-18","max":74,"min":23},{"avg":64,"day":"2022-04-19","max":81,"min":45},{"avg":59,"day":"2022-04-20","max":94,"min":33},{"avg":58,"day":"2022-04-21","max":79,"min":37},{"avg":56,"day":"2022-04-22","max":62,"min":46},{"avg":62,"day":"2022-04-23","max":70,"min":52},{"avg":53,"day":"2022-04-24","max":53,"min":52}],"uvi":[{"avg":1,"day":"2022-04-19","max":3,"min":0},{"avg":1,"day":"2022-04-20","max":4,"min":0},{"avg":1,"day":"2022-04-21","max":4,"min":0},{"avg":1,"day":"2022-04-22","max":3,"min":0},{"avg":1,"day":"2022-04-23","max":3,"min":0},{"avg":0,"day":"2022-04-24","max":2,"min":0},{"avg":0,"day":"2022-04-25","max":1,"min":0}]}},"debug":{"sync":"2022-04-21T09:24:45+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:07:51 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "209.793\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2269'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:51.51;-0.13/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Thu, 21 Apr 2022 01:07:52 GMT
+      Location:
+      - /feed/geo:51.51;-0.13/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:51.51;-0.13/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":57,"idx":5724,"attributions":[{"url":"http://uk-air.defra.gov.uk/","name":"UK-AIR,
+        air quality information resource - Defra, UK","logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"url":"https://londonair.org.uk/","name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","logo":"UK-London-Kings-College.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[51.5073509,-0.1277583],"name":"London","url":"https://aqicn.org/city/london","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":2.6},"h":{"v":78},"no2":{"v":14.8},"o3":{"v":26.6},"p":{"v":1015},"pm10":{"v":26},"pm25":{"v":57},"so2":{"v":0.6},"t":{"v":8.3},"w":{"v":3.6}},"time":{"s":"2022-04-21
+        00:00:00","tz":"+01:00","v":1650499200,"iso":"2022-04-21T00:00:00+01:00"},"forecast":{"daily":{"o3":[{"avg":19,"day":"2022-04-18","max":33,"min":8},{"avg":17,"day":"2022-04-19","max":34,"min":2},{"avg":25,"day":"2022-04-20","max":39,"min":14},{"avg":27,"day":"2022-04-21","max":36,"min":14},{"avg":23,"day":"2022-04-22","max":28,"min":17},{"avg":29,"day":"2022-04-23","max":37,"min":21},{"avg":36,"day":"2022-04-24","max":36,"min":32}],"pm10":[{"avg":18,"day":"2022-04-18","max":26,"min":10},{"avg":23,"day":"2022-04-19","max":31,"min":13},{"avg":19,"day":"2022-04-20","max":36,"min":10},{"avg":19,"day":"2022-04-21","max":28,"min":11},{"avg":18,"day":"2022-04-22","max":20,"min":14},{"avg":20,"day":"2022-04-23","max":23,"min":17},{"avg":16,"day":"2022-04-24","max":17,"min":16}],"pm25":[{"avg":47,"day":"2022-04-18","max":74,"min":23},{"avg":64,"day":"2022-04-19","max":81,"min":45},{"avg":59,"day":"2022-04-20","max":94,"min":33},{"avg":58,"day":"2022-04-21","max":79,"min":37},{"avg":56,"day":"2022-04-22","max":62,"min":46},{"avg":62,"day":"2022-04-23","max":70,"min":52},{"avg":53,"day":"2022-04-24","max":53,"min":52}],"uvi":[{"avg":1,"day":"2022-04-19","max":3,"min":0},{"avg":1,"day":"2022-04-20","max":4,"min":0},{"avg":1,"day":"2022-04-21","max":4,"min":0},{"avg":1,"day":"2022-04-22","max":3,"min":0},{"avg":1,"day":"2022-04-23","max":3,"min":0},{"avg":0,"day":"2022-04-24","max":2,"min":0},{"avg":0,"day":"2022-04-25","max":1,"min":0}]}},"debug":{"sync":"2022-04-21T09:24:45+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:07:52 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "171.813\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2269'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_coordinate_air/test_return_value_and_format.yaml
+++ b/tests/cassettes/test_get_coordinate_air/test_return_value_and_format.yaml
@@ -1,0 +1,76 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:51.51;-0.13/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Thu, 21 Apr 2022 01:07:36 GMT
+      Location:
+      - /feed/geo:51.51;-0.13/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:51.51;-0.13/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":57,"idx":5724,"attributions":[{"url":"http://uk-air.defra.gov.uk/","name":"UK-AIR,
+        air quality information resource - Defra, UK","logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"url":"https://londonair.org.uk/","name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","logo":"UK-London-Kings-College.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[51.5073509,-0.1277583],"name":"London","url":"https://aqicn.org/city/london","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":2.6},"h":{"v":78},"no2":{"v":14.8},"o3":{"v":26.6},"p":{"v":1015},"pm10":{"v":26},"pm25":{"v":57},"so2":{"v":0.6},"t":{"v":8.3},"w":{"v":3.6}},"time":{"s":"2022-04-21
+        00:00:00","tz":"+01:00","v":1650499200,"iso":"2022-04-21T00:00:00+01:00"},"forecast":{"daily":{"o3":[{"avg":19,"day":"2022-04-18","max":33,"min":8},{"avg":17,"day":"2022-04-19","max":34,"min":2},{"avg":25,"day":"2022-04-20","max":39,"min":14},{"avg":27,"day":"2022-04-21","max":36,"min":14},{"avg":23,"day":"2022-04-22","max":28,"min":17},{"avg":29,"day":"2022-04-23","max":37,"min":21},{"avg":36,"day":"2022-04-24","max":36,"min":32}],"pm10":[{"avg":18,"day":"2022-04-18","max":26,"min":10},{"avg":23,"day":"2022-04-19","max":31,"min":13},{"avg":19,"day":"2022-04-20","max":36,"min":10},{"avg":19,"day":"2022-04-21","max":28,"min":11},{"avg":18,"day":"2022-04-22","max":20,"min":14},{"avg":20,"day":"2022-04-23","max":23,"min":17},{"avg":16,"day":"2022-04-24","max":17,"min":16}],"pm25":[{"avg":47,"day":"2022-04-18","max":74,"min":23},{"avg":64,"day":"2022-04-19","max":81,"min":45},{"avg":59,"day":"2022-04-20","max":94,"min":33},{"avg":58,"day":"2022-04-21","max":79,"min":37},{"avg":56,"day":"2022-04-22","max":62,"min":46},{"avg":62,"day":"2022-04-23","max":70,"min":52},{"avg":53,"day":"2022-04-24","max":53,"min":52}],"uvi":[{"avg":1,"day":"2022-04-19","max":3,"min":0},{"avg":1,"day":"2022-04-20","max":4,"min":0},{"avg":1,"day":"2022-04-21","max":4,"min":0},{"avg":1,"day":"2022-04-22","max":3,"min":0},{"avg":1,"day":"2022-04-23","max":3,"min":0},{"avg":0,"day":"2022-04-24","max":2,"min":0},{"avg":0,"day":"2022-04-25","max":1,"min":0}]}},"debug":{"sync":"2022-04-21T09:24:45+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:07:36 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "571.141\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2269'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_historical_data/test_correct_data_format.yaml
+++ b/tests/cassettes/test_get_historical_data/test_correct_data_format.yaml
@@ -1,0 +1,1654 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/api/attsse/5724/yd.json
+  response:
+    body:
+      string: 'event: debug
+
+        data: "Fetching 2022-P4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2022-04-20T22:21:53+01:00","st":457992,"ps":{"co":"1|0B2CAabDaCbAba2BaCACa","no2":"1|0LEFEcDjDaHMghEFdbeAc","o3":"1|0!32BbcDAhEbFiFBAFaJfae","pm10":"1|0OFBdCdCBaCMCnALNenaJ","pm25":"1!32PGjhgANDCNCrHP!36g!-34iP","so2":"1|0.3ABa5AB3AaBaABa"},"dh":24,"time":{"span":["2022-04-20T00:00:00Z","2022-04-20T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"1ms"}},"status":"ok","cached":"3h51m35.659968022s"}
+
+
+        event: debug
+
+        data: "Fetching 2022-P3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2022-04-06T19:38:10+01:00","st":457248,"ps":{"co":"1|0.2BAaAa2BABa2AB2AIfdBCbBCb2a2ACEcaC","no2":"1|0XCInfaJc2FdeBJAgHak2DM2GjgiHhgeFCF","o3":"1|0ScEFBA2aEBbGbGkaBEaDcGFABCsbJ2ACBb","pm10":"1|0QPKrgCDOge2bcHBEb2DAT2FGcqtI2DueFC","pm25":"1!53!45C!-36bhb!31qadnDKbMqENK!28RPEA!-48!-34RKD!-48kRK","so2":"1|0.7AB2ABaABaB2a2ABA2B3A2aAa3A"},"dh":24,"time":{"span":["2022-04-03T00:00:00Z","2022-04-03T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"342h35m18.656259496s"}
+
+
+        event: debug
+
+        data: "Fetching 2022-P2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2022-03-06T19:26:40Z","st":456576,"ps":{"co":"1|0FaCFaBCdADAb2afbHabcC2ADaA2abCAbAB","no2":"1|0HENcBkOaAbGieHEiFfGgAKDcAFhHdJDpgb","o3":"1|0WDBDBaAaAkCFDbBGcCeE2aCBeDcagcFECB","pm10":"1|0TDFdFnKlFBEB2dHgPde2AEjiJAdIaPNvfB","pm25":"1!42FCiAjPqAOCDBgEfKcD2AEruTIiQH!44E!-38Il","so2":"1|0B2Aa2ABaBa2AB4AaBa3ABAaABa2Bb2A"},"dh":24,"time":{"span":["2022-03-06T00:00:00Z","2022-03-06T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"1ms"}},"status":"ok","cached":"1085h46m48.655800533s"}
+
+
+        event: debug
+
+        data: "Fetching 2022-P1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2022-02-06T19:39:29Z","st":455880,"ps":{"co":"1|0C2aFEcBAdFCBcabGeBdcBaA3BbDBAaCF2a","no2":"1|0.3ELEjFPrL2ElfGHkeHe2BbIdFrEbHDFfBk","o3":"1|0!28iaIc2adbibcGIe2CEiLCbhCEAHADeCBE2A","pm10":"1|0NdDFeDFLkPEIcmAMlkBfL2BcbBdFeAEFfGn","pm25":"1!33iGVsETOlWFZhzo!40!-38lcCw!47ImndmICbEDefj","so2":"1|0CbAB5ABABa2ABcB7ABbB2ABAb2A"},"dh":24,"time":{"span":["2022-02-06T00:00:00Z","2022-02-06T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"1ms"}},"status":"ok","cached":"1757h33m59.230502385s"}
+
+
+        event: debug
+
+        data: "Fetching 2021-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2022-01-06T17:48:21Z","st":453624,"ps":{"co":"1|0C4ABaAB3A2BbC2abBCBAaBabBABA2C2aGgDacbCABcCEFedBba2DeCbDEABC2AcAfAB2AdBAB2aA2BaACbaCcEcaABA","no2":"1|0!26ahMfADfKlaDFDaFfaiFaGCeEAdEAahIGgkSiaL2aDfjbMJhDfAmGQBoEoCXigEPkoVaecdTq2DbdABbHCKncjN2eDeBaD","o3":"1|0ZCeEaegDCabCeKBjKhEGbaDCeDEdDcCboJAmQaiIabEdbiEBEaIaboICGFblPAjCEAfKaeCeFagECacDCApJDaB2FgABcK","pm10":"1|0SAcCdGEaSdo2Bb2FfAEgcAcECab2BeCaFBgMBiGhbEBhaIFBbgBdCMJk2gCLBfdGIl!30AufgHecFaiFCfbHOBkbJfjEaFHi","pm25":"1!34aAFdHIB!51h!-43EjIEMhAJrh2cCGAhMaBjaOMr!31e!-27RrEFBsDVKg2edmNXWxudAWAD!-27RYv!78b!-72zdNoBLGoMGon!26PJwBVrmj2GS!-27","so2":"1|0AB6Aa3ABAaB11A2B2AcC2aBaABAB2AbBAa2B3AaCBabABa3ACbaEBA3aAbBAa2ACAb2Ba2AaAB2ABA"},"dh":24,"time":{"span":["2022-01-02T00:00:00Z","2022-01-02T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"3ms"}},"status":"ok","cached":"2503h25m7.732431141s"}
+
+
+        event: debug
+
+        data: "Fetching 2021-Q3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2021-12-31T15:17:19Z","st":451416,"ps":{"co":"1|0GE2AfcAFBbA2aBaB2ABa2A2aAaCACAaA2BAaB3ADbaCabABa2ABaABaBa2ABa4Ab2A2aBa2A2BE2AbACB2A2aABAbc2A","no2":"1|0YekdDaGOC2eGbacbdHE2DkeD2CAkLdDhaADfaKaCBGeABeCEaDAFhFda2DeAkdBAJaC!26ErtAaHcCDRBcjfGBAFgeFEfI2ah","o3":"1|0!30EicEeCADoCaLCgKCMADCndCgOgkDcEbDGbBhEceHCjEHAehHCebHBFcAb2BbadDBdTAOb!-28DFcBiHCAHtIjOhFlKIdeDACe","pm10":"1|0UFheEbCaCaBdEcdHcHDGCdnObGpdFafBABDcAaFaBAaDCfHfaCcDaAHfADgcdACIHIDIKe!-30g2BAFcGeGJsKEcAcDeEcGeAc","pm25":"1!57NunC2dAJICcFfiEbEIHTb!-27UDdvcdfBdBQIdmdCBKeBcadPpeJAIEhbkDCE2gaLGR2CBWAxqBDk!26PozQPzIFgAfCfcACBaA","so2":"1|0Eba2BA3a16AB5AaBa43ABAa4A2Ba5AaBA"},"dh":24,"time":{"span":["2021-10-03T00:00:00Z","2021-10-03T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"5ms"}},"status":"ok","cached":"2649h56m9.66008819s"}
+
+
+        event: debug
+
+        data: "Fetching 2021-Q2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2021-12-31T15:17:24Z","st":449232,"ps":{"co":"1|0FCA3B2A2aBCBdA2BAd3BA2aCBbd2aBaADBadaBABbB2ACbDcACbBAB2aAa2AB4Aa9AB13AFE2A","no2":"1|0RhbIBbJ2AebLMmeFeBLDefFgjDRiAFfdeDFCAkBGFAEfCgHBdBcAbHbAFGngDGIgGhdBFagadH2aLhC2dCAIA2bcDHbBekd","o3":"1|0!29ECBdcaACaD2bGcDcACfDaAKdAaFgDCaEheCD2gMHbkGAbcAF2AcHgdHGfIcHMbprWqEKbqDMHlhSq2AaFCImFCB2iKIEic","pm10":"1|0!35sBHcg2FebdHKdiCbCQIL!-28bAecNEla2BcdaBEcbBDBacDcAFcGai2BCaBIAbDAEAiacCACbdbGeDHce3aCAJhCDcEg2Fhe","pm25":"1!68!-31FNbuJBEacLPh!-27AbERY!61!-83bGkj!26asgBFqCgEAFdRDQeHvpPDfGFieAHaHNJdFBCcqJlA2dcDfGEfMFfAhiCNjEaMdAnVNun","so2":"1|0Ba5ACAbA2Bb4AB5AaBABAa3ABAFAgA2Ba5ABaA2BAaABABAa2ABca4ABAa3ABAa3ABaABAa4AEbaB"},"dh":24,"time":{"span":["2021-07-04T00:00:00Z","2021-07-04T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"3ms"}},"status":"ok","cached":"2649h56m4.700095247s"}
+
+
+        event: debug
+
+        data: "Fetching 2021-Q1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2021-12-31T15:17:30Z","st":447144,"ps":{"co":"1|0HBA2CAa2bEcE2aAcaAC2BAc3aB2ABDbBaCBABACAacAeAaBACb2ADAcBADaAbAbFcACaAdDBAB2Aaea2A%ACADCAB","no2":"1|0MBDGaDb2BFgCBEdidDIadFdCgFjABIEiAFjEa2IbgcICgCBAaJiD2Eck2BGbdFBNhjbEf2aHIDlKnJFbac2fOSG!-33hbI","o3":"1|0RBfdAFANagbdDHFABbiDEdAhLEjDgPcgDfNb2AeDCBcBGbaBcqWbAdFi2dm!30baDmNcBDAdFfbAGiKfEcFa2CaHqGECB","pm10":"1|0KBAJHBgcdHjMgBEjBAFabCaBbBbEDBbabCbdbEOBgCcbAbBRfFmCDHEgLGHrqALHBmcAdAFEDdhBaLBIqcFaEKPpsBH","pm25":"1!53sC!36bNmowRcVpcHvAlWKBbdLqdbHSkAEcPqnkG!37GpHiaidbZCKzbIdaiVUM!-60kRZ!33zjqhGfNBEDqVjPCE!-27iAGF2Z!-31!-31FN","so2":"1|0.3ABAaB2ACbaBACAa2CaAbaACD3AfaABa4AB2Aa2BaACDAdE2ABAaCabd3ACa5AaB2aB2AB2aBa3A2B2a2A"},"dh":24,"time":{"span":["2021-04-04T00:00:00Z","2021-04-04T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"3ms"}},"status":"ok","cached":"2649h55m58.426730938s"}
+
+
+        event: debug
+
+        data: "Fetching 2020-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2021-01-06T19:09:19Z","st":444864,"ps":{"co":"1|0Fc2ABABbECb2abABaDba3AaAB2ACaAaCDCGcdabAaBAbABa3BbBCcBDC2aBaCaBaABDcaAaAaB2A2cABA3CbACaCAbAB","no2":"1|0YcfdEbABHAkOkbAFbAdeEIChCJbaBabeFJDFcfgFAeECjcHbAGDkGEeCH2adaEGcacbDFbjCaC2FdbgcbCFBjGfaJaIeB2d","o3":"1|0VdGAdabDeDBeBEeDdfTdC2aGfdB2DBa2AckiDbAFJ2Ec2Db3AbBgaFdjgB2JanNADdgdHDEcdDaJd2DBcABCdHdmDfDACA","pm10":"1|0KBCfGaEdFdbF2cC2aF2AdBAeADBAaCGebCF!28AqApDaCE2dEADcBcALhGBHMfjkMidC2DGcgACkFBbHdcaCDcfAc2DEAE!33rg","pm25":"1!31CbfRcGjOlkJfD2FJLeagHhgjRfIfEHjCBG!51!49!-56I!-40pacGfhDCHeLoFZpLINTgp!-36ZrAgOCNwgHnuHbdDPFiPKgsKeAUDNFIym","so2":"1|0DB2AbBbABbAC2a3ABCDAcaDBa2AbA3BcAB3Aab3ABCca2ABaACDAaDab2ACEC2bC2aCDdgC2aCcAaB2Aa2AHBbcB2bA"},"dh":24,"time":{"span":["2021-01-03T00:00:00Z","2021-01-03T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"5ms"}},"status":"ok","cached":"11262h4m9.657078432s"}
+
+
+        event: debug
+
+        data: "Fetching 2020-Q3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-12-31T18:40:16Z","st":442656,"ps":{"co":"1|0Fa5ABAda2AB5AaAB6ABABa5A2BaABAa6Aa11ADeBAaBAaA2BaAB2Aa3ABAaBaBaD2aDc2A","no2":"1|0RdeaBFKjaCBCB2aeIgdHeJGefb2AJCOubCHeH!27qtNAKyaFafGdeDCDEg2CBfaIKGkGiCacbdChBPNoeBfdQJiBjDeIcAIcfd","o3":"1|0GCGaLaBmHDEMqCdcAHBGBFEqeaBbMDW!-32DECAbYEKACDxueBKlkPdFAbCAgHb2aDEgAbBeabKacDEM2eDEblUjsL2BjaKadGA","pm10":"1|0MabBDBAcCbBEaf2AHebEaBDdcCbBFBUubaEdBIEbINGujAFkacO2cfDbBDeBEcHBeDabBfaFDgASUmnadgGCicFEbEabdBCf","pm25":"1!33deDbKIDbeHNsa2fNEiIadc2adCfPBUxgBJqO!28LeB!32d!-27!-39TX!-35mAL2DgHAgKiaEBRdgbaFcfwNKld!30!39q!-33FdjUH!-27pODAOHshCbf","so2":"1|0BaAEBa2Bbd8ABa2A3B2A2a2B2AaBaAaAaBA2BCaKhCeB2a2ACa2AbaDb2ABaBAaB3AaCBbaBAbABaBa4ABCB2A"},"dh":24,"time":{"span":["2020-10-04T00:00:00Z","2020-10-04T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"5ms"}},"status":"ok","cached":"11406h33m12.483644969s"}
+
+
+        event: debug
+
+        data: "Fetching 2020-Q2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-12-31T18:40:35Z","st":440472,"ps":{"co":"1|0F2AaAaBa4AB2aABAa7ABa4ABa3ABAaB5AaAB2Aa2AB3ABa6AaBaB2AB3AaBAaAaB4ABaA2Ba3A","no2":"1|0WJ3fMADadDglKHBmBbCA2Eag2Dc2ADad2aELgAlaGcCFEbEAEbieDCFBgCedAKEdFebcHChDaDFAEcfAdHGE2aobFAadeaB","o3":"1|0!31BACFfCD2ABElBaAcdNbCE2CmJigCAbFBDc2GECnjEABCAbFfHLmAdICbhEJdDbhgCebFGeFcDCaBdFfdbHM!32bt!-27dEdnCGaL","pm10":"1|0SdGBdBMWC2hijaNU!-28EdIBAEanBHqFcBcDFbGFgQkgc2bFabB2AdHab3B2DA2cAFkABbHBacJiAd2BaC2aJBIBdqBDcAabBD","pm25":"1!52zR2eDNUlTbmob!26!45!-65JbfiFHeoDWpAgAaNFyZFJnmlBAGAbDFhMKEmNCnjfCDeENlicHACADMQuHecGbBjaKdNdH!-31bCaHdeDb","so2":"1|0EDCAB2cABaBCcA2BaB4AB2ABaeBAa2A2aB2AC2aABaABaAaABAa4A2B2ABACbCA2bA3B7AaBaACB3Aa2baAEB"},"dh":24,"time":{"span":["2020-07-05T00:00:00Z","2020-07-05T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"5ms"}},"status":"ok","cached":"11406h32m53.013409584s"}
+
+
+        event: debug
+
+        data: "Fetching 2020-Q1"
+
+
+        event: data
+
+        data: {"msg":{"st":438288,"ps":{"co":"1|0GcAB5ABbBAbCaBCBDBfb3A2D3aB3ACba2b2CAbBcACBAaBbABCB3aDbEbdCBbBb3BbaDb2aBCACaBabAB","no2":"1|0!30caEbsOFcDdAEmQsLHcLbedIsaJNAfbaACaKCgdnSdGBCoCHAHhBgc2HcaBgBDJBoHDhJgJdbljJfCGf2aQbCidge","o3":"1|0KRalHEdbBAKcE2eaDlAjaLCdGFIAbAcGbBbra2LDbBeGebIcbEABacdC2AdHafnLHbIAecJg2AdkGFBDAaeNdGFag","pm10":"1|0!41yaBebFHQyFeBdBGcHGSckcAIhnDHhbJACaQDaojCD2bLpbLcCgKaiaFAaCFhbNdbIBmBgEFaecEBEDeCBGa2Lele","pm25":"1!116!-60kBjgMLpImeaAMGhNBUJFo!-27!39qsoLkeZDbe!27LK!-38kbaAGIqbJeFkKIpb2BFDCkaUbHDbsbdeNCpfPgKQvGMGCTUj!-34u","so2":"1|0BABaAB2AB2aCBaAa2ABCAdACaC2Ba5AbBaBA2B2ACcFabaABbBdACaAaB2AB2Aa6A2a3A2B3ABa2BEda"},"dh":24,"time":{"span":["2020-03-29T00:00:00Z","2020-03-29T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"7ms"}},"status":"ok","cached":"18059h59m38.892041557s"}
+
+
+        event: debug
+
+        data: "Fetching 2019-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:09:47+01:00","st":436080,"ps":{"co":"1|0BADb2aC2BabBAaDa2ABbaFA2bACAa2CbADAdEBA2aCBAbc2DdGbabaCc2AaABbE2BaeBaBAC2aAaBAabCaBAaCaBAa","no2":"1|0!29eT2hjVBABlTnDPeMkcrAZAjfgASeA2BnKNwRElHceJGJ!-30XCyOaga2jEBAaKJlKJGkcfgBEJCgBeKAfcIebBcbacFd","o3":"1|0ZfCdcKeFcDabHkBEAFeEAkjFTAjACblQAgbFdBf2ED2cGehcIkPkJfDJAcEhgPmAdVcEBdBeaDHA2eaIfH2dFbBgDA","pm10":"1|0SeLCgeEIgDfaBFbEb2abcNMglbBUvHMFlDBmKkKDjcCacCEKqXnFhB2cfEaHFnOJKewBc2CDAdBdFcFcdaAE2aB2DA","pm25":"1!47dNDkcCFhBaCoKDKcbcJuJSmrPA2gORkmUpNO!-27YkcodRdEVK!-51!42iFyOqCo2LMC!-29!35pR2vPdAGAhDFdELaAajD2C2APHa","so2":"1|0CaDb2aDAaBcCAaDbaABaAB2A2aAEAB4ABa2ACbAaABbBA2aCaA2aABbBa3A2CABca3ACA2aA2CbA2CAbd3AaA"},"dh":24,"time":{"span":["2019-12-29T00:00:00Z","2019-12-29T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"4ms"}},"status":"ok","cached":"13866h3m41.550938181s"}
+
+
+        event: debug
+
+        data: "Fetching 2019-Q3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:04+01:00","st":433872,"ps":{"co":"1|0DaB2AaAB2Aa3Aa3BAaBaABAbBbB5A2Bb2ABaA2BaABaBAB2Aa2B2AbAa2ABaC2DcB2AaAc2AaAb3AbB5AaCaADb2a","no2":"1|0SFGHIxGMDFmrEaFL!26!-40CoIh!33MojdedbBFCICfBDFifBGFaeBhbHOcCENBAJ!-29cBdgMAk2GmCRfcbDMmgEFKAcecnASafjNbeT2hj","o3":"1|0ZEeIHtFIBDjaAcGIFtfIac!30!-30Vxb2JhgEKBHmabCa2BeHkGgFCBGBdE!26cAC!-30cEabBbcDeEBcbdaLdEiHCbDdDcbahBGCcJfCdcK","pm10":"1|0PBDBCfBFba2cCaDGCmdJeGKFBkiBCcbEHaAcCGh2CfbacBFaAGc2BFPFiCsdEbfIbcAFfDCKjACFdHlFBGIkgHhbCebFCeLCge","pm25":"1!40SnENka2ABgCHfeKGunGdMOSdjqnSU!-29ELHFfcAbDAcelD2ABCBQcFJ!37Psb!-43hHDnIcbCGfCJGnCBPhHvc2GagigIGcfBHFdNDkc","so2":"1|0B2AaBAFdGcdAaA2B2aBaABaB2AC2BdAa3AB3Aa4ABaBaABaBaBa3AB6AGEBdDdeABb3AaA2BAaBbBCbAaCAaDb2a"},"dh":24,"time":{"span":["2019-10-06T00:00:00Z","2019-10-06T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"7ms"}},"status":"ok","cached":"13866h3m23.824921957s"}
+
+
+        event: debug
+
+        data: "Fetching 2019-Q2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:12+01:00","st":431688,"ps":{"co":"1|0IDAaAdACbC2baCAaCDAaBAaBaBAb2B2ca4AECBd2CbBAcC2a2CBda2BaCbAabCaBbBCAcbCD3aDaB2AaBCbc2ABA2aB2AaA","no2":"1|0!32LpiBFjOaCFCicIDGFcelUcabfkdNLfhdmEGSbfJlbHeciMEdBbVevbABDLfDOAEigAedEb2aKB2fRAdAcblTjdFeTvdFGHIxG","o3":"1|0!33gmKBFCcIeEcaCfm2NLFEexHaAd2bCFnAFDhGfdMBAdCDAhCGAFEDuBhGDAecSadhEA2cCDbAEAabIkfJEFMs2BCg!33!-29bEeIHtF","pm10":"1|0ZFnd2FZCiqA2aESMCdkbAQkgtEBgLIegcdIhG2AdbABANcbDaAgEacdCbaFAbCABFgBDaCkEDaCadECAbdaPFdoEHGmeBDBCfB","pm25":"1!36!31myIS!74E!-32!-45iPefQKJvDfL!44!-28!-41uEaEZYyzKgPdRCafDodB!31jdOL!-40hIEDsCabKDjEcDEBhBbdUtEcFAeDObgBfY2AtBGVxbSnENka","so2":"1|0.2C2aAa2AaA2B5AaAaBHAe2a2AaABaBaBAaCB2a6ABaAa2BbABa2BAaBbBaDABbA2a2B2aAB2ABaAaCb2AB5AaBAF"},"dh":24,"time":{"span":["2019-07-07T00:00:00Z","2019-07-07T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"16ms"}},"status":"ok","cached":"13866h3m16.048560668s"}
+
+
+        event: debug
+
+        data: "Fetching 2019-Q1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:19+01:00","st":429528,"ps":{"co":"1|0H2ACBA2aDAdBbBDbBDcCDeBFebaEBaDeaEcAaCaAaCBbCBc2AB2aBACB2Ade2A2a2EA$aBa2AbADaBa4ABCaAcCa","no2":"1|0V2FAbBGiDaBAhDSdhPpEGgCQkfoLQhKqlMGaDhFgBIClZCkhFBbCAcBPGc!-30c2eLahNbsOAEbCGfBGEAfEibaNcSgcq","o3":"1|0XaAhFfLadjbOJfaDfbChGEemGRac2fGD2bDfaJEC2dcgAHFGhGAbfhdcACRgHImKcDcECcCAFgKd2gFfF2GbcabIBA","pm10":"1|0PHENhbdabMihACbfELAHKyGNhncLHeEkEDgDCceDgNEaTEjdjCbHKAEGFAzBlgDCAiFDgGdGcbCdJGfDaB2aKeIKIv","pm25":"1!49Kd!37khmjd!27mktLceEOM!36N!-70U!34j!-35jDFIbG!27!-30CHI!-30BblNfO!34!34wp!-28BIbMV!30FLC!-51h!-28hiDJuDCDbCJieDBIMeECBFtZiQI!31!-80","so2":"1|0.3ABA2BbC3AaAC2aBa2BaBEDCBheACa2ABAaEdAaACa2Bba2BaACabA2Caba4AFadaB2ABa3ABABA2aABaBABA"},"dh":24,"time":{"span":["2019-03-31T00:00:00Z","2019-03-31T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"6ms"}},"status":"ok","cached":"13866h3m9.662161167s"}
+
+
+        event: debug
+
+        data: "Fetching 2018-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:34+01:00","st":427320,"ps":{"co":"1|0F2ADAcAEAabA2aADAa2EebAaCABaABDdEcaCb3AbCABa2ABa2AEB2ba2BcACabAFca2AaCDbDBcaAbBAaBbDEeGbdA","no2":"1|0!37JHIO!-39F!28Dji2bqbQciJPxeFdDbiBDB!26iIanBEAFcFhMCfdnBc2CJdCjcDHEaNhkCOhCAdpMNmAImOFlOcjBhDCeLgeb","o3":"1|0VbdB2EcbIlHE2ad2abCcDCgACEaDdbajIMfqSEaCcDcAclaBPbdhfAKaEfQCgC2BnK2E2AofKkDNaAGdCABdgdAiFMc","pm10":"1|0SA2FJod2EWveCjGOgdIPscDdDicaDEKcIgBYpqFabd2FAKlHigFLTdnfdDgCEfdFIfEjEfFQiFMrdHg2AFdgOCgYjpe","pm25":"1!50aKOT!-28mJH!52!-53lEjIWclM!34!-35sHAC2laAMUFDhC!46!-31!-35aGBhECIUoQusO!26!45n!-29.2nOqd2ElPEhajAdK!26iCNmvHebABDg!27Jp!51r!-39A","so2":"1|0Ba7AB2Aa2AEAdCEcB2aBAa2A2B2AbAC2Aa3ABAa3Aa2ABCAda2BHCgaAaDbB3aBCcCB2ADeCA3aACbDAcA"},"dh":24,"time":{"span":["2018-12-30T00:00:00Z","2018-12-30T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13866h2m54.156040873s"}
+
+
+        event: debug
+
+        data: "Fetching 2018-Q3"
+
+
+        event: data
+
+        data: {"msg":{"st":425112,"ps":{"co":"1|0DCAaAa3AaA3BaB2ABabB6Ab3BabA2B2AaBA2a2BABabBABa4ABa2ABA2aA2BAaBaACBbaBAaACabDFeEfE2a2ADBdB","no2":"1|0!34IB2InAlGqDLOHfIiHGaofUafQj!-27bCKFBctI!31asiB2beFHaCfhIEAjGhHfMjAGNhCoCFADaG2gLHbfLfdIGf!-27N!26bM!-38!27rcJ2HO!-39G","o3":"1|0!64qfaOgCgco2FCLCetJEAVyF2DKhu2eMGcPjCQiqlBI2bD2dFeAEHoJbD2cGdECRCDqEfbaHcfAbBF2GhfBahGBDAEfaCbaebGEc","pm10":"1|0!26da2HcEjBhJaCBeDg2CBDeABEQmgiC2DB2bcJCj3AcDADB2acBF2caABcHCaBDAGecChFeCbECeCc2BGbc2dJKdFoQncA2FJod","pm25":"1!64kaPVhQ!-32blTfDBgDnCIAQpbEL!31!-28ydDFDCahDQLzLmabFAFBe2AaCJfiBDfKMDkF2GpfGkFdCDCIgceFbGcfBJlTAJ!-30UlgaKOT!-28m","so2":"1|0FAb6AB5AB3AB2AaAbBAbAB3Aa2A2Ba2AaBaA2BA2aBAa2BaBaBb2AC3aAC3ABAbDA2aBAba4ABa6AaABaA"},"dh":24,"time":{"span":["2018-07-01T00:00:00Z","2018-10-07T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"20328h12m47.506042346s"}
+
+
+        event: debug
+
+        data: "Fetching 2018-Q2"
+
+
+        event: data
+
+        data: {"msg":{"st":422928,"ps":{"co":"1|0GbABEBabA2aBDAbC2aCc2ACa2BbcACFcDbadCB2ABb2AaA2B2AabA2Ba2AaBABb2Aa2AB3AaCAB2AaAaBABaBba4A","no2":"1|0!32NIbeIElCAncWBgLbNM!-31HgHeDIe!-27lP!37qIbdjMNjsKaneEeIKCGAtAQHoPxfRCNqamHBGgcfPnWmJfaCBh2a2ASbefc2a","o3":"1|0!27aGAbCbgeFiFBOaDABQngLmcEDjDFCaAbA2KMguBahIBJkabIAaDAjAWja2fDcEFhBCeIdAbfJcBdbAkbREBKU!-30eKcEX","pm10":"1|0RAEAeJLhaJMfdKlhbIRjIknabEbfeIDfKDGFEBrfGabdA3CIaLjcTgNbE!-29EKilACeOfbCf2AH2beaCcCJfCaGbAb2aC","pm25":"1!58Ab2fTVfOF!34sw!28v!-38B!31TqW!-27!-37HgEFbiHBgRGTPRl!-47hELAtJbdFLJ!28!-27gUHW!-30V!-30E!30w!-32cMnGDbCakFEDFneFeBdDKBHgALkfI","so2":"1|0D3AaOm2Ab2AEbaCbCA2aAC2ABac2ADaCba2ACBcBAa2Aa2AB4A2Bb4AaDbAa3ABaB2AB5ABAbBaBAB4AB"},"dh":24,"time":{"span":["2018-04-01T00:00:00Z","2018-07-01T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"20328h12m40.589663177s"}
+
+
+        event: debug
+
+        data: "Fetching 2018-Q1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:40+01:00","st":420768,"ps":{"co":"1|0DBa2Bab2CBcAa2B2AaCbBADcAbAaBCabBAaABADaDbEb2ADa3bDA2BAbDAaAabaDAaAbBaC2aC2ACbDfBaAEb2BbaA","no2":"1|0!39FlNJphBOIrJjIJGdjWmdcMEFsJoDXiyBWuPca!31!-39Z!-30!30iKaLjfpmNKchdFKAp2BMGTmgDfehLaHF!-32AFJ!39xBrfOCHBmjd","o3":"1|0!27aEeadAdmMjRfdK2DClBcGEadjKGBgHgadGabdL2d3BAEhDEhGfDb3DcabaiOCceFjFaBaKABeAJaeEDoJCBeDfCF","pm10":"1|0SIDgDCjLKeB2bFpbFaMm2CdbLIkiCQoDFehHPIjmClOhEGIBfbi!28ncIqJFiPGQ!-33eBCgJbEkEeAJeHEcCc2FDjlaEi2A","pm25":"1!48JEgCV!-31!27ZySgCH!-38iEbGCMlfaKYqsDSqd2KsIXeiqCnQaKcEOgLy!65!-31iN!-37gGU2X!38!-75zFGxVaGbehDEAJlhQic!37I!-35iAda2D","so2":"1|0EBACaeaEBCdBbBDB2aEfBAFcadBaBEabaDdaCBFeCbEc2BCcaBcaB2A2a2BAB2ABD2a2Aa2Aa2BcaAaDaBAaA2BAaBb"},"dh":24,"time":{"span":["2018-04-01T00:00:00Z","2018-04-01T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13866h2m48.303118589s"}
+
+
+        event: debug
+
+        data: "Fetching 2017-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:45+01:00","st":418560,"ps":{"co":"1|0CABaAC2AC2aC2aBABa2A2aDaBAbCdED3AeADbaDba2AEAbBcACAaBABaA2aAaFcBCA2aCAbFabeACAEb3a4ABbAa","no2":"1|0!35MjOtHBfRfAIjcDAJlCRvARfIgkGqTYaqN!-29eVdlPiAoHWfbFiaFBeLjdbEhAfATmIMKyBMne!30fH!-32CFaShAghejNhVAf!-32","o3":"1|0VD2aB2bBhHBcAaNAeqTaBAiHArKDFkabhJCGiOcqTkMhgbGAcCEGEAqHCDjEIBpAcNDBfeEabOcjgLbmaKaJGCbBqQ2C","pm10":"1|0.2NfDhEcCHdBQkBHFbGgmahJbFD2chNGDOCseKpaLiDkHJBdFfdAFDfEbfdDdDaPcaecaeOdmTmIiDCIOk2difEdbPdIt","pm25":"1!48MbaiGBCOlhRAHMAr!34l!-36BgMFGRninTEJ!26N!-35fM!-34APrIlOcRjOmkACDl!34jzcIeaB!30obhaBg!28wb!33!-28DdALI!31ujiojHlCQaG!-36","so2":"1|0DBbDd2BaDaAB2aA2Ba2AbAC2ABbBaBCADBRsD2bCcdaBE3aBaDBcDbAaBba2ADcCDabaDcbJaE3ACF2gdAD2IaoaAd"},"dh":24,"time":{"span":["2017-12-31T00:00:00Z","2017-12-31T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"8ms"}},"status":"ok","cached":"13866h2m43.573321592s"}
+
+
+        event: debug
+
+        data: "Fetching 2017-Q3"
+
+
+        event: data
+
+        data: {"msg":{"st":416352,"ps":{"co":"1|0CA2BbCa2BbBbCBAb3BbBaA2aC2Bc2AaA2BaCA2a3AaB7ABAaB2ABaAa3ABa%Ba6ABAa6AB2Aa3A","no2":"1|0!33h!28KjOtp!28lKz!30!-34Jl2NceAafhFMedEjHDdbKqIEkCESwDZmHfClEAEbGKnhSgpQiId2C%!-31GNJFbjEjbKGNBAmcGbJGdeo","o3":"1|0!27EeAFZvAJnhEKi2fVHijFcbAGh3BEaCdC2BDg!47C!-45bAJaeJifFBkbSJOreOzdHDCBja%b2D2BJHbsFcfAGcDIsaPceFa","pm10":"1|0WdDAFJldFcabHdAfJKbhcdBcGECAebNjfNecbBdbKDnDHcBaBeBCPJwOgaSmX!-28dAeAa%lEIBaAcBAbICFeAdKOAGxDhg","pm25":"1!63lFEGSqiFfadIEejFOGoAiEbMbdeadG2aBFadEKh2EpEGabAbgCD!36C!-35U2B!38!-34lhKgnFe%!-28BVHcABGFiRIjeAd!29!32a!27!-81Iqh","so2":"1|0CaDBb2AaBABbDcC2aBABaABbACAaBa2BAaAbABA2aDbaCaBABbABAaCAbaBCbCb2ACA%bA2B2AbB2aABDaCcaBA2BA2a"},"dh":24,"time":{"span":["2017-07-01T00:00:00Z","2017-10-01T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"20225h2m58.997251081s"}
+
+
+        event: debug
+
+        data: "Fetching 2017-Q2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:53+01:00","st":414168,"ps":{"co":"1|0EbCbA2BDab2BaBbCaBb3a2BaAC4AaAa5A2BA2a2BABABaBAaBAa2ABbB2aAB3ABa3AaBaCABaBAbA2aBaAa2A","no2":"1|0!50rYsAIe!27.2rHCeDiAaGVbpd2DkDNdKrcHaCagdDHSCdcmN2cb2EcPmANehiBIhOatDIaDFbldLBDCpDKTcAkfkgJIlZyBi","o3":"1|0!37cCiFcDKBjBaAdKebDdBK!26ynbcEdLBfaDABdHeabeMCehaiKGCFEt!70!-37nafBgfOcBcacBbCBDdAPkbJZD!-28!45!-39reAIhabHCE","pm10":"1|0YaLgBHBLavBCafcABFCHEnDEiAIAbBkRCEjEcB2AQnbjD2CAfabKfDJebeBdFAFgeDb!70!-67FecCDFCfCBLGbgnbeIFgaACd","pm25":"1!60F!28wHKBWh!-40eIBodHebMSEubPrDEIfDvZHBu!32kpaG!45!-28luGDSfkhbVmMCcDkBeBEWzkFbCJBdfC2GEhLDPNioydhIPBjDCl","so2":"1|0DbCbaCaC2a2BbCbAaABDabBCbaCaCbAaAaB2AaADBA2a2BAa2AaABaBA2aBCaC2a2ABaBA2aC2aCb4AB2AaAaBACbaA"},"dh":24,"time":{"span":["2017-07-02T00:00:00Z","2017-07-02T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"20ms"}},"status":"ok","cached":"13866h2m35.147090746s"}
+
+
+        event: debug
+
+        data: "Fetching 2017-Q1"
+
+
+        event: data
+
+        data: {"msg":{"st":412032,"ps":{"co":"1|0.2CbFAcBaAaBbB2ABDbaBICcbeA2aA2BbBCbDbcA3BaAa2BaBaBcA2BACac8ACAaA3Ba2A2BAda2ACBa3Aa","no2":"1|0!32RdMP!-34.2HbhJpBDNHNkcdJLcgqAbdAaEeLOuLBkI2iBALEHcefcHDpKcgRbGgAcfbKEeKflEBJbcjeOEBjdCfIJAJBjq","o3":"1|0XjGhCAbIfOcB2fbBfAEac2ABFfTaheHIFlbDEnHeFd2bKCaHcfFHCbBCDcABeJ2bcHglBcMgcBIbDaCAdALehKBGcAd","pm10":"1|0!27BFMBtDeKW!-32.3AGPQakBXKqsMDwpICiCFCeOgGAJgGKio2BAge2cCEDmCIEDAfiJBAcEJCjaIBkecFDb2Iqd!27EwBaca","pm25":"1!72hJZDoDrLhfCbdQT!26H!-35H!60Nv!-36YA!-74s!29SxneOKZxMN!29jKL!-36zmLMokiCkNBoGCFALknLEQiBVM!-37HJL!-36ceF2B!31K!-37f!65D!-56aBeF","so2":"1|0CEcBDc2BAaCBd2ABCbaBDFb2c2AaBABaABbCabaB3ABACAbAB2AbaBaDB3aBa2ACbBA2aC2BbAaCAb2a2ABCaABAb"},"dh":24,"time":{"span":["2017-01-02T00:00:00Z","2017-04-02T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"20225h2m56.597473525s"}
+
+
+        event: debug
+
+        data: "Fetching 2016-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:58+01:00","st":409800,"ps":{"co":"1|0DaDb2aBa2AC2BABaD2ba4ABC2aCB2AcCabaA3B2AaBAcAD2aAE2acEaBDIfedAECdaAaCABAaACb2A2BcAaBICdbcb","no2":"1|0!47oUlbHAncIGfAFJjTqfaGgbL2IbjIg2CLPm!-28lMNhJB2gVmKCImpIFgbEhaMPXlsgbFIafAjGBCEhCFBajIPpew!49Ua2uh!-28","o3":"1|0SFebDGjKBcfBgAPCaAg2cEahcNFbodaPb2cMcCm2Ed2DdBGFBiHCagIagECsbACMfjDGCbQoHgce2aBAIKkQEabwbDADU","pm10":"1|0XbIAafEdeG2ADHbjHgBDabCJLchCLJDkmKhCmcLlJGiDJ2fD2biIA!30!-32AGfDR!40whwC!27BmfA2fECJBJgjLgeDoJpE!27Nhfnp","pm25":"1!63AIambRenKCaHMftIkMaJhEQXnoGU!34B!-33sNrCloVvHShgRmjAcbFX!-32RvEYij!40!54lo!-66J!63R!-43hcklFMLEXgrMj!-30EtCsI!53!41og!-36!-35","so2":"1|0GdEDbdB2A4BDBeDcaBA2B2A2a2BGcfdF2aBaCbBb2aFa2ABa2BbBcAC2aCHbAaB2Ededa2ABab2BbA3BcaABCB2Aba"},"dh":24,"time":{"span":["2017-01-01T00:00:00Z","2017-01-01T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13866h2m30.18740628s"}
+
+
+        event: debug
+
+        data: "Fetching 2016-Q3"
+
+
+        event: data
+
+        data: {"msg":{"st":407592,"ps":{"co":"1|0F3AacFDaABadbDaBC2BcBAaDC2baBaDBabAaBbaDBbcbB3ABa3A2BaADcCaADaACA2acaABAaCaD2AaDAbdC4ABab","no2":"1|0!54oBGtJ!29wdfJblFQrdXNbyLFpaHaKBtcUeCdAbfc2ADRkhNBJeGscNUCpfdfd!35.2idemQaPA2h2FRCi!-31g2GEZdGkmMeAbKio","o3":"1|0XaFeGDb2fHdcCGfbDWbItgVobcdFfIBiaFBHFhcBaeLeDbGFBgcAaONojGgDJpDkHAjc!28iceJeUbFuhNkcTmFIfkaBDAcE","pm10":"1|0!26gBCcCGcbd2EeaDfaIGHoNghBDA2CehIBC2bDdAEcAEga2DI2BhjMBJClDfbH3acdIEBAgbADRdBdrCNfHaefBNjIiFhb","pm25":"1!59BeIqHRBAgFEfBeiB2KMpXsuBHFebJsIDcADElJCeCFkaCEOaN!-28jQFWKqgjFacdDejNPeCobcF!31BGsuKWiCgobgHBHjGbA","so2":"1|0Fa2AaAD2aC3AaBaA3Bac3ABaACcACAa3AaAa3BabC3AB2a3BbBaAaCBAaABaAbCAa3AaAaAB2A4B3ABCB2d"},"dh":24,"time":{"span":["2016-07-01T00:00:00Z","2016-10-02T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"3ms"}},"status":"ok","cached":"19313h3m47.669051891s"}
+
+
+        event: debug
+
+        data: "Fetching 2016-Q2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:10+01:00","st":405408,"ps":{"co":"1|0HbaAb3BbADb2A2aBDcAa3ABaACBbEcbCAB2aBCDe2aBABAaBA2aABCab6Aa3BAcCABAEda2ADCBbCdc2AGbcB2A","no2":"1|0!68miOkMjCegHNaEcvcWmABahdKh2JdnJmL!28FdqbHjAEqbKDOajFljaEDUghtdFCJFdeU!26oiVrnAHECodCAQFcAsgdZcKepB","o3":"1|0!29GgCBbi2FEsQeHhAGdFeC2AFhDCacFEfDFEgKHnra!33mcEcaAhAaEbaFbEF3d2CbcHjdPpUA2kBFEAfIjCdhQaACAgGbaF","pm10":"1|0!34bAcbabFibYoCDehAKfHDeiBFf2FDkDACHGFBpJbGAhlHFdcAadbcAJ2EbjceEaILcaQjdDdfFfBcBE2fG2DchbaMdBCgB","pm25":"1!83fJpehCLua!55!-40KACocKkEJdhDLpHKHpfDHBJTO!-38LJVourUAcfBfeajbT2GJqhjBcZUrhYcieGqBcBcKajkLJGmjAhTdGfBe","so2":"1|0FbAC4AaA2BaABabCbABaBACAaBab2A2Ba2BABa2Bba2ABCaABAcbABAaB5ABaAB2A2BABCAaAbaCabBAbaA2CbA2a"},"dh":24,"time":{"span":["2016-07-03T00:00:00Z","2016-07-03T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"7ms"}},"status":"ok","cached":"13866h2m18.447937917s"}
+
+
+        event: debug
+
+        data: "Fetching 2016-Q1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:17+01:00","st":403296,"ps":{"co":"1|0F2BbCcBCAacBDaB2Ffb2c2Aa2B2Ca2BAbcCBCBCgaABEabCdbACE2AaABAaca5A2BAbABAB2aABABCcb2A2BADba","no2":"1|0!44HBkRrbMgJkD2FbZM!-28lAnI2bMkaAaGdCGrDGMk!28rigWOasUtkAGTCdzcQDceNreHUpaLgmCDcLdgcJIBTwgba!27iDJmi","o3":"1|0TAqVhOaeabAciJbnAL2CbIEBACAdEbiB2GCagehCAN2cBbHDAcgjHAGHfEBababCbBlCFHBLgDdGdede2HC2abcACGg","pm10":"1|0ZFIrNjeEAJmCSoL!27LqmdrKBnSlEgIGiAEfeNbg!26rBfFMehGmeBKUbAlqMbdAHbBDGqWRGumAcMphBNDKAvCbdHDcJbA","pm25":"1!54H!30!-40UojNdGnF!30xN!67V!-50!-27eqDboMhBAIFeEAerQCB!35zPwKHcbCzfMJ!40Bcl!-38LeiHDUlaMi!41!45I!-45!-30dg!28!-32tA!37BTh!-38dtFHFLQfJ","so2":"1|0LABaceBCaA2bCbCFDeA2aBa2BbB6A2BABaCbBadDaBAaABaC2A3a2C2AfaAEbaBAbaB2ABA2BA2Ba2BCbAbAbA"},"dh":24,"time":{"span":["2016-04-03T00:00:00Z","2016-04-03T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13866h2m11.188226447s"}
+
+
+        event: debug
+
+        data: "Fetching 2015-Q4"
+
+
+        event: data
+
+        data: {"msg":{"st":401016,"ps":{"co":"1|0E2B2A2aACcABA2B2aBACEcB2aAC2AaAFdcaCAa2ABa3AaCaAabACDacG4AaAba2AaAB2Aa2AB3Aa2AaAaAaDaBb$BaA","no2":"1|0!42VlEiGkIMsdQbCbAnhTLci!27eljfMBgiEcBMBkhCFCJACkpVhCOjqLVfoLcehNJceBjdEKDdBhgIbKcKsELmK2khQbRp$BjJ","o3":"1|0YfdToagHgHFbBAdFBdBefQjIiadGDcibaFCICAaHbBbFe2C2AbfHmCHefMFBcCEgBGAiAaHiIiciSiEaIa2B2aCAlKB$jCG","pm10":"1|0!28IOfncBGKrMake2HghGIDcFlAJModBUKkcfkcAbFaBHcicGAGabkHOlbKhbcAEGCecbIdEcaAeJEdPl2ebgLfdF!33smd$HlC","pm25":"1!66U!43s!-28efJW!-34!28dyoULodHKHpJfgMPthB!43!41!-36lksefAeGdKkagHcFJncP!37!-43GLgqcCJIFjhaQdACfcBQMtZpdrcQjflS!38wpi$Opf","so2":"1|0C3BAB2ABd3AaBAaA2BEbBba3BaAaCa2B2aAaB3ABbaCAaCbBaCAa2Aa2ABaABaABABaBa2AaB2AaB2AaBa2ABAB$aDB"},"dh":24,"time":{"span":["2015-10-01T00:00:00Z","2016-01-03T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"19313h3m44.529349069s"}
+
+
+        event: debug
+
+        data: "Fetching 2015-Q3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:23+01:00","st":398808,"ps":{"co":"1|0Iaca2AB2aCaC2AFfCaAB2A2aAD2AcbFbABb2BcBAa5ABaCBA2aBbBaBAaAaCAa3AaBA2BAaCAcD2aCBcaCaAa4A3B","no2":"1|0!86pycgOEnDXufHeBMJfibMBeF!-31XCdnGXpCeiNMflHkFfiPpDMICjCdDhJeGDgnDKBaBbhHAcNDhgEGfIZvaKfBClafIb2aVmF","o3":"1|0!69!-32ca2cBDFHmifaEPcFarG2DcCcaEcALgStCabDNenjKdGDdJiDjGQfpBCAECc2bCBcCHha2DIcgDBABjLEjfABEBCea2DgdU","pm10":"1|0!44.2kLiaCaJebgBaDLBhcIe2aFjEAdCKdGkEaCdDBeaBbLFkACFic2BCfEaDAdHkHACcaAcbFKInABDeFDiHdeGAHdj2EDcIOf","pm25":"1!104!-27x!28sbgGeJaeHfDKadiRjbfOpJghBAVdiJdIabda2cg!27T!-30bCMhfCBFkDBDdaKrQcCAiBiaGPQugEAhPbdVewEFGBoACEBU!43s","so2":"1|0FBbBAB2Aa2BaBbAaBAaB3AaA2B2aABAaBbaE2aB2Aa2B3ABaBaABCbAbAabACA2a2AaAC2BaACBbBAc2CbBAb2aBaAaCAB"},"dh":24,"time":{"span":["2015-10-04T00:00:00Z","2015-10-04T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"6ms"}},"status":"ok","cached":"13866h2m5.815213405s"}
+
+
+        event: debug
+
+        data: "Fetching 2015-Q2"
+
+
+        event: data
+
+        data: {"msg":{"st":396624,"ps":{"co":"1|0EBAaB2A$aAb$A2BabAOCdedC2bBABa4AaBCbBaCBa2A3BabAabBAaB3AaB2A2BcAB2AC2BbaC3aD2AaDA2aCaABacaA","no2":"1|0!35HgdbHE$YD!-30.2EICqBgCOBbMQxrEJQjifcAFLTCyHIfCberKLcn!27roFhJNoNfjJbA!27c!-28cJhMNKqoFWkrBNqLc!39fG!-29BMQJpybh","o3":"1|0!29cfBGAc$aJDBgHAlGFaBbcADbdhHCAabIEcabdLagF2eGIdbeBJqEDGcEAfBACBfHhHEjEFJanaBHpLajHfGHADfhLKY!-28kEd","pm10":"1|0UDaBbFd$!37B!-34bEDGjeBAMagDUxfIBUzDAfAIcBJjFcaFgEdBcbLABfdDcEdCbaHdEJEtBGCdFRmegJbJcgiECAKfcbBIK2kLi","pm25":"1!46JFGeJu$!100e!-79i2JPxm2BRbAH!49!-48pFeJgeHabKfDI!-27LDiEHdDhAgKNdibEeNsIAhJbCLS!-39EHkFO!29jsuScDEBr2BNGdkCDE!36!-27x!28s","so2":"1|0E2A2a2B$aCaA2BAbAa4A2C2aBAB2a2BAB2aAbABAbBa2ACBcEacBbA2BC2aB3AB2bBaACACbaCBcACaBbDB2aABAaBaAB"},"dh":24,"time":{"span":["2015-04-01T00:00:00Z","2015-07-05T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"19313h3m42.662876137s"}
+
+
+        event: debug
+
+        data: "Fetching 2015-Q1"
+
+
+        event: data
+
+        data: {"msg":{"st":394464,"ps":{"co":"1|0DBAD4ABbCACbBA$AcC2AEeEfDBcAabC2Aa2A2BCA2abCBdD2AaCBABcaba2CbC4AaCc2aADA2aCbADaCcBaABaABAaB","no2":"1|0TIKaGfDBanOAIdCjkCPKhDHwOh2DAbdhLKbjnTfFIkLbkCGmH2EmdPiGRlojQFaHegACLhCioBNbBFLqgQFElJoaEmOHgdb","o3":"1|0YEgmGKAEDadIeAFmiBcAEhCSkImP2bAGnFcDAaGhBEpTCkaHFDeDEa2fcDLEcabgK2ahaCaDEeibOIDfAlGgLBcHcD2cfBG","pm10":"1|0!28kaRdjDcBiIbBACFlDKRkKM!-31No2dcHcDKbImCAQaHaMnvXfoGa2deJbGFbkaBCFEeM2fJKb2hKHUfgaxFdFJtFdeEfHDaBb","pm25":"1!75!-33H!39puCcCtOaCcIBfIUZr!32S!-82TtatEMbeQIDpfVFSbN!29!-28!-46!47j!-37LbkaeHdHcKpbaDFOiVlab!38donPX!52m!-37E!-55k!27lX!-33FArFkQJFGe","so2":"1|0DAaCBa2ABc2BCaBbaABDbaFgDb2BCAabBaAbAa2BDaBa2ABdCB3AC2abDbaCBcDb3AaBAacBDabACaAC2A2Bb2AaB2A2a"},"dh":24,"time":{"span":["2015-01-01T00:00:00Z","2015-04-05T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"19313h3m41.506304559s"}
+
+
+        event: debug
+
+        data: "Fetching 2014-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:30+01:00","st":392256,"ps":{"co":"1|0FABcBACac2BaBAaDbaACdB|35GEbCbcAaAbAbABa2ADbACbaD2BaAaACbA","no2":"1|0!36ALtGCKfiDGmADCVkhaLrH|35.2Ek2AaPcfDLkBLDcbEnWeicEcDaBndKjB","o3":"1|0RgLbAcGcDhJADtBHE2CdDe|35lAcAICJ2bkaTiHJbEzTcqOFCdFAFbibGd","pm10":"1|0!34bElcBEaAcabcBNBAgaElKDB2eFIj!26gjgcDJLwDFfecHFDefEVCAfvVk2DCIeifABFCnBIAdcPjDGldaAbDbeFCeO","pm25":"1!69DLveCFAfdECoCXbe2fMuP2GhkLPm!51xylEFT!26!-50GSokCcNKbmI!46Ddt!-36!28kJFcTfrsiPIE!-31bNcdaZqEPwheDcFfhKLlL","so2":"1|0DABcBACAbABaBAaDabACbA|35DCbA2bAaCBAaADAaBAaDA2ab2ABAba2Bb"},"dh":24,"time":{"span":["2014-12-28T00:00:00Z","2014-12-28T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"3ms"}},"status":"ok","cached":"13866h1m58.382296995s"}
+
+
+        event: debug
+
+        data: "Fetching 2014-Q3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:34+01:00","st":390048,"ps":{"co":"1|0D2BAa2A2aAB4ABa4Aa2ABAa2AHeC2aB2AaBA$BabCcAEd2ACbA2Bb3A$DCc3ABa3BaAa2ABACBbaA$3AbBC2aABcB","no2":"1|0!48ELi!-46!31cEjFGfiKAMdNmtAiIkOfBdbGTFmAGDcAFk$KBpLdaZ!-27dCSneLfeImjcKXlHaN2gIHhcDmgSajIEiaDjDUbhbNCoALtG","o3":"1|0!29aIboFfbMgdVoFaCbScjfdMBhQlfMcfCbDcABadA$cHiBaKahDaB3CjMjCeADpMJiJdDAfdbIGCjDHAo2GibF2beHaJigLbA","pm10":"1|0QGAanLdCDbAFgACHcJgA2cD2ADfeAFGBedEBabId$bBfCA2bAbEFfaENlGhCgDKcLCNFmgAfMhfaEWACcfwRHmEdcHOfgbElc","pm25":"1!49LEb!-31YiMAfGIpdGLj!29nBeiEaEGmkbMNFklIHdbSl$fbnKbceAgGTtbP!32!-35LnBmK!26lZC!28W!-34wAm!27uiAD!54GElu!-44!39!27!-37oab2YtwDLve","so2":"1|0EB2AbB2Ab2A2BaBABaA2a2A2BABACBab2aC2AaBA$BABD2CjCdBCba2Bb2aABACb3A2BAbBbB$a2Ba2BbCRfj2AbACa2ABcB"},"dh":24,"time":{"span":["2014-10-05T00:00:00Z","2014-10-05T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13866h1m54.509240411s"}
+
+
+        event: debug
+
+        data: "Fetching 2014-Q2"
+
+
+        event: data
+
+        data: {"msg":{"st":387864,"ps":{"co":"1|0EB2Aba2ABABDcaCE2aACABaBaAaABA2cACABaBbaAB2aBA$BABbB2bA$DBAa2A2B2aB2ABAb3Aa3ACaABAaA2BabCaC2AaA","no2":"1|0!50bqHijKEKcLkoMaUeufAOKEahaeEHPflgNCDadeiCEDAbaqSKDkaBekJBjIgKhPeE!-31!32hBFbfEalhKcGaFcDIhAGEolXEFLj!-46!32","o3":"1|0RdbP2bBJgACAE2cIdDAdcCAeaLg2ALk2F2GmfACcCbgIAaEShckFAfDnGAcGLfahDaMCAbdbFDhbdHlfOIecD2AdhIDCaIaqG","pm10":"1|0!45SbwqfCALeDFkBaLFqA!30ghfcLmdPIbh2g2GecACeAaBcKB2ALjgcCacABWqAcFb2aiJDhFdCEC2gDFfJeBDaDjGHieHbGAanL","pm25":"1!105!39k!-34!-42hafWiGKsDgQO!-34F!68j!-29hdV!-30g!33Vcr2qPLmfBCfgDIcQHeBZuoeAahbCAThbMcChzWPnLgfGBhvHFfYpGEVk!-30MTvmRALEb!-31Y","so2":"1|0GabFdABaCabB2aACBdA2BDaAa2AaBCAe2BAD2A3aCabBAbC2BaBaA2aACAbABC2BdCAa2BbaBAbCAa4AB2aBCAbBAC2AbA"},"dh":24,"time":{"span":["2014-04-01T00:00:00Z","2014-07-06T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"3ms"}},"status":"ok","cached":"19313h3m39.719999369s"}
+
+
+        event: debug
+
+        data: "Fetching 2014-Q1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:45+01:00","st":385704,"ps":{"co":"1|0EB3AaC2ACBAbA3abBEBd2Aa2BaEHhcBaCABAbA2BdABCabC2bCBaABEfaBaBCBAB$abaC2AcABADbEAaBc2aBABaB2ABca","no2":"1|0XG2a2ABDAOSy2AdcHfa!29gnbKsCMaAEem2CHcHgmCTAiKegIBCikRGnMIDdajhXJbmbzINqOLI!-32CKaHjNsaSCBAcgGFBbqHij","o3":"1|0!29cFdcEAfCimKMiICDnEpOABdNaAcemNEAeJEaACAmHCAFAka2ACEaFbDqIfALdkDNiGE2aqICKCnIaIbDbcbebdQ2bjeaOba","pm10":"1|0QEHicIHfcGNfkDcB2bDRGqeFgbEcbJfiGACDacaBC2aDcBEBDAlHadGbGdgOlbSJke$NjcSQG!-44dLfHagiaHDBIUbgkLSbwqf","pm25":"1!37JDadbAfOL!45p!-37Fh2DcG!40K!-44bDjgGeD!26p!-37MKEBHfhaJCeBcDKCJDyI2fSiIeg!27!-27a!34Nvg$Zqp!48!42J!-95hVoHalsAUHDS!51es!-31X!39k!-34!-42h","so2":"1|0GFh3AaCaDbABAbCAcCDBcaAaAD2bCBbAaCABAbACACab2A2BbaC2aCACaABA2BacAdBAbDAEdBC2AbCbaBaAB4ACacFcA"},"dh":24,"time":{"span":["2014-04-06T00:00:00Z","2014-04-06T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13866h1m43.653058925s"}
+
+
+        event: done
+
+        data: "12.775486ms"
+
+
+        '
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Type:
+      - text/event-stream; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:13:28 GMT
+      Server:
+      - nginx
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://search.waqi.info/nsearch/station/london
+  response:
+    body:
+      string: "{\"dt\":\"26.623166ms\",\"term\":\"london\",\"results\":[{\"s\":{\"a\":\"57\",\"t\":[\"2022-04-21
+        00:00:00\",\"+01:00\"],\"n\":[\"London\"],\"u\":\"london\"},\"n\":[\"London\"],\"score\":8,\"x\":5724,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"72\",\"t\":[\"2022-04-21
+        00:00:00\",\"+01:00\"],\"n\":[\"London Honor Oak Park\"],\"u\":\"united-kingdom/london-honor-oak-park\"},\"n\":[\"London
+        Honor Oak Park, United Kingdom\"],\"score\":7,\"x\":11653,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"53\",\"t\":[\"2022-04-21
+        00:00:00\",\"+01:00\"],\"n\":[\"London Marylebone Road\"],\"u\":\"united-kingdom/london-marylebone-road\"},\"n\":[\"London
+        Marylebone Road, United Kingdom\"],\"score\":7,\"x\":3193,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"48\",\"t\":[\"2022-04-21
+        00:00:00\",\"+01:00\"],\"n\":[\"London Teddington Bushy Park\"],\"u\":\"united-kingdom/london-teddington-bushy-park\"},\"n\":[\"London
+        Teddington Bushy Park, United Kingdom\"],\"score\":7,\"x\":3195,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"46\",\"t\":[\"2022-04-20
+        23:00:00\",\"+01:00\"],\"n\":[\"London Harlington\"],\"u\":\"united-kingdom/london-harlington\"},\"n\":[\"London
+        Harlington, United Kingdom\"],\"score\":7,\"x\":3191,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"46\",\"t\":[\"2022-04-20
+        23:00:00\",\"+01:00\"],\"n\":[\"London Bexley\"],\"u\":\"united-kingdom/london-bexley\"},\"n\":[\"London
+        Bexley, United Kingdom\"],\"score\":7,\"x\":3188,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"46\",\"t\":[\"2022-04-20
+        23:00:00\",\"+01:00\"],\"n\":[\"London Harrow Stanmore\"],\"u\":\"united-kingdom/london-harrow-stanmore\"},\"n\":[\"London
+        Harrow Stanmore, United Kingdom\"],\"score\":7,\"x\":3192,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"39\",\"t\":[\"2022-04-20
+        19:00:00\",\"-05:00\"],\"n\":[\"London, Ohio\"],\"u\":\"usa/ohio/london\"},\"n\":[\"London,
+        Ohio, USA\"],\"score\":7,\"x\":7930,\"c\":\"US\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"38\",\"t\":[\"2022-04-21
+        00:00:00\",\"+01:00\"],\"n\":[\"London Westminster\"],\"u\":\"united-kingdom/london-westminster\"},\"n\":[\"London
+        Westminster, United Kingdom\"],\"score\":7,\"x\":10874,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"34\",\"t\":[\"2022-04-20
+        20:00:00\",\"-05:00\"],\"n\":[\"London, Ontario\"],\"u\":\"canada/ontario/london\"},\"n\":[\"London,
+        Ontario, Canada\"],\"score\":7,\"x\":15,\"c\":\"CA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"33\",\"t\":[\"2022-04-20
+        19:00:00\",\"-05:00\"],\"n\":[\"Londonderry - Moose Hill, New Hampshire\"],\"u\":\"usa/new-hampshire/londonderry-moose-hill\"},\"n\":[\"Londonderry
+        - Moose Hill, New Hampshire, USA\"],\"score\":7,\"x\":7449,\"c\":\"US\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"32\",\"t\":[\"2022-04-20
+        22:00:00\",\"+01:00\"],\"n\":[\"London Bloomsbury\"],\"u\":\"united-kingdom/london-bloomsbury\"},\"n\":[\"London
+        Bloomsbury, United Kingdom\"],\"score\":7,\"x\":3189,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"1\",\"t\":[\"2022-04-21
+        00:00:00\",\"+01:00\"],\"n\":[\"London N. Kensington\"],\"u\":\"united-kingdom/london-n.-kensington\"},\"n\":[\"London
+        N. Kensington, United Kingdom\"],\"score\":7,\"x\":3194,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"-\",\"t\":[\"2021-12-13
+        15:00:00\",\"+01:00\"],\"n\":[\"London Eltham\"],\"u\":\"united-kingdom/london-eltham\"},\"n\":[\"London
+        Eltham, United Kingdom\"],\"score\":7,\"x\":3190,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"-\",\"t\":[\"2022-04-20
+        05:00:00\",\"+01:00\"],\"n\":[\"London Hillingdon Harmondsworth Os\"],\"u\":\"united-kingdom/london-hillingdon-harmondsworth-os\"},\"n\":[\"London
+        Hillingdon Harmondsworth Os, United Kingdom\"],\"score\":7,\"x\":3390,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"157\",\"t\":[\"2022-04-21
+        09:00:00\",\"+09:00\"],\"n\":[\"Palbong-dong, Iksan-si, Jeonbuk\",\"\uC775\uC0B0\uC2DC
+        \uD314\uBD09\uB3D9 \uC804\uBD81\"],\"u\":\"korea/jeonbuk/iksan-si\"},\"n\":[\"Palbong-dong,
+        Iksan-si, Jeonbuk, South Korea\"],\"score\":5,\"x\":1802,\"c\":\"KR\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"109\",\"t\":[\"2022-04-21
+        09:00:00\",\"+09:00\"],\"n\":[\"Wolpyeong-dong, Daejeon\",\"\uC6D4\uD3C9\uB3D9
+        \uB300\uC804\"],\"u\":\"korea/daejeon/wolpyeong-dong\"},\"n\":[\"Wolpyeong-dong,
+        Daejeon, South Korea\"],\"score\":5,\"x\":4527,\"c\":\"KR\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"57\",\"t\":[\"2022-04-21
+        00:00:00\",\"+01:00\"],\"n\":[\"City of London - Farringdon Street\"],\"u\":\"united-kingdom/city-of-london-farringdon-street\"},\"n\":[\"City
+        of London - Farringdon Street, United Kingdom\"],\"score\":5,\"x\":7949,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"26\",\"t\":[\"2022-04-20
+        20:00:00\",\"-05:00\"],\"n\":[\"Hamilton Downtown, Ontario\"],\"u\":\"canada/ontario/hamilton-downtown\"},\"n\":[\"Hamilton
+        Downtown, Ontario, Canada\"],\"score\":5,\"x\":10,\"c\":\"CA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"-\",\"t\":[\"2021-09-15
+        20:00:00\",\"+02:00\"],\"n\":[\"East London, Buffalo City Metro\"],\"u\":\"south-africa/buffalo-city-metro/east-london\"},\"n\":[\"East
+        London, Buffalo City Metro, South Africa\"],\"score\":5,\"x\":11407,\"c\":\"ZA\",\"z\":0,\"$\":\"realtime\"}]}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:14:46 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      X-Gen-Time:
+      - 26.800696ms
+      X-Powered-By:
+      - waqi-search/1.2
+      content-length:
+      - '4439'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/api/attsse/5724/yd.json
+  response:
+    body:
+      string: 'event: debug
+
+        data: "Fetching 2022-P4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2022-04-20T22:21:53+01:00","st":457992,"ps":{"co":"1|0B2CAabDaCbAba2BaCACa","no2":"1|0LEFEcDjDaHMghEFdbeAc","o3":"1|0!32BbcDAhEbFiFBAFaJfae","pm10":"1|0OFBdCdCBaCMCnALNenaJ","pm25":"1!32PGjhgANDCNCrHP!36g!-34iP","so2":"1|0.3ABa5AB3AaBaABa"},"dh":24,"time":{"span":["2022-04-20T00:00:00Z","2022-04-20T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"1ms"}},"status":"ok","cached":"3h52m54.033230075s"}
+
+
+        event: debug
+
+        data: "Fetching 2022-P3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2022-04-06T19:38:10+01:00","st":457248,"ps":{"co":"1|0.2BAaAa2BABa2AB2AIfdBCbBCb2a2ACEcaC","no2":"1|0XCInfaJc2FdeBJAgHak2DM2GjgiHhgeFCF","o3":"1|0ScEFBA2aEBbGbGkaBEaDcGFABCsbJ2ACBb","pm10":"1|0QPKrgCDOge2bcHBEb2DAT2FGcqtI2DueFC","pm25":"1!53!45C!-36bhb!31qadnDKbMqENK!28RPEA!-48!-34RKD!-48kRK","so2":"1|0.7AB2ABaABaB2a2ABA2B3A2aAa3A"},"dh":24,"time":{"span":["2022-04-03T00:00:00Z","2022-04-03T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"342h36m37.029531859s"}
+
+
+        event: debug
+
+        data: "Fetching 2022-P2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2022-03-06T19:26:40Z","st":456576,"ps":{"co":"1|0FaCFaBCdADAb2afbHabcC2ADaA2abCAbAB","no2":"1|0HENcBkOaAbGieHEiFfGgAKDcAFhHdJDpgb","o3":"1|0WDBDBaAaAkCFDbBGcCeE2aCBeDcagcFECB","pm10":"1|0TDFdFnKlFBEB2dHgPde2AEjiJAdIaPNvfB","pm25":"1!42FCiAjPqAOCDBgEfKcD2AEruTIiQH!44E!-38Il","so2":"1|0B2Aa2ABaBa2AB4AaBa3ABAaABa2Bb2A"},"dh":24,"time":{"span":["2022-03-06T00:00:00Z","2022-03-06T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"1ms"}},"status":"ok","cached":"1085h48m7.029091538s"}
+
+
+        event: debug
+
+        data: "Fetching 2022-P1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2022-02-06T19:39:29Z","st":455880,"ps":{"co":"1|0C2aFEcBAdFCBcabGeBdcBaA3BbDBAaCF2a","no2":"1|0.3ELEjFPrL2ElfGHkeHe2BbIdFrEbHDFfBk","o3":"1|0!28iaIc2adbibcGIe2CEiLCbhCEAHADeCBE2A","pm10":"1|0NdDFeDFLkPEIcmAMlkBfL2BcbBdFeAEFfGn","pm25":"1!33iGVsETOlWFZhzo!40!-38lcCw!47ImndmICbEDefj","so2":"1|0CbAB5ABABa2ABcB7ABbB2ABAb2A"},"dh":24,"time":{"span":["2022-02-06T00:00:00Z","2022-02-06T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"1ms"}},"status":"ok","cached":"1757h35m17.603809958s"}
+
+
+        event: debug
+
+        data: "Fetching 2021-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2022-01-06T17:48:21Z","st":453624,"ps":{"co":"1|0C4ABaAB3A2BbC2abBCBAaBabBABA2C2aGgDacbCABcCEFedBba2DeCbDEABC2AcAfAB2AdBAB2aA2BaACbaCcEcaABA","no2":"1|0!26ahMfADfKlaDFDaFfaiFaGCeEAdEAahIGgkSiaL2aDfjbMJhDfAmGQBoEoCXigEPkoVaecdTq2DbdABbHCKncjN2eDeBaD","o3":"1|0ZCeEaegDCabCeKBjKhEGbaDCeDEdDcCboJAmQaiIabEdbiEBEaIaboICGFblPAjCEAfKaeCeFagECacDCApJDaB2FgABcK","pm10":"1|0SAcCdGEaSdo2Bb2FfAEgcAcECab2BeCaFBgMBiGhbEBhaIFBbgBdCMJk2gCLBfdGIl!30AufgHecFaiFCfbHOBkbJfjEaFHi","pm25":"1!34aAFdHIB!51h!-43EjIEMhAJrh2cCGAhMaBjaOMr!31e!-27RrEFBsDVKg2edmNXWxudAWAD!-27RYv!78b!-72zdNoBLGoMGon!26PJwBVrmj2GS!-27","so2":"1|0AB6Aa3ABAaB11A2B2AcC2aBaABAB2AbBAa2B3AaCBabABa3ACbaEBA3aAbBAa2ACAb2Ba2AaAB2ABA"},"dh":24,"time":{"span":["2022-01-02T00:00:00Z","2022-01-02T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"3ms"}},"status":"ok","cached":"2503h26m26.105774696s"}
+
+
+        event: debug
+
+        data: "Fetching 2021-Q3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2021-12-31T15:17:19Z","st":451416,"ps":{"co":"1|0GE2AfcAFBbA2aBaB2ABa2A2aAaCACAaA2BAaB3ADbaCabABa2ABaABaBa2ABa4Ab2A2aBa2A2BE2AbACB2A2aABAbc2A","no2":"1|0YekdDaGOC2eGbacbdHE2DkeD2CAkLdDhaADfaKaCBGeABeCEaDAFhFda2DeAkdBAJaC!26ErtAaHcCDRBcjfGBAFgeFEfI2ah","o3":"1|0!30EicEeCADoCaLCgKCMADCndCgOgkDcEbDGbBhEceHCjEHAehHCebHBFcAb2BbadDBdTAOb!-28DFcBiHCAHtIjOhFlKIdeDACe","pm10":"1|0UFheEbCaCaBdEcdHcHDGCdnObGpdFafBABDcAaFaBAaDCfHfaCcDaAHfADgcdACIHIDIKe!-30g2BAFcGeGJsKEcAcDeEcGeAc","pm25":"1!57NunC2dAJICcFfiEbEIHTb!-27UDdvcdfBdBQIdmdCBKeBcadPpeJAIEhbkDCE2gaLGR2CBWAxqBDk!26PozQPzIFgAfCfcACBaA","so2":"1|0Eba2BA3a16AB5AaBa43ABAa4A2Ba5AaBA"},"dh":24,"time":{"span":["2021-10-03T00:00:00Z","2021-10-03T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"5ms"}},"status":"ok","cached":"2649h57m28.033477966s"}
+
+
+        event: debug
+
+        data: "Fetching 2021-Q2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2021-12-31T15:17:24Z","st":449232,"ps":{"co":"1|0FCA3B2A2aBCBdA2BAd3BA2aCBbd2aBaADBadaBABbB2ACbDcACbBAB2aAa2AB4Aa9AB13AFE2A","no2":"1|0RhbIBbJ2AebLMmeFeBLDefFgjDRiAFfdeDFCAkBGFAEfCgHBdBcAbHbAFGngDGIgGhdBFagadH2aLhC2dCAIA2bcDHbBekd","o3":"1|0!29ECBdcaACaD2bGcDcACfDaAKdAaFgDCaEheCD2gMHbkGAbcAF2AcHgdHGfIcHMbprWqEKbqDMHlhSq2AaFCImFCB2iKIEic","pm10":"1|0!35sBHcg2FebdHKdiCbCQIL!-28bAecNEla2BcdaBEcbBDBacDcAFcGai2BCaBIAbDAEAiacCACbdbGeDHce3aCAJhCDcEg2Fhe","pm25":"1!68!-31FNbuJBEacLPh!-27AbERY!61!-83bGkj!26asgBFqCgEAFdRDQeHvpPDfGFieAHaHNJdFBCcqJlA2dcDfGEfMFfAhiCNjEaMdAnVNun","so2":"1|0Ba5ACAbA2Bb4AB5AaBABAa3ABAFAgA2Ba5ABaA2BAaABABAa2ABca4ABAa3ABAa3ABaABAa4AEbaB"},"dh":24,"time":{"span":["2021-07-04T00:00:00Z","2021-07-04T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"3ms"}},"status":"ok","cached":"2649h57m23.073494473s"}
+
+
+        event: debug
+
+        data: "Fetching 2021-Q1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2021-12-31T15:17:30Z","st":447144,"ps":{"co":"1|0HBA2CAa2bEcE2aAcaAC2BAc3aB2ABDbBaCBABACAacAeAaBACb2ADAcBADaAbAbFcACaAdDBAB2Aaea2A%ACADCAB","no2":"1|0MBDGaDb2BFgCBEdidDIadFdCgFjABIEiAFjEa2IbgcICgCBAaJiD2Eck2BGbdFBNhjbEf2aHIDlKnJFbac2fOSG!-33hbI","o3":"1|0RBfdAFANagbdDHFABbiDEdAhLEjDgPcgDfNb2AeDCBcBGbaBcqWbAdFi2dm!30baDmNcBDAdFfbAGiKfEcFa2CaHqGECB","pm10":"1|0KBAJHBgcdHjMgBEjBAFabCaBbBbEDBbabCbdbEOBgCcbAbBRfFmCDHEgLGHrqALHBmcAdAFEDdhBaLBIqcFaEKPpsBH","pm25":"1!53sC!36bNmowRcVpcHvAlWKBbdLqdbHSkAEcPqnkG!37GpHiaidbZCKzbIdaiVUM!-60kRZ!33zjqhGfNBEDqVjPCE!-27iAGF2Z!-31!-31FN","so2":"1|0.3ABAaB2ACbaBACAa2CaAbaACD3AfaABa4AB2Aa2BaACDAdE2ABAaCabd3ACa5AaB2aB2AB2aBa3A2B2a2A"},"dh":24,"time":{"span":["2021-04-04T00:00:00Z","2021-04-04T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"3ms"}},"status":"ok","cached":"2649h57m16.800206755s"}
+
+
+        event: debug
+
+        data: "Fetching 2020-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2021-01-06T19:09:19Z","st":444864,"ps":{"co":"1|0Fc2ABABbECb2abABaDba3AaAB2ACaAaCDCGcdabAaBAbABa3BbBCcBDC2aBaCaBaABDcaAaAaB2A2cABA3CbACaCAbAB","no2":"1|0YcfdEbABHAkOkbAFbAdeEIChCJbaBabeFJDFcfgFAeECjcHbAGDkGEeCH2adaEGcacbDFbjCaC2FdbgcbCFBjGfaJaIeB2d","o3":"1|0VdGAdabDeDBeBEeDdfTdC2aGfdB2DBa2AckiDbAFJ2Ec2Db3AbBgaFdjgB2JanNADdgdHDEcdDaJd2DBcABCdHdmDfDACA","pm10":"1|0KBCfGaEdFdbF2cC2aF2AdBAeADBAaCGebCF!28AqApDaCE2dEADcBcALhGBHMfjkMidC2DGcgACkFBbHdcaCDcfAc2DEAE!33rg","pm25":"1!31CbfRcGjOlkJfD2FJLeagHhgjRfIfEHjCBG!51!49!-56I!-40pacGfhDCHeLoFZpLINTgp!-36ZrAgOCNwgHnuHbdDPFiPKgsKeAUDNFIym","so2":"1|0DB2AbBbABbAC2a3ABCDAcaDBa2AbA3BcAB3Aab3ABCca2ABaACDAaDab2ACEC2bC2aCDdgC2aCcAaB2Aa2AHBbcB2bA"},"dh":24,"time":{"span":["2021-01-03T00:00:00Z","2021-01-03T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"5ms"}},"status":"ok","cached":"11262h5m28.03056941s"}
+
+
+        event: debug
+
+        data: "Fetching 2020-Q3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-12-31T18:40:16Z","st":442656,"ps":{"co":"1|0Fa5ABAda2AB5AaAB6ABABa5A2BaABAa6Aa11ADeBAaBAaA2BaAB2Aa3ABAaBaBaD2aDc2A","no2":"1|0RdeaBFKjaCBCB2aeIgdHeJGefb2AJCOubCHeH!27qtNAKyaFafGdeDCDEg2CBfaIKGkGiCacbdChBPNoeBfdQJiBjDeIcAIcfd","o3":"1|0GCGaLaBmHDEMqCdcAHBGBFEqeaBbMDW!-32DECAbYEKACDxueBKlkPdFAbCAgHb2aDEgAbBeabKacDEM2eDEblUjsL2BjaKadGA","pm10":"1|0MabBDBAcCbBEaf2AHebEaBDdcCbBFBUubaEdBIEbINGujAFkacO2cfDbBDeBEcHBeDabBfaFDgASUmnadgGCicFEbEabdBCf","pm25":"1!33deDbKIDbeHNsa2fNEiIadc2adCfPBUxgBJqO!28LeB!32d!-27!-39TX!-35mAL2DgHAgKiaEBRdgbaFcfwNKld!30!39q!-33FdjUH!-27pODAOHshCbf","so2":"1|0BaAEBa2Bbd8ABa2A3B2A2a2B2AaBaAaAaBA2BCaKhCeB2a2ACa2AbaDb2ABaBAaB3AaCBbaBAbABaBa4ABCB2A"},"dh":24,"time":{"span":["2020-10-04T00:00:00Z","2020-10-04T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"5ms"}},"status":"ok","cached":"11406h34m30.857181297s"}
+
+
+        event: debug
+
+        data: "Fetching 2020-Q2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-12-31T18:40:35Z","st":440472,"ps":{"co":"1|0F2AaAaBa4AB2aABAa7ABa4ABa3ABAaB5AaAB2Aa2AB3ABa6AaBaB2AB3AaBAaAaB4ABaA2Ba3A","no2":"1|0WJ3fMADadDglKHBmBbCA2Eag2Dc2ADad2aELgAlaGcCFEbEAEbieDCFBgCedAKEdFebcHChDaDFAEcfAdHGE2aobFAadeaB","o3":"1|0!31BACFfCD2ABElBaAcdNbCE2CmJigCAbFBDc2GECnjEABCAbFfHLmAdICbhEJdDbhgCebFGeFcDCaBdFfdbHM!32bt!-27dEdnCGaL","pm10":"1|0SdGBdBMWC2hijaNU!-28EdIBAEanBHqFcBcDFbGFgQkgc2bFabB2AdHab3B2DA2cAFkABbHBacJiAd2BaC2aJBIBdqBDcAabBD","pm25":"1!52zR2eDNUlTbmob!26!45!-65JbfiFHeoDWpAgAaNFyZFJnmlBAGAbDFhMKEmNCnjfCDeENlicHACADMQuHecGbBjaKdNdH!-31bCaHdeDb","so2":"1|0EDCAB2cABaBCcA2BaB4AB2ABaeBAa2A2aB2AC2aABaABaAaABAa4A2B2ABACbCA2bA3B7AaBaACB3Aa2baAEB"},"dh":24,"time":{"span":["2020-07-05T00:00:00Z","2020-07-05T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"5ms"}},"status":"ok","cached":"11406h34m11.386994983s"}
+
+
+        event: debug
+
+        data: "Fetching 2020-Q1"
+
+
+        event: data
+
+        data: {"msg":{"st":438288,"ps":{"co":"1|0GcAB5ABbBAbCaBCBDBfb3A2D3aB3ACba2b2CAbBcACBAaBbABCB3aDbEbdCBbBb3BbaDb2aBCACaBabAB","no2":"1|0!30caEbsOFcDdAEmQsLHcLbedIsaJNAfbaACaKCgdnSdGBCoCHAHhBgc2HcaBgBDJBoHDhJgJdbljJfCGf2aQbCidge","o3":"1|0KRalHEdbBAKcE2eaDlAjaLCdGFIAbAcGbBbra2LDbBeGebIcbEABacdC2AdHafnLHbIAecJg2AdkGFBDAaeNdGFag","pm10":"1|0!41yaBebFHQyFeBdBGcHGSckcAIhnDHhbJACaQDaojCD2bLpbLcCgKaiaFAaCFhbNdbIBmBgEFaecEBEDeCBGa2Lele","pm25":"1!116!-60kBjgMLpImeaAMGhNBUJFo!-27!39qsoLkeZDbe!27LK!-38kbaAGIqbJeFkKIpb2BFDCkaUbHDbsbdeNCpfPgKQvGMGCTUj!-34u","so2":"1|0BABaAB2AB2aCBaAa2ABCAdACaC2Ba5AbBaBA2B2ACcFabaABbBdACaAaB2AB2Aa6A2a3A2B3ABa2BEda"},"dh":24,"time":{"span":["2020-03-29T00:00:00Z","2020-03-29T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"7ms"}},"status":"ok","cached":"18060h0m57.255904068s"}
+
+
+        event: debug
+
+        data: "Fetching 2019-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:09:47+01:00","st":436080,"ps":{"co":"1|0BADb2aC2BabBAaDa2ABbaFA2bACAa2CbADAdEBA2aCBAbc2DdGbabaCc2AaABbE2BaeBaBAC2aAaBAabCaBAaCaBAa","no2":"1|0!29eT2hjVBABlTnDPeMkcrAZAjfgASeA2BnKNwRElHceJGJ!-30XCyOaga2jEBAaKJlKJGkcfgBEJCgBeKAfcIebBcbacFd","o3":"1|0ZfCdcKeFcDabHkBEAFeEAkjFTAjACblQAgbFdBf2ED2cGehcIkPkJfDJAcEhgPmAdVcEBdBeaDHA2eaIfH2dFbBgDA","pm10":"1|0SeLCgeEIgDfaBFbEb2abcNMglbBUvHMFlDBmKkKDjcCacCEKqXnFhB2cfEaHFnOJKewBc2CDAdBdFcFcdaAE2aB2DA","pm25":"1!47dNDkcCFhBaCoKDKcbcJuJSmrPA2gORkmUpNO!-27YkcodRdEVK!-51!42iFyOqCo2LMC!-29!35pR2vPdAGAhDFdELaAajD2C2APHa","so2":"1|0CaDb2aDAaBcCAaDbaABaAB2A2aAEAB4ABa2ACbAaABbBA2aCaA2aABbBa3A2CABca3ACA2aA2CbA2CAbd3AaA"},"dh":24,"time":{"span":["2019-12-29T00:00:00Z","2019-12-29T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"4ms"}},"status":"ok","cached":"13866h4m59.914714939s"}
+
+
+        event: debug
+
+        data: "Fetching 2019-Q3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:04+01:00","st":433872,"ps":{"co":"1|0DaB2AaAB2Aa3Aa3BAaBaABAbBbB5A2Bb2ABaA2BaABaBAB2Aa2B2AbAa2ABaC2DcB2AaAc2AaAb3AbB5AaCaADb2a","no2":"1|0SFGHIxGMDFmrEaFL!26!-40CoIh!33MojdedbBFCICfBDFifBGFaeBhbHOcCENBAJ!-29cBdgMAk2GmCRfcbDMmgEFKAcecnASafjNbeT2hj","o3":"1|0ZEeIHtFIBDjaAcGIFtfIac!30!-30Vxb2JhgEKBHmabCa2BeHkGgFCBGBdE!26cAC!-30cEabBbcDeEBcbdaLdEiHCbDdDcbahBGCcJfCdcK","pm10":"1|0PBDBCfBFba2cCaDGCmdJeGKFBkiBCcbEHaAcCGh2CfbacBFaAGc2BFPFiCsdEbfIbcAFfDCKjACFdHlFBGIkgHhbCebFCeLCge","pm25":"1!40SnENka2ABgCHfeKGunGdMOSdjqnSU!-29ELHFfcAbDAcelD2ABCBQcFJ!37Psb!-43hHDnIcbCGfCJGnCBPhHvc2GagigIGcfBHFdNDkc","so2":"1|0B2AaBAFdGcdAaA2B2aBaABaB2AC2BdAa3AB3Aa4ABaBaABaBaBa3AB6AGEBdDdeABb3AaA2BAaBbBCbAaCAaDb2a"},"dh":24,"time":{"span":["2019-10-06T00:00:00Z","2019-10-06T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"7ms"}},"status":"ok","cached":"13866h4m42.188707545s"}
+
+
+        event: debug
+
+        data: "Fetching 2019-Q2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:12+01:00","st":431688,"ps":{"co":"1|0IDAaAdACbC2baCAaCDAaBAaBaBAb2B2ca4AECBd2CbBAcC2a2CBda2BaCbAabCaBbBCAcbCD3aDaB2AaBCbc2ABA2aB2AaA","no2":"1|0!32LpiBFjOaCFCicIDGFcelUcabfkdNLfhdmEGSbfJlbHeciMEdBbVevbABDLfDOAEigAedEb2aKB2fRAdAcblTjdFeTvdFGHIxG","o3":"1|0!33gmKBFCcIeEcaCfm2NLFEexHaAd2bCFnAFDhGfdMBAdCDAhCGAFEDuBhGDAecSadhEA2cCDbAEAabIkfJEFMs2BCg!33!-29bEeIHtF","pm10":"1|0ZFnd2FZCiqA2aESMCdkbAQkgtEBgLIegcdIhG2AdbABANcbDaAgEacdCbaFAbCABFgBDaCkEDaCadECAbdaPFdoEHGmeBDBCfB","pm25":"1!36!31myIS!74E!-32!-45iPefQKJvDfL!44!-28!-41uEaEZYyzKgPdRCafDodB!31jdOL!-40hIEDsCabKDjEcDEBhBbdUtEcFAeDObgBfY2AtBGVxbSnENka","so2":"1|0.2C2aAa2AaA2B5AaAaBHAe2a2AaABaBaBAaCB2a6ABaAa2BbABa2BAaBbBaDABbA2a2B2aAB2ABaAaCb2AB5AaBAF"},"dh":24,"time":{"span":["2019-07-07T00:00:00Z","2019-07-07T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"16ms"}},"status":"ok","cached":"13866h4m34.412388077s"}
+
+
+        event: debug
+
+        data: "Fetching 2019-Q1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:19+01:00","st":429528,"ps":{"co":"1|0H2ACBA2aDAdBbBDbBDcCDeBFebaEBaDeaEcAaCaAaCBbCBc2AB2aBACB2Ade2A2a2EA$aBa2AbADaBa4ABCaAcCa","no2":"1|0V2FAbBGiDaBAhDSdhPpEGgCQkfoLQhKqlMGaDhFgBIClZCkhFBbCAcBPGc!-30c2eLahNbsOAEbCGfBGEAfEibaNcSgcq","o3":"1|0XaAhFfLadjbOJfaDfbChGEemGRac2fGD2bDfaJEC2dcgAHFGhGAbfhdcACRgHImKcDcECcCAFgKd2gFfF2GbcabIBA","pm10":"1|0PHENhbdabMihACbfELAHKyGNhncLHeEkEDgDCceDgNEaTEjdjCbHKAEGFAzBlgDCAiFDgGdGcbCdJGfDaB2aKeIKIv","pm25":"1!49Kd!37khmjd!27mktLceEOM!36N!-70U!34j!-35jDFIbG!27!-30CHI!-30BblNfO!34!34wp!-28BIbMV!30FLC!-51h!-28hiDJuDCDbCJieDBIMeECBFtZiQI!31!-80","so2":"1|0.3ABA2BbC3AaAC2aBa2BaBEDCBheACa2ABAaEdAaACa2Bba2BaACabA2Caba4AFadaB2ABa3ABABA2aABaBABA"},"dh":24,"time":{"span":["2019-03-31T00:00:00Z","2019-03-31T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"6ms"}},"status":"ok","cached":"13866h4m28.026016766s"}
+
+
+        event: debug
+
+        data: "Fetching 2018-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:34+01:00","st":427320,"ps":{"co":"1|0F2ADAcAEAabA2aADAa2EebAaCABaABDdEcaCb3AbCABa2ABa2AEB2ba2BcACabAFca2AaCDbDBcaAbBAaBbDEeGbdA","no2":"1|0!37JHIO!-39F!28Dji2bqbQciJPxeFdDbiBDB!26iIanBEAFcFhMCfdnBc2CJdCjcDHEaNhkCOhCAdpMNmAImOFlOcjBhDCeLgeb","o3":"1|0VbdB2EcbIlHE2ad2abCcDCgACEaDdbajIMfqSEaCcDcAclaBPbdhfAKaEfQCgC2BnK2E2AofKkDNaAGdCABdgdAiFMc","pm10":"1|0SA2FJod2EWveCjGOgdIPscDdDicaDEKcIgBYpqFabd2FAKlHigFLTdnfdDgCEfdFIfEjEfFQiFMrdHg2AFdgOCgYjpe","pm25":"1!50aKOT!-28mJH!52!-53lEjIWclM!34!-35sHAC2laAMUFDhC!46!-31!-35aGBhECIUoQusO!26!45n!-29.2nOqd2ElPEhajAdK!26iCNmvHebABDg!27Jp!51r!-39A","so2":"1|0Ba7AB2Aa2AEAdCEcB2aBAa2A2B2AbAC2Aa3ABAa3Aa2ABCAda2BHCgaAaDbB3aBCcCB2ADeCA3aACbDAcA"},"dh":24,"time":{"span":["2018-12-30T00:00:00Z","2018-12-30T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13866h4m12.519927504s"}
+
+
+        event: debug
+
+        data: "Fetching 2018-Q3"
+
+
+        event: data
+
+        data: {"msg":{"st":425112,"ps":{"co":"1|0DCAaAa3AaA3BaB2ABabB6Ab3BabA2B2AaBA2a2BABabBABa4ABa2ABA2aA2BAaBaACBbaBAaACabDFeEfE2a2ADBdB","no2":"1|0!34IB2InAlGqDLOHfIiHGaofUafQj!-27bCKFBctI!31asiB2beFHaCfhIEAjGhHfMjAGNhCoCFADaG2gLHbfLfdIGf!-27N!26bM!-38!27rcJ2HO!-39G","o3":"1|0!64qfaOgCgco2FCLCetJEAVyF2DKhu2eMGcPjCQiqlBI2bD2dFeAEHoJbD2cGdECRCDqEfbaHcfAbBF2GhfBahGBDAEfaCbaebGEc","pm10":"1|0!26da2HcEjBhJaCBeDg2CBDeABEQmgiC2DB2bcJCj3AcDADB2acBF2caABcHCaBDAGecChFeCbECeCc2BGbc2dJKdFoQncA2FJod","pm25":"1!64kaPVhQ!-32blTfDBgDnCIAQpbEL!31!-28ydDFDCahDQLzLmabFAFBe2AaCJfiBDfKMDkF2GpfGkFdCDCIgceFbGcfBJlTAJ!-30UlgaKOT!-28m","so2":"1|0FAb6AB5AB3AB2AaAbBAbAB3Aa2A2Ba2AaBaA2BA2aBAa2BaBaBb2AC3aAC3ABAbDA2aBAba4ABa6AaABaA"},"dh":24,"time":{"span":["2018-07-01T00:00:00Z","2018-10-07T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"20328h14m5.869924616s"}
+
+
+        event: debug
+
+        data: "Fetching 2018-Q2"
+
+
+        event: data
+
+        data: {"msg":{"st":422928,"ps":{"co":"1|0GbABEBabA2aBDAbC2aCc2ACa2BbcACFcDbadCB2ABb2AaA2B2AabA2Ba2AaBABb2Aa2AB3AaCAB2AaAaBABaBba4A","no2":"1|0!32NIbeIElCAncWBgLbNM!-31HgHeDIe!-27lP!37qIbdjMNjsKaneEeIKCGAtAQHoPxfRCNqamHBGgcfPnWmJfaCBh2a2ASbefc2a","o3":"1|0!27aGAbCbgeFiFBOaDABQngLmcEDjDFCaAbA2KMguBahIBJkabIAaDAjAWja2fDcEFhBCeIdAbfJcBdbAkbREBKU!-30eKcEX","pm10":"1|0RAEAeJLhaJMfdKlhbIRjIknabEbfeIDfKDGFEBrfGabdA3CIaLjcTgNbE!-29EKilACeOfbCf2AH2beaCcCJfCaGbAb2aC","pm25":"1!58Ab2fTVfOF!34sw!28v!-38B!31TqW!-27!-37HgEFbiHBgRGTPRl!-47hELAtJbdFLJ!28!-27gUHW!-30V!-30E!30w!-32cMnGDbCakFEDFneFeBdDKBHgALkfI","so2":"1|0D3AaOm2Ab2AEbaCbCA2aAC2ABac2ADaCba2ACBcBAa2Aa2AB4A2Bb4AaDbAa3ABaB2AB5ABAbBaBAB4AB"},"dh":24,"time":{"span":["2018-04-01T00:00:00Z","2018-07-01T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"20328h13m58.953537687s"}
+
+
+        event: debug
+
+        data: "Fetching 2018-Q1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:40+01:00","st":420768,"ps":{"co":"1|0DBa2Bab2CBcAa2B2AaCbBADcAbAaBCabBAaABADaDbEb2ADa3bDA2BAbDAaAabaDAaAbBaC2aC2ACbDfBaAEb2BbaA","no2":"1|0!39FlNJphBOIrJjIJGdjWmdcMEFsJoDXiyBWuPca!31!-39Z!-30!30iKaLjfpmNKchdFKAp2BMGTmgDfehLaHF!-32AFJ!39xBrfOCHBmjd","o3":"1|0!27aEeadAdmMjRfdK2DClBcGEadjKGBgHgadGabdL2d3BAEhDEhGfDb3DcabaiOCceFjFaBaKABeAJaeEDoJCBeDfCF","pm10":"1|0SIDgDCjLKeB2bFpbFaMm2CdbLIkiCQoDFehHPIjmClOhEGIBfbi!28ncIqJFiPGQ!-33eBCgJbEkEeAJeHEcCc2FDjlaEi2A","pm25":"1!48JEgCV!-31!27ZySgCH!-38iEbGCMlfaKYqsDSqd2KsIXeiqCnQaKcEOgLy!65!-31iN!-37gGU2X!38!-75zFGxVaGbehDEAJlhQic!37I!-35iAda2D","so2":"1|0EBACaeaEBCdBbBDB2aEfBAFcadBaBEabaDdaCBFeCbEc2BCcaBcaB2A2a2BAB2ABD2a2Aa2Aa2BcaAaDaBAaA2BAaBb"},"dh":24,"time":{"span":["2018-04-01T00:00:00Z","2018-04-01T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13866h4m6.666973349s"}
+
+
+        event: debug
+
+        data: "Fetching 2017-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:45+01:00","st":418560,"ps":{"co":"1|0CABaAC2AC2aC2aBABa2A2aDaBAbCdED3AeADbaDba2AEAbBcACAaBABaA2aAaFcBCA2aCAbFabeACAEb3a4ABbAa","no2":"1|0!35MjOtHBfRfAIjcDAJlCRvARfIgkGqTYaqN!-29eVdlPiAoHWfbFiaFBeLjdbEhAfATmIMKyBMne!30fH!-32CFaShAghejNhVAf!-32","o3":"1|0VD2aB2bBhHBcAaNAeqTaBAiHArKDFkabhJCGiOcqTkMhgbGAcCEGEAqHCDjEIBpAcNDBfeEabOcjgLbmaKaJGCbBqQ2C","pm10":"1|0.2NfDhEcCHdBQkBHFbGgmahJbFD2chNGDOCseKpaLiDkHJBdFfdAFDfEbfdDdDaPcaecaeOdmTmIiDCIOk2difEdbPdIt","pm25":"1!48MbaiGBCOlhRAHMAr!34l!-36BgMFGRninTEJ!26N!-35fM!-34APrIlOcRjOmkACDl!34jzcIeaB!30obhaBg!28wb!33!-28DdALI!31ujiojHlCQaG!-36","so2":"1|0DBbDd2BaDaAB2aA2Ba2AbAC2ABbBaBCADBRsD2bCcdaBE3aBaDBcDbAaBba2ADcCDabaDcbJaE3ACF2gdAD2IaoaAd"},"dh":24,"time":{"span":["2017-12-31T00:00:00Z","2017-12-31T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"8ms"}},"status":"ok","cached":"13866h4m1.937186562s"}
+
+
+        event: debug
+
+        data: "Fetching 2017-Q3"
+
+
+        event: data
+
+        data: {"msg":{"st":416352,"ps":{"co":"1|0CA2BbCa2BbBbCBAb3BbBaA2aC2Bc2AaA2BaCA2a3AaB7ABAaB2ABaAa3ABa%Ba6ABAa6AB2Aa3A","no2":"1|0!33h!28KjOtp!28lKz!30!-34Jl2NceAafhFMedEjHDdbKqIEkCESwDZmHfClEAEbGKnhSgpQiId2C%!-31GNJFbjEjbKGNBAmcGbJGdeo","o3":"1|0!27EeAFZvAJnhEKi2fVHijFcbAGh3BEaCdC2BDg!47C!-45bAJaeJifFBkbSJOreOzdHDCBja%b2D2BJHbsFcfAGcDIsaPceFa","pm10":"1|0WdDAFJldFcabHdAfJKbhcdBcGECAebNjfNecbBdbKDnDHcBaBeBCPJwOgaSmX!-28dAeAa%lEIBaAcBAbICFeAdKOAGxDhg","pm25":"1!63lFEGSqiFfadIEejFOGoAiEbMbdeadG2aBFadEKh2EpEGabAbgCD!36C!-35U2B!38!-34lhKgnFe%!-28BVHcABGFiRIjeAd!29!32a!27!-81Iqh","so2":"1|0CaDBb2AaBABbDcC2aBABaABbACAaBa2BAaAbABA2aDbaCaBABbABAaCAbaBCbCb2ACA%bA2B2AbB2aABDaCcaBA2BA2a"},"dh":24,"time":{"span":["2017-07-01T00:00:00Z","2017-10-01T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"20225h4m17.36105314s"}
+
+
+        event: debug
+
+        data: "Fetching 2017-Q2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:53+01:00","st":414168,"ps":{"co":"1|0EbCbA2BDab2BaBbCaBb3a2BaAC4AaAa5A2BA2a2BABABaBAaBAa2ABbB2aAB3ABa3AaBaCABaBAbA2aBaAa2A","no2":"1|0!50rYsAIe!27.2rHCeDiAaGVbpd2DkDNdKrcHaCagdDHSCdcmN2cb2EcPmANehiBIhOatDIaDFbldLBDCpDKTcAkfkgJIlZyBi","o3":"1|0!37cCiFcDKBjBaAdKebDdBK!26ynbcEdLBfaDABdHeabeMCehaiKGCFEt!70!-37nafBgfOcBcacBbCBDdAPkbJZD!-28!45!-39reAIhabHCE","pm10":"1|0YaLgBHBLavBCafcABFCHEnDEiAIAbBkRCEjEcB2AQnbjD2CAfabKfDJebeBdFAFgeDb!70!-67FecCDFCfCBLGbgnbeIFgaACd","pm25":"1!60F!28wHKBWh!-40eIBodHebMSEubPrDEIfDvZHBu!32kpaG!45!-28luGDSfkhbVmMCcDkBeBEWzkFbCJBdfC2GEhLDPNioydhIPBjDCl","so2":"1|0DbCbaCaC2a2BbCbAaABDabBCbaCaCbAaAaB2AaADBA2a2BAa2AaABaBA2aBCaC2a2ABaBA2aC2aCb4AB2AaAaBACbaA"},"dh":24,"time":{"span":["2017-07-02T00:00:00Z","2017-07-02T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"20ms"}},"status":"ok","cached":"13866h3m53.510871995s"}
+
+
+        event: debug
+
+        data: "Fetching 2017-Q1"
+
+
+        event: data
+
+        data: {"msg":{"st":412032,"ps":{"co":"1|0.2CbFAcBaAaBbB2ABDbaBICcbeA2aA2BbBCbDbcA3BaAa2BaBaBcA2BACac8ACAaA3Ba2A2BAda2ACBa3Aa","no2":"1|0!32RdMP!-34.2HbhJpBDNHNkcdJLcgqAbdAaEeLOuLBkI2iBALEHcefcHDpKcgRbGgAcfbKEeKflEBJbcjeOEBjdCfIJAJBjq","o3":"1|0XjGhCAbIfOcB2fbBfAEac2ABFfTaheHIFlbDEnHeFd2bKCaHcfFHCbBCDcABeJ2bcHglBcMgcBIbDaCAdALehKBGcAd","pm10":"1|0!27BFMBtDeKW!-32.3AGPQakBXKqsMDwpICiCFCeOgGAJgGKio2BAge2cCEDmCIEDAfiJBAcEJCjaIBkecFDb2Iqd!27EwBaca","pm25":"1!72hJZDoDrLhfCbdQT!26H!-35H!60Nv!-36YA!-74s!29SxneOKZxMN!29jKL!-36zmLMokiCkNBoGCFALknLEQiBVM!-37HJL!-36ceF2B!31K!-37f!65D!-56aBeF","so2":"1|0CEcBDc2BAaCBd2ABCbaBDFb2c2AaBABaABbCabaB3ABACAbAB2AbaBaDB3aBa2ACbBA2aC2BbAaCAb2a2ABCaABAb"},"dh":24,"time":{"span":["2017-01-02T00:00:00Z","2017-04-02T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"20225h4m14.961237383s"}
+
+
+        event: debug
+
+        data: "Fetching 2016-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:58+01:00","st":409800,"ps":{"co":"1|0DaDb2aBa2AC2BABaD2ba4ABC2aCB2AcCabaA3B2AaBAcAD2aAE2acEaBDIfedAECdaAaCABAaACb2A2BcAaBICdbcb","no2":"1|0!47oUlbHAncIGfAFJjTqfaGgbL2IbjIg2CLPm!-28lMNhJB2gVmKCImpIFgbEhaMPXlsgbFIafAjGBCEhCFBajIPpew!49Ua2uh!-28","o3":"1|0SFebDGjKBcfBgAPCaAg2cEahcNFbodaPb2cMcCm2Ed2DdBGFBiHCagIagECsbACMfjDGCbQoHgce2aBAIKkQEabwbDADU","pm10":"1|0XbIAafEdeG2ADHbjHgBDabCJLchCLJDkmKhCmcLlJGiDJ2fD2biIA!30!-32AGfDR!40whwC!27BmfA2fECJBJgjLgeDoJpE!27Nhfnp","pm25":"1!63AIambRenKCaHMftIkMaJhEQXnoGU!34B!-33sNrCloVvHShgRmjAcbFX!-32RvEYij!40!54lo!-66J!63R!-43hcklFMLEXgrMj!-30EtCsI!53!41og!-36!-35","so2":"1|0GdEDbdB2A4BDBeDcaBA2B2A2a2BGcfdF2aBaCbBb2aFa2ABa2BbBcAC2aCHbAaB2Ededa2ABab2BbA3BcaABCB2Aba"},"dh":24,"time":{"span":["2017-01-01T00:00:00Z","2017-01-01T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13866h3m48.551122047s"}
+
+
+        event: debug
+
+        data: "Fetching 2016-Q3"
+
+
+        event: data
+
+        data: {"msg":{"st":407592,"ps":{"co":"1|0F3AacFDaABadbDaBC2BcBAaDC2baBaDBabAaBbaDBbcbB3ABa3A2BaADcCaADaACA2acaABAaCaD2AaDAbdC4ABab","no2":"1|0!54oBGtJ!29wdfJblFQrdXNbyLFpaHaKBtcUeCdAbfc2ADRkhNBJeGscNUCpfdfd!35.2idemQaPA2h2FRCi!-31g2GEZdGkmMeAbKio","o3":"1|0XaFeGDb2fHdcCGfbDWbItgVobcdFfIBiaFBHFhcBaeLeDbGFBgcAaONojGgDJpDkHAjc!28iceJeUbFuhNkcTmFIfkaBDAcE","pm10":"1|0!26gBCcCGcbd2EeaDfaIGHoNghBDA2CehIBC2bDdAEcAEga2DI2BhjMBJClDfbH3acdIEBAgbADRdBdrCNfHaefBNjIiFhb","pm25":"1!59BeIqHRBAgFEfBeiB2KMpXsuBHFebJsIDcADElJCeCFkaCEOaN!-28jQFWKqgjFacdDejNPeCobcF!31BGsuKWiCgobgHBHjGbA","so2":"1|0Fa2AaAD2aC3AaBaA3Bac3ABaACcACAa3AaAa3BabC3AB2a3BbBaAaCBAaABaAbCAa3AaAaAB2A4B3ABCB2d"},"dh":24,"time":{"span":["2016-07-01T00:00:00Z","2016-10-02T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"3ms"}},"status":"ok","cached":"19313h5m6.032705968s"}
+
+
+        event: debug
+
+        data: "Fetching 2016-Q2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:10+01:00","st":405408,"ps":{"co":"1|0HbaAb3BbADb2A2aBDcAa3ABaACBbEcbCAB2aBCDe2aBABAaBA2aABCab6Aa3BAcCABAEda2ADCBbCdc2AGbcB2A","no2":"1|0!68miOkMjCegHNaEcvcWmABahdKh2JdnJmL!28FdqbHjAEqbKDOajFljaEDUghtdFCJFdeU!26oiVrnAHECodCAQFcAsgdZcKepB","o3":"1|0!29GgCBbi2FEsQeHhAGdFeC2AFhDCacFEfDFEgKHnra!33mcEcaAhAaEbaFbEF3d2CbcHjdPpUA2kBFEAfIjCdhQaACAgGbaF","pm10":"1|0!34bAcbabFibYoCDehAKfHDeiBFf2FDkDACHGFBpJbGAhlHFdcAadbcAJ2EbjceEaILcaQjdDdfFfBcBE2fG2DchbaMdBCgB","pm25":"1!83fJpehCLua!55!-40KACocKkEJdhDLpHKHpfDHBJTO!-38LJVourUAcfBfeajbT2GJqhjBcZUrhYcieGqBcBcKajkLJGmjAhTdGfBe","so2":"1|0FbAC4AaA2BaABabCbABaBACAaBab2A2Ba2BABa2Bba2ABCaABAcbABAaB5ABaAB2A2BABCAaAbaCabBAbaA2CbA2a"},"dh":24,"time":{"span":["2016-07-03T00:00:00Z","2016-07-03T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"7ms"}},"status":"ok","cached":"13866h3m36.811568694s"}
+
+
+        event: debug
+
+        data: "Fetching 2016-Q1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:17+01:00","st":403296,"ps":{"co":"1|0F2BbCcBCAacBDaB2Ffb2c2Aa2B2Ca2BAbcCBCBCgaABEabCdbACE2AaABAaca5A2BAbABAB2aABABCcb2A2BADba","no2":"1|0!44HBkRrbMgJkD2FbZM!-28lAnI2bMkaAaGdCGrDGMk!28rigWOasUtkAGTCdzcQDceNreHUpaLgmCDcLdgcJIBTwgba!27iDJmi","o3":"1|0TAqVhOaeabAciJbnAL2CbIEBACAdEbiB2GCagehCAN2cBbHDAcgjHAGHfEBababCbBlCFHBLgDdGdede2HC2abcACGg","pm10":"1|0ZFIrNjeEAJmCSoL!27LqmdrKBnSlEgIGiAEfeNbg!26rBfFMehGmeBKUbAlqMbdAHbBDGqWRGumAcMphBNDKAvCbdHDcJbA","pm25":"1!54H!30!-40UojNdGnF!30xN!67V!-50!-27eqDboMhBAIFeEAerQCB!35zPwKHcbCzfMJ!40Bcl!-38LeiHDUlaMi!41!45I!-45!-30dg!28!-32tA!37BTh!-38dtFHFLQfJ","so2":"1|0LABaceBCaA2bCbCFDeA2aBa2BbB6A2BABaCbBadDaBAaABaC2A3a2C2AfaAEbaBAbaB2ABA2BA2Ba2BCbAbAbA"},"dh":24,"time":{"span":["2016-04-03T00:00:00Z","2016-04-03T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13866h3m29.551850562s"}
+
+
+        event: debug
+
+        data: "Fetching 2015-Q4"
+
+
+        event: data
+
+        data: {"msg":{"st":401016,"ps":{"co":"1|0E2B2A2aACcABA2B2aBACEcB2aAC2AaAFdcaCAa2ABa3AaCaAabACDacG4AaAba2AaAB2Aa2AB3Aa2AaAaAaDaBb$BaA","no2":"1|0!42VlEiGkIMsdQbCbAnhTLci!27eljfMBgiEcBMBkhCFCJACkpVhCOjqLVfoLcehNJceBjdEKDdBhgIbKcKsELmK2khQbRp$BjJ","o3":"1|0YfdToagHgHFbBAdFBdBefQjIiadGDcibaFCICAaHbBbFe2C2AbfHmCHefMFBcCEgBGAiAaHiIiciSiEaIa2B2aCAlKB$jCG","pm10":"1|0!28IOfncBGKrMake2HghGIDcFlAJModBUKkcfkcAbFaBHcicGAGabkHOlbKhbcAEGCecbIdEcaAeJEdPl2ebgLfdF!33smd$HlC","pm25":"1!66U!43s!-28efJW!-34!28dyoULodHKHpJfgMPthB!43!41!-36lksefAeGdKkagHcFJncP!37!-43GLgqcCJIFjhaQdACfcBQMtZpdrcQjflS!38wpi$Opf","so2":"1|0C3BAB2ABd3AaBAaA2BEbBba3BaAaCa2B2aAaB3ABbaCAaCbBaCAa2Aa2ABaABaABABaBa2AaB2AaB2AaBa2ABAB$aDB"},"dh":24,"time":{"span":["2015-10-01T00:00:00Z","2016-01-03T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"19313h5m2.892985035s"}
+
+
+        event: debug
+
+        data: "Fetching 2015-Q3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:23+01:00","st":398808,"ps":{"co":"1|0Iaca2AB2aCaC2AFfCaAB2A2aAD2AcbFbABb2BcBAa5ABaCBA2aBbBaBAaAaCAa3AaBA2BAaCAcD2aCBcaCaAa4A3B","no2":"1|0!86pycgOEnDXufHeBMJfibMBeF!-31XCdnGXpCeiNMflHkFfiPpDMICjCdDhJeGDgnDKBaBbhHAcNDhgEGfIZvaKfBClafIb2aVmF","o3":"1|0!69!-32ca2cBDFHmifaEPcFarG2DcCcaEcALgStCabDNenjKdGDdJiDjGQfpBCAECc2bCBcCHha2DIcgDBABjLEjfABEBCea2DgdU","pm10":"1|0!44.2kLiaCaJebgBaDLBhcIe2aFjEAdCKdGkEaCdDBeaBbLFkACFic2BCfEaDAdHkHACcaAcbFKInABDeFDiHdeGAHdj2EDcIOf","pm25":"1!104!-27x!28sbgGeJaeHfDKadiRjbfOpJghBAVdiJdIabda2cg!27T!-30bCMhfCBFkDBDdaKrQcCAiBiaGPQugEAhPbdVewEFGBoACEBU!43s","so2":"1|0FBbBAB2Aa2BaBbAaBAaB3AaA2B2aABAaBbaE2aB2Aa2B3ABaBaABCbAbAabACA2a2AaAC2BaACBbBAc2CbBAb2aBaAaCAB"},"dh":24,"time":{"span":["2015-10-04T00:00:00Z","2015-10-04T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"6ms"}},"status":"ok","cached":"13866h3m24.17881605s"}
+
+
+        event: debug
+
+        data: "Fetching 2015-Q2"
+
+
+        event: data
+
+        data: {"msg":{"st":396624,"ps":{"co":"1|0EBAaB2A$aAb$A2BabAOCdedC2bBABa4AaBCbBaCBa2A3BabAabBAaB3AaB2A2BcAB2AC2BbaC3aD2AaDA2aCaABacaA","no2":"1|0!35HgdbHE$YD!-30.2EICqBgCOBbMQxrEJQjifcAFLTCyHIfCberKLcn!27roFhJNoNfjJbA!27c!-28cJhMNKqoFWkrBNqLc!39fG!-29BMQJpybh","o3":"1|0!29cfBGAc$aJDBgHAlGFaBbcADbdhHCAabIEcabdLagF2eGIdbeBJqEDGcEAfBACBfHhHEjEFJanaBHpLajHfGHADfhLKY!-28kEd","pm10":"1|0UDaBbFd$!37B!-34bEDGjeBAMagDUxfIBUzDAfAIcBJjFcaFgEdBcbLABfdDcEdCbaHdEJEtBGCdFRmegJbJcgiECAKfcbBIK2kLi","pm25":"1!46JFGeJu$!100e!-79i2JPxm2BRbAH!49!-48pFeJgeHabKfDI!-27LDiEHdDhAgKNdibEeNsIAhJbCLS!-39EHkFO!29jsuScDEBr2BNGdkCDE!36!-27x!28s","so2":"1|0E2A2a2B$aCaA2BAbAa4A2C2aBAB2a2BAB2aAbABAbBa2ACBcEacBbA2BC2aB3AB2bBaACACbaCBcACaBbDB2aABAaBaAB"},"dh":24,"time":{"span":["2015-04-01T00:00:00Z","2015-07-05T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"19313h5m1.026470742s"}
+
+
+        event: debug
+
+        data: "Fetching 2015-Q1"
+
+
+        event: data
+
+        data: {"msg":{"st":394464,"ps":{"co":"1|0DBAD4ABbCACbBA$AcC2AEeEfDBcAabC2Aa2A2BCA2abCBdD2AaCBABcaba2CbC4AaCc2aADA2aCbADaCcBaABaABAaB","no2":"1|0TIKaGfDBanOAIdCjkCPKhDHwOh2DAbdhLKbjnTfFIkLbkCGmH2EmdPiGRlojQFaHegACLhCioBNbBFLqgQFElJoaEmOHgdb","o3":"1|0YEgmGKAEDadIeAFmiBcAEhCSkImP2bAGnFcDAaGhBEpTCkaHFDeDEa2fcDLEcabgK2ahaCaDEeibOIDfAlGgLBcHcD2cfBG","pm10":"1|0!28kaRdjDcBiIbBACFlDKRkKM!-31No2dcHcDKbImCAQaHaMnvXfoGa2deJbGFbkaBCFEeM2fJKb2hKHUfgaxFdFJtFdeEfHDaBb","pm25":"1!75!-33H!39puCcCtOaCcIBfIUZr!32S!-82TtatEMbeQIDpfVFSbN!29!-28!-46!47j!-37LbkaeHdHcKpbaDFOiVlab!38donPX!52m!-37E!-55k!27lX!-33FArFkQJFGe","so2":"1|0DAaCBa2ABc2BCaBbaABDbaFgDb2BCAabBaAbAa2BDaBa2ABdCB3AC2abDbaCBcDb3AaBAacBDabACaAC2A2Bb2AaB2A2a"},"dh":24,"time":{"span":["2015-01-01T00:00:00Z","2015-04-05T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"19313h4m59.869871873s"}
+
+
+        event: debug
+
+        data: "Fetching 2014-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:30+01:00","st":392256,"ps":{"co":"1|0FABcBACac2BaBAaDbaACdB|35GEbCbcAaAbAbABa2ADbACbaD2BaAaACbA","no2":"1|0!36ALtGCKfiDGmADCVkhaLrH|35.2Ek2AaPcfDLkBLDcbEnWeicEcDaBndKjB","o3":"1|0RgLbAcGcDhJADtBHE2CdDe|35lAcAICJ2bkaTiHJbEzTcqOFCdFAFbibGd","pm10":"1|0!34bElcBEaAcabcBNBAgaElKDB2eFIj!26gjgcDJLwDFfecHFDefEVCAfvVk2DCIeifABFCnBIAdcPjDGldaAbDbeFCeO","pm25":"1!69DLveCFAfdECoCXbe2fMuP2GhkLPm!51xylEFT!26!-50GSokCcNKbmI!46Ddt!-36!28kJFcTfrsiPIE!-31bNcdaZqEPwheDcFfhKLlL","so2":"1|0DABcBACAbABaBAaDabACbA|35DCbA2bAaCBAaADAaBAaDA2ab2ABAba2Bb"},"dh":24,"time":{"span":["2014-12-28T00:00:00Z","2014-12-28T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"3ms"}},"status":"ok","cached":"13866h3m16.746042233s"}
+
+
+        event: debug
+
+        data: "Fetching 2014-Q3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:34+01:00","st":390048,"ps":{"co":"1|0D2BAa2A2aAB4ABa4Aa2ABAa2AHeC2aB2AaBA$BabCcAEd2ACbA2Bb3A$DCc3ABa3BaAa2ABACBbaA$3AbBC2aABcB","no2":"1|0!48ELi!-46!31cEjFGfiKAMdNmtAiIkOfBdbGTFmAGDcAFk$KBpLdaZ!-27dCSneLfeImjcKXlHaN2gIHhcDmgSajIEiaDjDUbhbNCoALtG","o3":"1|0!29aIboFfbMgdVoFaCbScjfdMBhQlfMcfCbDcABadA$cHiBaKahDaB3CjMjCeADpMJiJdDAfdbIGCjDHAo2GibF2beHaJigLbA","pm10":"1|0QGAanLdCDbAFgACHcJgA2cD2ADfeAFGBedEBabId$bBfCA2bAbEFfaENlGhCgDKcLCNFmgAfMhfaEWACcfwRHmEdcHOfgbElc","pm25":"1!49LEb!-31YiMAfGIpdGLj!29nBeiEaEGmkbMNFklIHdbSl$fbnKbceAgGTtbP!32!-35LnBmK!26lZC!28W!-34wAm!27uiAD!54GElu!-44!39!27!-37oab2YtwDLve","so2":"1|0EB2AbB2Ab2A2BaBABaA2a2A2BABACBab2aC2AaBA$BABD2CjCdBCba2Bb2aABACb3A2BAbBbB$a2Ba2BbCRfj2AbACa2ABcB"},"dh":24,"time":{"span":["2014-10-05T00:00:00Z","2014-10-05T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13866h3m12.872883187s"}
+
+
+        event: debug
+
+        data: "Fetching 2014-Q2"
+
+
+        event: data
+
+        data: {"msg":{"st":387864,"ps":{"co":"1|0EB2Aba2ABABDcaCE2aACABaBaAaABA2cACABaBbaAB2aBA$BABbB2bA$DBAa2A2B2aB2ABAb3Aa3ACaABAaA2BabCaC2AaA","no2":"1|0!50bqHijKEKcLkoMaUeufAOKEahaeEHPflgNCDadeiCEDAbaqSKDkaBekJBjIgKhPeE!-31!32hBFbfEalhKcGaFcDIhAGEolXEFLj!-46!32","o3":"1|0RdbP2bBJgACAE2cIdDAdcCAeaLg2ALk2F2GmfACcCbgIAaEShckFAfDnGAcGLfahDaMCAbdbFDhbdHlfOIecD2AdhIDCaIaqG","pm10":"1|0!45SbwqfCALeDFkBaLFqA!30ghfcLmdPIbh2g2GecACeAaBcKB2ALjgcCacABWqAcFb2aiJDhFdCEC2gDFfJeBDaDjGHieHbGAanL","pm25":"1!105!39k!-34!-42hafWiGKsDgQO!-34F!68j!-29hdV!-30g!33Vcr2qPLmfBCfgDIcQHeBZuoeAahbCAThbMcChzWPnLgfGBhvHFfYpGEVk!-30MTvmRALEb!-31Y","so2":"1|0GabFdABaCabB2aACBdA2BDaAa2AaBCAe2BAD2A3aCabBAbC2BaBaA2aACAbABC2BdCAa2BbaBAbCAa4AB2aBCAbBAC2AbA"},"dh":24,"time":{"span":["2014-04-01T00:00:00Z","2014-07-06T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"3ms"}},"status":"ok","cached":"19313h4m58.083622564s"}
+
+
+        event: debug
+
+        data: "Fetching 2014-Q1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:45+01:00","st":385704,"ps":{"co":"1|0EB3AaC2ACBAbA3abBEBd2Aa2BaEHhcBaCABAbA2BdABCabC2bCBaABEfaBaBCBAB$abaC2AcABADbEAaBc2aBABaB2ABca","no2":"1|0XG2a2ABDAOSy2AdcHfa!29gnbKsCMaAEem2CHcHgmCTAiKegIBCikRGnMIDdajhXJbmbzINqOLI!-32CKaHjNsaSCBAcgGFBbqHij","o3":"1|0!29cFdcEAfCimKMiICDnEpOABdNaAcemNEAeJEaACAmHCAFAka2ACEaFbDqIfALdkDNiGE2aqICKCnIaIbDbcbebdQ2bjeaOba","pm10":"1|0QEHicIHfcGNfkDcB2bDRGqeFgbEcbJfiGACDacaBC2aDcBEBDAlHadGbGdgOlbSJke$NjcSQG!-44dLfHagiaHDBIUbgkLSbwqf","pm25":"1!37JDadbAfOL!45p!-37Fh2DcG!40K!-44bDjgGeD!26p!-37MKEBHfhaJCeBcDKCJDyI2fSiIeg!27!-27a!34Nvg$Zqp!48!42J!-95hVoHalsAUHDS!51es!-31X!39k!-34!-42h","so2":"1|0GFh3AaCaDbABAbCAcCDBcaAaAD2bCBbAaCABAbACACab2A2BbaC2aCACaABA2BacAdBAbDAEdBC2AbCbaBaAB4ACacFcA"},"dh":24,"time":{"span":["2014-04-06T00:00:00Z","2014-04-06T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13866h3m2.016662029s"}
+
+
+        event: done
+
+        data: "3.122487ms"
+
+
+        '
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Type:
+      - text/event-stream; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:14:47 GMT
+      Server:
+      - nginx
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://search.waqi.info/nsearch/station/london
+  response:
+    body:
+      string: "{\"dt\":\"28.998055ms\",\"term\":\"london\",\"results\":[{\"s\":{\"a\":\"63\",\"t\":[\"2022-04-21
+        01:00:00\",\"+01:00\"],\"n\":[\"London\"],\"u\":\"london\"},\"n\":[\"London\"],\"score\":8,\"x\":5724,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"72\",\"t\":[\"2022-04-21
+        00:00:00\",\"+01:00\"],\"n\":[\"London Honor Oak Park\"],\"u\":\"united-kingdom/london-honor-oak-park\"},\"n\":[\"London
+        Honor Oak Park, United Kingdom\"],\"score\":7,\"x\":11653,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"55\",\"t\":[\"2022-04-21
+        00:00:00\",\"+01:00\"],\"n\":[\"London Harrow Stanmore\"],\"u\":\"united-kingdom/london-harrow-stanmore\"},\"n\":[\"London
+        Harrow Stanmore, United Kingdom\"],\"score\":7,\"x\":3192,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"53\",\"t\":[\"2022-04-21
+        00:00:00\",\"+01:00\"],\"n\":[\"London Marylebone Road\"],\"u\":\"united-kingdom/london-marylebone-road\"},\"n\":[\"London
+        Marylebone Road, United Kingdom\"],\"score\":7,\"x\":3193,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"48\",\"t\":[\"2022-04-21
+        00:00:00\",\"+01:00\"],\"n\":[\"London Teddington Bushy Park\"],\"u\":\"united-kingdom/london-teddington-bushy-park\"},\"n\":[\"London
+        Teddington Bushy Park, United Kingdom\"],\"score\":7,\"x\":3195,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"46\",\"t\":[\"2022-04-20
+        23:00:00\",\"+01:00\"],\"n\":[\"London Harlington\"],\"u\":\"united-kingdom/london-harlington\"},\"n\":[\"London
+        Harlington, United Kingdom\"],\"score\":7,\"x\":3191,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"46\",\"t\":[\"2022-04-20
+        23:00:00\",\"+01:00\"],\"n\":[\"London Bexley\"],\"u\":\"united-kingdom/london-bexley\"},\"n\":[\"London
+        Bexley, United Kingdom\"],\"score\":7,\"x\":3188,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"39\",\"t\":[\"2022-04-20
+        19:00:00\",\"-05:00\"],\"n\":[\"London, Ohio\"],\"u\":\"usa/ohio/london\"},\"n\":[\"London,
+        Ohio, USA\"],\"score\":7,\"x\":7930,\"c\":\"US\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"38\",\"t\":[\"2022-04-21
+        00:00:00\",\"+01:00\"],\"n\":[\"London Westminster\"],\"u\":\"united-kingdom/london-westminster\"},\"n\":[\"London
+        Westminster, United Kingdom\"],\"score\":7,\"x\":10874,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"34\",\"t\":[\"2022-04-20
+        20:00:00\",\"-05:00\"],\"n\":[\"London, Ontario\"],\"u\":\"canada/ontario/london\"},\"n\":[\"London,
+        Ontario, Canada\"],\"score\":7,\"x\":15,\"c\":\"CA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"33\",\"t\":[\"2022-04-20
+        19:00:00\",\"-05:00\"],\"n\":[\"Londonderry - Moose Hill, New Hampshire\"],\"u\":\"usa/new-hampshire/londonderry-moose-hill\"},\"n\":[\"Londonderry
+        - Moose Hill, New Hampshire, USA\"],\"score\":7,\"x\":7449,\"c\":\"US\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"32\",\"t\":[\"2022-04-20
+        22:00:00\",\"+01:00\"],\"n\":[\"London Bloomsbury\"],\"u\":\"united-kingdom/london-bloomsbury\"},\"n\":[\"London
+        Bloomsbury, United Kingdom\"],\"score\":7,\"x\":3189,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"1\",\"t\":[\"2022-04-21
+        00:00:00\",\"+01:00\"],\"n\":[\"London N. Kensington\"],\"u\":\"united-kingdom/london-n.-kensington\"},\"n\":[\"London
+        N. Kensington, United Kingdom\"],\"score\":7,\"x\":3194,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"-\",\"t\":[\"2021-12-13
+        15:00:00\",\"+01:00\"],\"n\":[\"London Eltham\"],\"u\":\"united-kingdom/london-eltham\"},\"n\":[\"London
+        Eltham, United Kingdom\"],\"score\":7,\"x\":3190,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"-\",\"t\":[\"2022-04-20
+        05:00:00\",\"+01:00\"],\"n\":[\"London Hillingdon Harmondsworth Os\"],\"u\":\"united-kingdom/london-hillingdon-harmondsworth-os\"},\"n\":[\"London
+        Hillingdon Harmondsworth Os, United Kingdom\"],\"score\":7,\"x\":3390,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"157\",\"t\":[\"2022-04-21
+        09:00:00\",\"+09:00\"],\"n\":[\"Palbong-dong, Iksan-si, Jeonbuk\",\"\uC775\uC0B0\uC2DC
+        \uD314\uBD09\uB3D9 \uC804\uBD81\"],\"u\":\"korea/jeonbuk/iksan-si\"},\"n\":[\"Palbong-dong,
+        Iksan-si, Jeonbuk, South Korea\"],\"score\":5,\"x\":1802,\"c\":\"KR\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"109\",\"t\":[\"2022-04-21
+        09:00:00\",\"+09:00\"],\"n\":[\"Wolpyeong-dong, Daejeon\",\"\uC6D4\uD3C9\uB3D9
+        \uB300\uC804\"],\"u\":\"korea/daejeon/wolpyeong-dong\"},\"n\":[\"Wolpyeong-dong,
+        Daejeon, South Korea\"],\"score\":5,\"x\":4527,\"c\":\"KR\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"57\",\"t\":[\"2022-04-21
+        00:00:00\",\"+01:00\"],\"n\":[\"City of London - Farringdon Street\"],\"u\":\"united-kingdom/city-of-london-farringdon-street\"},\"n\":[\"City
+        of London - Farringdon Street, United Kingdom\"],\"score\":5,\"x\":7949,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"26\",\"t\":[\"2022-04-20
+        20:00:00\",\"-05:00\"],\"n\":[\"Hamilton Downtown, Ontario\"],\"u\":\"canada/ontario/hamilton-downtown\"},\"n\":[\"Hamilton
+        Downtown, Ontario, Canada\"],\"score\":5,\"x\":10,\"c\":\"CA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"-\",\"t\":[\"2021-09-15
+        20:00:00\",\"+02:00\"],\"n\":[\"East London, Buffalo City Metro\"],\"u\":\"south-africa/buffalo-city-metro/east-london\"},\"n\":[\"East
+        London, Buffalo City Metro, South Africa\"],\"score\":5,\"x\":11407,\"c\":\"ZA\",\"z\":0,\"$\":\"realtime\"}]}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:16:17 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      X-Gen-Time:
+      - 29.252875ms
+      X-Powered-By:
+      - waqi-search/1.2
+      content-length:
+      - '4439'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/api/attsse/5724/yd.json
+  response:
+    body:
+      string: 'event: debug
+
+        data: "Fetching 2022-P4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2022-04-20T22:21:53+01:00","st":457992,"ps":{"co":"1|0B2CAabDaCbAba2BaCACa","no2":"1|0LEFEcDjDaHMghEFdbeAc","o3":"1|0!32BbcDAhEbFiFBAFaJfae","pm10":"1|0OFBdCdCBaCMCnALNenaJ","pm25":"1!32PGjhgANDCNCrHP!36g!-34iP","so2":"1|0.3ABa5AB3AaBaABa"},"dh":24,"time":{"span":["2022-04-20T00:00:00Z","2022-04-20T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"1ms"}},"status":"ok","cached":"3h54m26.501738396s"}
+
+
+        event: debug
+
+        data: "Fetching 2022-P3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2022-04-06T19:38:10+01:00","st":457248,"ps":{"co":"1|0.2BAaAa2BABa2AB2AIfdBCbBCb2a2ACEcaC","no2":"1|0XCInfaJc2FdeBJAgHak2DM2GjgiHhgeFCF","o3":"1|0ScEFBA2aEBbGbGkaBEaDcGFABCsbJ2ACBb","pm10":"1|0QPKrgCDOge2bcHBEb2DAT2FGcqtI2DueFC","pm25":"1!53!45C!-36bhb!31qadnDKbMqENK!28RPEA!-48!-34RKD!-48kRK","so2":"1|0.7AB2ABaABaB2a2ABA2B3A2aAa3A"},"dh":24,"time":{"span":["2022-04-03T00:00:00Z","2022-04-03T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"342h38m9.49796358s"}
+
+
+        event: debug
+
+        data: "Fetching 2022-P2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2022-03-06T19:26:40Z","st":456576,"ps":{"co":"1|0FaCFaBCdADAb2afbHabcC2ADaA2abCAbAB","no2":"1|0HENcBkOaAbGieHEiFfGgAKDcAFhHdJDpgb","o3":"1|0WDBDBaAaAkCFDbBGcCeE2aCBeDcagcFECB","pm10":"1|0TDFdFnKlFBEB2dHgPde2AEjiJAdIaPNvfB","pm25":"1!42FCiAjPqAOCDBgEfKcD2AEruTIiQH!44E!-38Il","so2":"1|0B2Aa2ABaBa2AB4AaBa3ABAaABa2Bb2A"},"dh":24,"time":{"span":["2022-03-06T00:00:00Z","2022-03-06T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"1ms"}},"status":"ok","cached":"1085h49m39.497476276s"}
+
+
+        event: debug
+
+        data: "Fetching 2022-P1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2022-02-06T19:39:29Z","st":455880,"ps":{"co":"1|0C2aFEcBAdFCBcabGeBdcBaA3BbDBAaCF2a","no2":"1|0.3ELEjFPrL2ElfGHkeHe2BbIdFrEbHDFfBk","o3":"1|0!28iaIc2adbibcGIe2CEiLCbhCEAHADeCBE2A","pm10":"1|0NdDFeDFLkPEIcmAMlkBfL2BcbBdFeAEFfGn","pm25":"1!33iGVsETOlWFZhzo!40!-38lcCw!47ImndmICbEDefj","so2":"1|0CbAB5ABABa2ABcB7ABbB2ABAb2A"},"dh":24,"time":{"span":["2022-02-06T00:00:00Z","2022-02-06T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"1ms"}},"status":"ok","cached":"1757h36m50.072202038s"}
+
+
+        event: debug
+
+        data: "Fetching 2021-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2022-01-06T17:48:21Z","st":453624,"ps":{"co":"1|0C4ABaAB3A2BbC2abBCBAaBabBABA2C2aGgDacbCABcCEFedBba2DeCbDEABC2AcAfAB2AdBAB2aA2BaACbaCcEcaABA","no2":"1|0!26ahMfADfKlaDFDaFfaiFaGCeEAdEAahIGgkSiaL2aDfjbMJhDfAmGQBoEoCXigEPkoVaecdTq2DbdABbHCKncjN2eDeBaD","o3":"1|0ZCeEaegDCabCeKBjKhEGbaDCeDEdDcCboJAmQaiIabEdbiEBEaIaboICGFblPAjCEAfKaeCeFagECacDCApJDaB2FgABcK","pm10":"1|0SAcCdGEaSdo2Bb2FfAEgcAcECab2BeCaFBgMBiGhbEBhaIFBbgBdCMJk2gCLBfdGIl!30AufgHecFaiFCfbHOBkbJfjEaFHi","pm25":"1!34aAFdHIB!51h!-43EjIEMhAJrh2cCGAhMaBjaOMr!31e!-27RrEFBsDVKg2edmNXWxudAWAD!-27RYv!78b!-72zdNoBLGoMGon!26PJwBVrmj2GS!-27","so2":"1|0AB6Aa3ABAaB11A2B2AcC2aBaABAB2AbBAa2B3AaCBabABa3ACbaEBA3aAbBAa2ACAb2Ba2AaAB2ABA"},"dh":24,"time":{"span":["2022-01-02T00:00:00Z","2022-01-02T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"3ms"}},"status":"ok","cached":"2503h27m58.574122334s"}
+
+
+        event: debug
+
+        data: "Fetching 2021-Q3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2021-12-31T15:17:19Z","st":451416,"ps":{"co":"1|0GE2AfcAFBbA2aBaB2ABa2A2aAaCACAaA2BAaB3ADbaCabABa2ABaABaBa2ABa4Ab2A2aBa2A2BE2AbACB2A2aABAbc2A","no2":"1|0YekdDaGOC2eGbacbdHE2DkeD2CAkLdDhaADfaKaCBGeABeCEaDAFhFda2DeAkdBAJaC!26ErtAaHcCDRBcjfGBAFgeFEfI2ah","o3":"1|0!30EicEeCADoCaLCgKCMADCndCgOgkDcEbDGbBhEceHCjEHAehHCebHBFcAb2BbadDBdTAOb!-28DFcBiHCAHtIjOhFlKIdeDACe","pm10":"1|0UFheEbCaCaBdEcdHcHDGCdnObGpdFafBABDcAaFaBAaDCfHfaCcDaAHfADgcdACIHIDIKe!-30g2BAFcGeGJsKEcAcDeEcGeAc","pm25":"1!57NunC2dAJICcFfiEbEIHTb!-27UDdvcdfBdBQIdmdCBKeBcadPpeJAIEhbkDCE2gaLGR2CBWAxqBDk!26PozQPzIFgAfCfcACBaA","so2":"1|0Eba2BA3a16AB5AaBa43ABAa4A2Ba5AaBA"},"dh":24,"time":{"span":["2021-10-03T00:00:00Z","2021-10-03T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"5ms"}},"status":"ok","cached":"2649h59m0.501751432s"}
+
+
+        event: debug
+
+        data: "Fetching 2021-Q2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2021-12-31T15:17:24Z","st":449232,"ps":{"co":"1|0FCA3B2A2aBCBdA2BAd3BA2aCBbd2aBaADBadaBABbB2ACbDcACbBAB2aAa2AB4Aa9AB13AFE2A","no2":"1|0RhbIBbJ2AebLMmeFeBLDefFgjDRiAFfdeDFCAkBGFAEfCgHBdBcAbHbAFGngDGIgGhdBFagadH2aLhC2dCAIA2bcDHbBekd","o3":"1|0!29ECBdcaACaD2bGcDcACfDaAKdAaFgDCaEheCD2gMHbkGAbcAF2AcHgdHGfIcHMbprWqEKbqDMHlhSq2AaFCImFCB2iKIEic","pm10":"1|0!35sBHcg2FebdHKdiCbCQIL!-28bAecNEla2BcdaBEcbBDBacDcAFcGai2BCaBIAbDAEAiacCACbdbGeDHce3aCAJhCDcEg2Fhe","pm25":"1!68!-31FNbuJBEacLPh!-27AbERY!61!-83bGkj!26asgBFqCgEAFdRDQeHvpPDfGFieAHaHNJdFBCcqJlA2dcDfGEfMFfAhiCNjEaMdAnVNun","so2":"1|0Ba5ACAbA2Bb4AB5AaBABAa3ABAFAgA2Ba5ABaA2BAaABABAa2ABca4ABAa3ABAa3ABaABAa4AEbaB"},"dh":24,"time":{"span":["2021-07-04T00:00:00Z","2021-07-04T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"3ms"}},"status":"ok","cached":"2649h58m55.541730619s"}
+
+
+        event: debug
+
+        data: "Fetching 2021-Q1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2021-12-31T15:17:30Z","st":447144,"ps":{"co":"1|0HBA2CAa2bEcE2aAcaAC2BAc3aB2ABDbBaCBABACAacAeAaBACb2ADAcBADaAbAbFcACaAdDBAB2Aaea2A%ACADCAB","no2":"1|0MBDGaDb2BFgCBEdidDIadFdCgFjABIEiAFjEa2IbgcICgCBAaJiD2Eck2BGbdFBNhjbEf2aHIDlKnJFbac2fOSG!-33hbI","o3":"1|0RBfdAFANagbdDHFABbiDEdAhLEjDgPcgDfNb2AeDCBcBGbaBcqWbAdFi2dm!30baDmNcBDAdFfbAGiKfEcFa2CaHqGECB","pm10":"1|0KBAJHBgcdHjMgBEjBAFabCaBbBbEDBbabCbdbEOBgCcbAbBRfFmCDHEgLGHrqALHBmcAdAFEDdhBaLBIqcFaEKPpsBH","pm25":"1!53sC!36bNmowRcVpcHvAlWKBbdLqdbHSkAEcPqnkG!37GpHiaidbZCKzbIdaiVUM!-60kRZ!33zjqhGfNBEDqVjPCE!-27iAGF2Z!-31!-31FN","so2":"1|0.3ABAaB2ACbaBACAa2CaAbaACD3AfaABa4AB2Aa2BaACDAdE2ABAaCabd3ACa5AaB2aB2AB2aBa3A2B2a2A"},"dh":24,"time":{"span":["2021-04-04T00:00:00Z","2021-04-04T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"3ms"}},"status":"ok","cached":"2649h58m49.2683596s"}
+
+
+        event: debug
+
+        data: "Fetching 2020-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2021-01-06T19:09:19Z","st":444864,"ps":{"co":"1|0Fc2ABABbECb2abABaDba3AaAB2ACaAaCDCGcdabAaBAbABa3BbBCcBDC2aBaCaBaABDcaAaAaB2A2cABA3CbACaCAbAB","no2":"1|0YcfdEbABHAkOkbAFbAdeEIChCJbaBabeFJDFcfgFAeECjcHbAGDkGEeCH2adaEGcacbDFbjCaC2FdbgcbCFBjGfaJaIeB2d","o3":"1|0VdGAdabDeDBeBEeDdfTdC2aGfdB2DBa2AckiDbAFJ2Ec2Db3AbBgaFdjgB2JanNADdgdHDEcdDaJd2DBcABCdHdmDfDACA","pm10":"1|0KBCfGaEdFdbF2cC2aF2AdBAeADBAaCGebCF!28AqApDaCE2dEADcBcALhGBHMfjkMidC2DGcgACkFBbHdcaCDcfAc2DEAE!33rg","pm25":"1!31CbfRcGjOlkJfD2FJLeagHhgjRfIfEHjCBG!51!49!-56I!-40pacGfhDCHeLoFZpLINTgp!-36ZrAgOCNwgHnuHbdDPFiPKgsKeAUDNFIym","so2":"1|0DB2AbBbABbAC2a3ABCDAcaDBa2AbA3BcAB3Aab3ABCca2ABaACDAaDab2ACEC2bC2aCDdgC2aCcAaB2Aa2AHBbcB2bA"},"dh":24,"time":{"span":["2021-01-03T00:00:00Z","2021-01-03T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"5ms"}},"status":"ok","cached":"11262h7m0.498694874s"}
+
+
+        event: debug
+
+        data: "Fetching 2020-Q3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-12-31T18:40:16Z","st":442656,"ps":{"co":"1|0Fa5ABAda2AB5AaAB6ABABa5A2BaABAa6Aa11ADeBAaBAaA2BaAB2Aa3ABAaBaBaD2aDc2A","no2":"1|0RdeaBFKjaCBCB2aeIgdHeJGefb2AJCOubCHeH!27qtNAKyaFafGdeDCDEg2CBfaIKGkGiCacbdChBPNoeBfdQJiBjDeIcAIcfd","o3":"1|0GCGaLaBmHDEMqCdcAHBGBFEqeaBbMDW!-32DECAbYEKACDxueBKlkPdFAbCAgHb2aDEgAbBeabKacDEM2eDEblUjsL2BjaKadGA","pm10":"1|0MabBDBAcCbBEaf2AHebEaBDdcCbBFBUubaEdBIEbINGujAFkacO2cfDbBDeBEcHBeDabBfaFDgASUmnadgGCicFEbEabdBCf","pm25":"1!33deDbKIDbeHNsa2fNEiIadc2adCfPBUxgBJqO!28LeB!32d!-27!-39TX!-35mAL2DgHAgKiaEBRdgbaFcfwNKld!30!39q!-33FdjUH!-27pODAOHshCbf","so2":"1|0BaAEBa2Bbd8ABa2A3B2A2a2B2AaBaAaAaBA2BCaKhCeB2a2ACa2AbaDb2ABaBAaB3AaCBbaBAbABaBa4ABCB2A"},"dh":24,"time":{"span":["2020-10-04T00:00:00Z","2020-10-04T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"5ms"}},"status":"ok","cached":"11406h36m3.325248051s"}
+
+
+        event: debug
+
+        data: "Fetching 2020-Q2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-12-31T18:40:35Z","st":440472,"ps":{"co":"1|0F2AaAaBa4AB2aABAa7ABa4ABa3ABAaB5AaAB2Aa2AB3ABa6AaBaB2AB3AaBAaAaB4ABaA2Ba3A","no2":"1|0WJ3fMADadDglKHBmBbCA2Eag2Dc2ADad2aELgAlaGcCFEbEAEbieDCFBgCedAKEdFebcHChDaDFAEcfAdHGE2aobFAadeaB","o3":"1|0!31BACFfCD2ABElBaAcdNbCE2CmJigCAbFBDc2GECnjEABCAbFfHLmAdICbhEJdDbhgCebFGeFcDCaBdFfdbHM!32bt!-27dEdnCGaL","pm10":"1|0SdGBdBMWC2hijaNU!-28EdIBAEanBHqFcBcDFbGFgQkgc2bFabB2AdHab3B2DA2cAFkABbHBacJiAd2BaC2aJBIBdqBDcAabBD","pm25":"1!52zR2eDNUlTbmob!26!45!-65JbfiFHeoDWpAgAaNFyZFJnmlBAGAbDFhMKEmNCnjfCDeENlicHACADMQuHecGbBjaKdNdH!-31bCaHdeDb","so2":"1|0EDCAB2cABaBCcA2BaB4AB2ABaeBAa2A2aB2AC2aABaABaAaABAa4A2B2ABACbCA2bA3B7AaBaACB3Aa2baAEB"},"dh":24,"time":{"span":["2020-07-05T00:00:00Z","2020-07-05T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"5ms"}},"status":"ok","cached":"11406h35m43.854991465s"}
+
+
+        event: debug
+
+        data: "Fetching 2020-Q1"
+
+
+        event: data
+
+        data: {"msg":{"st":438288,"ps":{"co":"1|0GcAB5ABbBAbCaBCBDBfb3A2D3aB3ACba2b2CAbBcACBAaBbABCB3aDbEbdCBbBb3BbaDb2aBCACaBabAB","no2":"1|0!30caEbsOFcDdAEmQsLHcLbedIsaJNAfbaACaKCgdnSdGBCoCHAHhBgc2HcaBgBDJBoHDhJgJdbljJfCGf2aQbCidge","o3":"1|0KRalHEdbBAKcE2eaDlAjaLCdGFIAbAcGbBbra2LDbBeGebIcbEABacdC2AdHafnLHbIAecJg2AdkGFBDAaeNdGFag","pm10":"1|0!41yaBebFHQyFeBdBGcHGSckcAIhnDHhbJACaQDaojCD2bLpbLcCgKaiaFAaCFhbNdbIBmBgEFaecEBEDeCBGa2Lele","pm25":"1!116!-60kBjgMLpImeaAMGhNBUJFo!-27!39qsoLkeZDbe!27LK!-38kbaAGIqbJeFkKIpb2BFDCkaUbHDbsbdeNCpfPgKQvGMGCTUj!-34u","so2":"1|0BABaAB2AB2aCBaAa2ABCAdACaC2Ba5AbBaBA2B2ACcFabaABbBdACaAaB2AB2Aa6A2a3A2B3ABa2BEda"},"dh":24,"time":{"span":["2020-03-29T00:00:00Z","2020-03-29T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"7ms"}},"status":"ok","cached":"18060h2m29.723872649s"}
+
+
+        event: debug
+
+        data: "Fetching 2019-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:09:47+01:00","st":436080,"ps":{"co":"1|0BADb2aC2BabBAaDa2ABbaFA2bACAa2CbADAdEBA2aCBAbc2DdGbabaCc2AaABbE2BaeBaBAC2aAaBAabCaBAaCaBAa","no2":"1|0!29eT2hjVBABlTnDPeMkcrAZAjfgASeA2BnKNwRElHceJGJ!-30XCyOaga2jEBAaKJlKJGkcfgBEJCgBeKAfcIebBcbacFd","o3":"1|0ZfCdcKeFcDabHkBEAFeEAkjFTAjACblQAgbFdBf2ED2cGehcIkPkJfDJAcEhgPmAdVcEBdBeaDHA2eaIfH2dFbBgDA","pm10":"1|0SeLCgeEIgDfaBFbEb2abcNMglbBUvHMFlDBmKkKDjcCacCEKqXnFhB2cfEaHFnOJKewBc2CDAdBdFcFcdaAE2aB2DA","pm25":"1!47dNDkcCFhBaCoKDKcbcJuJSmrPA2gORkmUpNO!-27YkcodRdEVK!-51!42iFyOqCo2LMC!-29!35pR2vPdAGAhDFdELaAajD2C2APHa","so2":"1|0CaDb2aDAaBcCAaDbaABaAB2A2aAEAB4ABa2ACbAaABbBA2aCaA2aABbBa3A2CABca3ACA2aA2CbA2CAbd3AaA"},"dh":24,"time":{"span":["2019-12-29T00:00:00Z","2019-12-29T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"4ms"}},"status":"ok","cached":"13866h6m32.38265501s"}
+
+
+        event: debug
+
+        data: "Fetching 2019-Q3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:04+01:00","st":433872,"ps":{"co":"1|0DaB2AaAB2Aa3Aa3BAaBaABAbBbB5A2Bb2ABaA2BaABaBAB2Aa2B2AbAa2ABaC2DcB2AaAc2AaAb3AbB5AaCaADb2a","no2":"1|0SFGHIxGMDFmrEaFL!26!-40CoIh!33MojdedbBFCICfBDFifBGFaeBhbHOcCENBAJ!-29cBdgMAk2GmCRfcbDMmgEFKAcecnASafjNbeT2hj","o3":"1|0ZEeIHtFIBDjaAcGIFtfIac!30!-30Vxb2JhgEKBHmabCa2BeHkGgFCBGBdE!26cAC!-30cEabBbcDeEBcbdaLdEiHCbDdDcbahBGCcJfCdcK","pm10":"1|0PBDBCfBFba2cCaDGCmdJeGKFBkiBCcbEHaAcCGh2CfbacBFaAGc2BFPFiCsdEbfIbcAFfDCKjACFdHlFBGIkgHhbCebFCeLCge","pm25":"1!40SnENka2ABgCHfeKGunGdMOSdjqnSU!-29ELHFfcAbDAcelD2ABCBQcFJ!37Psb!-43hHDnIcbCGfCJGnCBPhHvc2GagigIGcfBHFdNDkc","so2":"1|0B2AaBAFdGcdAaA2B2aBaABaB2AC2BdAa3AB3Aa4ABaBaABaBaBa3AB6AGEBdDdeABb3AaA2BAaBbBCbAaCAaDb2a"},"dh":24,"time":{"span":["2019-10-06T00:00:00Z","2019-10-06T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"7ms"}},"status":"ok","cached":"13866h6m14.656581854s"}
+
+
+        event: debug
+
+        data: "Fetching 2019-Q2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:12+01:00","st":431688,"ps":{"co":"1|0IDAaAdACbC2baCAaCDAaBAaBaBAb2B2ca4AECBd2CbBAcC2a2CBda2BaCbAabCaBbBCAcbCD3aDaB2AaBCbc2ABA2aB2AaA","no2":"1|0!32LpiBFjOaCFCicIDGFcelUcabfkdNLfhdmEGSbfJlbHeciMEdBbVevbABDLfDOAEigAedEb2aKB2fRAdAcblTjdFeTvdFGHIxG","o3":"1|0!33gmKBFCcIeEcaCfm2NLFEexHaAd2bCFnAFDhGfdMBAdCDAhCGAFEDuBhGDAecSadhEA2cCDbAEAabIkfJEFMs2BCg!33!-29bEeIHtF","pm10":"1|0ZFnd2FZCiqA2aESMCdkbAQkgtEBgLIegcdIhG2AdbABANcbDaAgEacdCbaFAbCABFgBDaCkEDaCadECAbdaPFdoEHGmeBDBCfB","pm25":"1!36!31myIS!74E!-32!-45iPefQKJvDfL!44!-28!-41uEaEZYyzKgPdRCafDodB!31jdOL!-40hIEDsCabKDjEcDEBhBbdUtEcFAeDObgBfY2AtBGVxbSnENka","so2":"1|0.2C2aAa2AaA2B5AaAaBHAe2a2AaABaBaBAaCB2a6ABaAa2BbABa2BAaBbBaDABbA2a2B2aAB2ABaAaCb2AB5AaBAF"},"dh":24,"time":{"span":["2019-07-07T00:00:00Z","2019-07-07T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"16ms"}},"status":"ok","cached":"13866h6m6.880199695s"}
+
+
+        event: debug
+
+        data: "Fetching 2019-Q1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:19+01:00","st":429528,"ps":{"co":"1|0H2ACBA2aDAdBbBDbBDcCDeBFebaEBaDeaEcAaCaAaCBbCBc2AB2aBACB2Ade2A2a2EA$aBa2AbADaBa4ABCaAcCa","no2":"1|0V2FAbBGiDaBAhDSdhPpEGgCQkfoLQhKqlMGaDhFgBIClZCkhFBbCAcBPGc!-30c2eLahNbsOAEbCGfBGEAfEibaNcSgcq","o3":"1|0XaAhFfLadjbOJfaDfbChGEemGRac2fGD2bDfaJEC2dcgAHFGhGAbfhdcACRgHImKcDcECcCAFgKd2gFfF2GbcabIBA","pm10":"1|0PHENhbdabMihACbfELAHKyGNhncLHeEkEDgDCceDgNEaTEjdjCbHKAEGFAzBlgDCAiFDgGdGcbCdJGfDaB2aKeIKIv","pm25":"1!49Kd!37khmjd!27mktLceEOM!36N!-70U!34j!-35jDFIbG!27!-30CHI!-30BblNfO!34!34wp!-28BIbMV!30FLC!-51h!-28hiDJuDCDbCJieDBIMeECBFtZiQI!31!-80","so2":"1|0.3ABA2BbC3AaAC2aBa2BaBEDCBheACa2ABAaEdAaACa2Bba2BaACabA2Caba4AFadaB2ABa3ABABA2aABaBABA"},"dh":24,"time":{"span":["2019-03-31T00:00:00Z","2019-03-31T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"6ms"}},"status":"ok","cached":"13866h6m0.493777844s"}
+
+
+        event: debug
+
+        data: "Fetching 2018-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:34+01:00","st":427320,"ps":{"co":"1|0F2ADAcAEAabA2aADAa2EebAaCABaABDdEcaCb3AbCABa2ABa2AEB2ba2BcACabAFca2AaCDbDBcaAbBAaBbDEeGbdA","no2":"1|0!37JHIO!-39F!28Dji2bqbQciJPxeFdDbiBDB!26iIanBEAFcFhMCfdnBc2CJdCjcDHEaNhkCOhCAdpMNmAImOFlOcjBhDCeLgeb","o3":"1|0VbdB2EcbIlHE2ad2abCcDCgACEaDdbajIMfqSEaCcDcAclaBPbdhfAKaEfQCgC2BnK2E2AofKkDNaAGdCABdgdAiFMc","pm10":"1|0SA2FJod2EWveCjGOgdIPscDdDicaDEKcIgBYpqFabd2FAKlHigFLTdnfdDgCEfdFIfEjEfFQiFMrdHg2AFdgOCgYjpe","pm25":"1!50aKOT!-28mJH!52!-53lEjIWclM!34!-35sHAC2laAMUFDhC!46!-31!-35aGBhECIUoQusO!26!45n!-29.2nOqd2ElPEhajAdK!26iCNmvHebABDg!27Jp!51r!-39A","so2":"1|0Ba7AB2Aa2AEAdCEcB2aBAa2A2B2AbAC2Aa3ABAa3Aa2ABCAda2BHCgaAaDbB3aBCcCB2ADeCA3aACbDAcA"},"dh":24,"time":{"span":["2018-12-30T00:00:00Z","2018-12-30T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13866h5m44.98763175s"}
+
+
+        event: debug
+
+        data: "Fetching 2018-Q3"
+
+
+        event: data
+
+        data: {"msg":{"st":425112,"ps":{"co":"1|0DCAaAa3AaA3BaB2ABabB6Ab3BabA2B2AaBA2a2BABabBABa4ABa2ABA2aA2BAaBaACBbaBAaACabDFeEfE2a2ADBdB","no2":"1|0!34IB2InAlGqDLOHfIiHGaofUafQj!-27bCKFBctI!31asiB2beFHaCfhIEAjGhHfMjAGNhCoCFADaG2gLHbfLfdIGf!-27N!26bM!-38!27rcJ2HO!-39G","o3":"1|0!64qfaOgCgco2FCLCetJEAVyF2DKhu2eMGcPjCQiqlBI2bD2dFeAEHoJbD2cGdECRCDqEfbaHcfAbBF2GhfBahGBDAEfaCbaebGEc","pm10":"1|0!26da2HcEjBhJaCBeDg2CBDeABEQmgiC2DB2bcJCj3AcDADB2acBF2caABcHCaBDAGecChFeCbECeCc2BGbc2dJKdFoQncA2FJod","pm25":"1!64kaPVhQ!-32blTfDBgDnCIAQpbEL!31!-28ydDFDCahDQLzLmabFAFBe2AaCJfiBDfKMDkF2GpfGkFdCDCIgceFbGcfBJlTAJ!-30UlgaKOT!-28m","so2":"1|0FAb6AB5AB3AB2AaAbBAbAB3Aa2A2Ba2AaBaA2BA2aBAa2BaBaBb2AC3aAC3ABAbDA2aBAba4ABa6AaABaA"},"dh":24,"time":{"span":["2018-07-01T00:00:00Z","2018-10-07T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"20328h15m38.337603931s"}
+
+
+        event: debug
+
+        data: "Fetching 2018-Q2"
+
+
+        event: data
+
+        data: {"msg":{"st":422928,"ps":{"co":"1|0GbABEBabA2aBDAbC2aCc2ACa2BbcACFcDbadCB2ABb2AaA2B2AabA2Ba2AaBABb2Aa2AB3AaCAB2AaAaBABaBba4A","no2":"1|0!32NIbeIElCAncWBgLbNM!-31HgHeDIe!-27lP!37qIbdjMNjsKaneEeIKCGAtAQHoPxfRCNqamHBGgcfPnWmJfaCBh2a2ASbefc2a","o3":"1|0!27aGAbCbgeFiFBOaDABQngLmcEDjDFCaAbA2KMguBahIBJkabIAaDAjAWja2fDcEFhBCeIdAbfJcBdbAkbREBKU!-30eKcEX","pm10":"1|0RAEAeJLhaJMfdKlhbIRjIknabEbfeIDfKDGFEBrfGabdA3CIaLjcTgNbE!-29EKilACeOfbCf2AH2beaCcCJfCaGbAb2aC","pm25":"1!58Ab2fTVfOF!34sw!28v!-38B!31TqW!-27!-37HgEFbiHBgRGTPRl!-47hELAtJbdFLJ!28!-27gUHW!-30V!-30E!30w!-32cMnGDbCakFEDFneFeBdDKBHgALkfI","so2":"1|0D3AaOm2Ab2AEbaCbCA2aAC2ABac2ADaCba2ACBcBAa2Aa2AB4A2Bb4AaDbAa3ABaB2AB5ABAbBaBAB4AB"},"dh":24,"time":{"span":["2018-04-01T00:00:00Z","2018-07-01T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"20328h15m31.421212943s"}
+
+
+        event: debug
+
+        data: "Fetching 2018-Q1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:40+01:00","st":420768,"ps":{"co":"1|0DBa2Bab2CBcAa2B2AaCbBADcAbAaBCabBAaABADaDbEb2ADa3bDA2BAbDAaAabaDAaAbBaC2aC2ACbDfBaAEb2BbaA","no2":"1|0!39FlNJphBOIrJjIJGdjWmdcMEFsJoDXiyBWuPca!31!-39Z!-30!30iKaLjfpmNKchdFKAp2BMGTmgDfehLaHF!-32AFJ!39xBrfOCHBmjd","o3":"1|0!27aEeadAdmMjRfdK2DClBcGEadjKGBgHgadGabdL2d3BAEhDEhGfDb3DcabaiOCceFjFaBaKABeAJaeEDoJCBeDfCF","pm10":"1|0SIDgDCjLKeB2bFpbFaMm2CdbLIkiCQoDFehHPIjmClOhEGIBfbi!28ncIqJFiPGQ!-33eBCgJbEkEeAJeHEcCc2FDjlaEi2A","pm25":"1!48JEgCV!-31!27ZySgCH!-38iEbGCMlfaKYqsDSqd2KsIXeiqCnQaKcEOgLy!65!-31iN!-37gGU2X!38!-75zFGxVaGbehDEAJlhQic!37I!-35iAda2D","so2":"1|0EBACaeaEBCdBbBDB2aEfBAFcadBaBEabaDdaCBFeCbEc2BCcaBcaB2A2a2BAB2ABD2a2Aa2Aa2BcaAaDaBAaA2BAaBb"},"dh":24,"time":{"span":["2018-04-01T00:00:00Z","2018-04-01T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13866h5m39.134640735s"}
+
+
+        event: debug
+
+        data: "Fetching 2017-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:45+01:00","st":418560,"ps":{"co":"1|0CABaAC2AC2aC2aBABa2A2aDaBAbCdED3AeADbaDba2AEAbBcACAaBABaA2aAaFcBCA2aCAbFabeACAEb3a4ABbAa","no2":"1|0!35MjOtHBfRfAIjcDAJlCRvARfIgkGqTYaqN!-29eVdlPiAoHWfbFiaFBeLjdbEhAfATmIMKyBMne!30fH!-32CFaShAghejNhVAf!-32","o3":"1|0VD2aB2bBhHBcAaNAeqTaBAiHArKDFkabhJCGiOcqTkMhgbGAcCEGEAqHCDjEIBpAcNDBfeEabOcjgLbmaKaJGCbBqQ2C","pm10":"1|0.2NfDhEcCHdBQkBHFbGgmahJbFD2chNGDOCseKpaLiDkHJBdFfdAFDfEbfdDdDaPcaecaeOdmTmIiDCIOk2difEdbPdIt","pm25":"1!48MbaiGBCOlhRAHMAr!34l!-36BgMFGRninTEJ!26N!-35fM!-34APrIlOcRjOmkACDl!34jzcIeaB!30obhaBg!28wb!33!-28DdALI!31ujiojHlCQaG!-36","so2":"1|0DBbDd2BaDaAB2aA2Ba2AbAC2ABbBaBCADBRsD2bCcdaBE3aBaDBcDbAaBba2ADcCDabaDcbJaE3ACF2gdAD2IaoaAd"},"dh":24,"time":{"span":["2017-12-31T00:00:00Z","2017-12-31T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"8ms"}},"status":"ok","cached":"13866h5m34.404824058s"}
+
+
+        event: debug
+
+        data: "Fetching 2017-Q3"
+
+
+        event: data
+
+        data: {"msg":{"st":416352,"ps":{"co":"1|0CA2BbCa2BbBbCBAb3BbBaA2aC2Bc2AaA2BaCA2a3AaB7ABAaB2ABaAa3ABa%Ba6ABAa6AB2Aa3A","no2":"1|0!33h!28KjOtp!28lKz!30!-34Jl2NceAafhFMedEjHDdbKqIEkCESwDZmHfClEAEbGKnhSgpQiId2C%!-31GNJFbjEjbKGNBAmcGbJGdeo","o3":"1|0!27EeAFZvAJnhEKi2fVHijFcbAGh3BEaCdC2BDg!47C!-45bAJaeJifFBkbSJOreOzdHDCBja%b2D2BJHbsFcfAGcDIsaPceFa","pm10":"1|0WdDAFJldFcabHdAfJKbhcdBcGECAebNjfNecbBdbKDnDHcBaBeBCPJwOgaSmX!-28dAeAa%lEIBaAcBAbICFeAdKOAGxDhg","pm25":"1!63lFEGSqiFfadIEejFOGoAiEbMbdeadG2aBFadEKh2EpEGabAbgCD!36C!-35U2B!38!-34lhKgnFe%!-28BVHcABGFiRIjeAd!29!32a!27!-81Iqh","so2":"1|0CaDBb2AaBABbDcC2aBABaABbACAaBa2BAaAbABA2aDbaCaBABbABAaCAbaBCbCb2ACA%bA2B2AbB2aABDaCcaBA2BA2a"},"dh":24,"time":{"span":["2017-07-01T00:00:00Z","2017-10-01T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"20225h5m49.828718875s"}
+
+
+        event: debug
+
+        data: "Fetching 2017-Q2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:53+01:00","st":414168,"ps":{"co":"1|0EbCbA2BDab2BaBbCaBb3a2BaAC4AaAa5A2BA2a2BABABaBAaBAa2ABbB2aAB3ABa3AaBaCABaBAbA2aBaAa2A","no2":"1|0!50rYsAIe!27.2rHCeDiAaGVbpd2DkDNdKrcHaCagdDHSCdcmN2cb2EcPmANehiBIhOatDIaDFbldLBDCpDKTcAkfkgJIlZyBi","o3":"1|0!37cCiFcDKBjBaAdKebDdBK!26ynbcEdLBfaDABdHeabeMCehaiKGCFEt!70!-37nafBgfOcBcacBbCBDdAPkbJZD!-28!45!-39reAIhabHCE","pm10":"1|0YaLgBHBLavBCafcABFCHEnDEiAIAbBkRCEjEcB2AQnbjD2CAfabKfDJebeBdFAFgeDb!70!-67FecCDFCfCBLGbgnbeIFgaACd","pm25":"1!60F!28wHKBWh!-40eIBodHebMSEubPrDEIfDvZHBu!32kpaG!45!-28luGDSfkhbVmMCcDkBeBEWzkFbCJBdfC2GEhLDPNioydhIPBjDCl","so2":"1|0DbCbaCaC2a2BbCbAaABDabBCbaCaCbAaAaB2AaADBA2a2BAa2AaABaBA2aBCaC2a2ABaBA2aC2aCb4AB2AaAaBACbaA"},"dh":24,"time":{"span":["2017-07-02T00:00:00Z","2017-07-02T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"20ms"}},"status":"ok","cached":"13866h5m25.97856742s"}
+
+
+        event: debug
+
+        data: "Fetching 2017-Q1"
+
+
+        event: data
+
+        data: {"msg":{"st":412032,"ps":{"co":"1|0.2CbFAcBaAaBbB2ABDbaBICcbeA2aA2BbBCbDbcA3BaAa2BaBaBcA2BACac8ACAaA3Ba2A2BAda2ACBa3Aa","no2":"1|0!32RdMP!-34.2HbhJpBDNHNkcdJLcgqAbdAaEeLOuLBkI2iBALEHcefcHDpKcgRbGgAcfbKEeKflEBJbcjeOEBjdCfIJAJBjq","o3":"1|0XjGhCAbIfOcB2fbBfAEac2ABFfTaheHIFlbDEnHeFd2bKCaHcfFHCbBCDcABeJ2bcHglBcMgcBIbDaCAdALehKBGcAd","pm10":"1|0!27BFMBtDeKW!-32.3AGPQakBXKqsMDwpICiCFCeOgGAJgGKio2BAge2cCEDmCIEDAfiJBAcEJCjaIBkecFDb2Iqd!27EwBaca","pm25":"1!72hJZDoDrLhfCbdQT!26H!-35H!60Nv!-36YA!-74s!29SxneOKZxMN!29jKL!-36zmLMokiCkNBoGCFALknLEQiBVM!-37HJL!-36ceF2B!31K!-37f!65D!-56aBeF","so2":"1|0CEcBDc2BAaCBd2ABCbaBDFb2c2AaBABaABbCabaB3ABACAbAB2AbaBaDB3aBa2ACbBA2aC2BbAaCAb2a2ABCaABAb"},"dh":24,"time":{"span":["2017-01-02T00:00:00Z","2017-04-02T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"20225h5m47.42893039s"}
+
+
+        event: debug
+
+        data: "Fetching 2016-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:58+01:00","st":409800,"ps":{"co":"1|0DaDb2aBa2AC2BABaD2ba4ABC2aCB2AcCabaA3B2AaBAcAD2aAE2acEaBDIfedAECdaAaCABAaACb2A2BcAaBICdbcb","no2":"1|0!47oUlbHAncIGfAFJjTqfaGgbL2IbjIg2CLPm!-28lMNhJB2gVmKCImpIFgbEhaMPXlsgbFIafAjGBCEhCFBajIPpew!49Ua2uh!-28","o3":"1|0SFebDGjKBcfBgAPCaAg2cEahcNFbodaPb2cMcCm2Ed2DdBGFBiHCagIagECsbACMfjDGCbQoHgce2aBAIKkQEabwbDADU","pm10":"1|0XbIAafEdeG2ADHbjHgBDabCJLchCLJDkmKhCmcLlJGiDJ2fD2biIA!30!-32AGfDR!40whwC!27BmfA2fECJBJgjLgeDoJpE!27Nhfnp","pm25":"1!63AIambRenKCaHMftIkMaJhEQXnoGU!34B!-33sNrCloVvHShgRmjAcbFX!-32RvEYij!40!54lo!-66J!63R!-43hcklFMLEXgrMj!-30EtCsI!53!41og!-36!-35","so2":"1|0GdEDbdB2A4BDBeDcaBA2B2A2a2BGcfdF2aBaCbBb2aFa2ABa2BbBcAC2aCHbAaB2Ededa2ABab2BbA3BcaABCB2Aba"},"dh":24,"time":{"span":["2017-01-01T00:00:00Z","2017-01-01T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13866h5m21.018823533s"}
+
+
+        event: debug
+
+        data: "Fetching 2016-Q3"
+
+
+        event: data
+
+        data: {"msg":{"st":407592,"ps":{"co":"1|0F3AacFDaABadbDaBC2BcBAaDC2baBaDBabAaBbaDBbcbB3ABa3A2BaADcCaADaACA2acaABAaCaD2AaDAbdC4ABab","no2":"1|0!54oBGtJ!29wdfJblFQrdXNbyLFpaHaKBtcUeCdAbfc2ADRkhNBJeGscNUCpfdfd!35.2idemQaPA2h2FRCi!-31g2GEZdGkmMeAbKio","o3":"1|0XaFeGDb2fHdcCGfbDWbItgVobcdFfIBiaFBHFhcBaeLeDbGFBgcAaONojGgDJpDkHAjc!28iceJeUbFuhNkcTmFIfkaBDAcE","pm10":"1|0!26gBCcCGcbd2EeaDfaIGHoNghBDA2CehIBC2bDdAEcAEga2DI2BhjMBJClDfbH3acdIEBAgbADRdBdrCNfHaefBNjIiFhb","pm25":"1!59BeIqHRBAgFEfBeiB2KMpXsuBHFebJsIDcADElJCeCFkaCEOaN!-28jQFWKqgjFacdDejNPeCobcF!31BGsuKWiCgobgHBHjGbA","so2":"1|0Fa2AaAD2aC3AaBaA3Bac3ABaACcACAa3AaAa3BabC3AB2a3BbBaAaCBAaABaAbCAa3AaAaAB2A4B3ABCB2d"},"dh":24,"time":{"span":["2016-07-01T00:00:00Z","2016-10-02T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"3ms"}},"status":"ok","cached":"19313h6m38.500406924s"}
+
+
+        event: debug
+
+        data: "Fetching 2016-Q2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:10+01:00","st":405408,"ps":{"co":"1|0HbaAb3BbADb2A2aBDcAa3ABaACBbEcbCAB2aBCDe2aBABAaBA2aABCab6Aa3BAcCABAEda2ADCBbCdc2AGbcB2A","no2":"1|0!68miOkMjCegHNaEcvcWmABahdKh2JdnJmL!28FdqbHjAEqbKDOajFljaEDUghtdFCJFdeU!26oiVrnAHECodCAQFcAsgdZcKepB","o3":"1|0!29GgCBbi2FEsQeHhAGdFeC2AFhDCacFEfDFEgKHnra!33mcEcaAhAaEbaFbEF3d2CbcHjdPpUA2kBFEAfIjCdhQaACAgGbaF","pm10":"1|0!34bAcbabFibYoCDehAKfHDeiBFf2FDkDACHGFBpJbGAhlHFdcAadbcAJ2EbjceEaILcaQjdDdfFfBcBE2fG2DchbaMdBCgB","pm25":"1!83fJpehCLua!55!-40KACocKkEJdhDLpHKHpfDHBJTO!-38LJVourUAcfBfeajbT2GJqhjBcZUrhYcieGqBcBcKajkLJGmjAhTdGfBe","so2":"1|0FbAC4AaA2BaABabCbABaBACAaBab2A2Ba2BABa2Bba2ABCaABAcbABAaB5ABaAB2A2BABCAaAbaCabBAbaA2CbA2a"},"dh":24,"time":{"span":["2016-07-03T00:00:00Z","2016-07-03T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"7ms"}},"status":"ok","cached":"13866h5m9.27927557s"}
+
+
+        event: debug
+
+        data: "Fetching 2016-Q1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:17+01:00","st":403296,"ps":{"co":"1|0F2BbCcBCAacBDaB2Ffb2c2Aa2B2Ca2BAbcCBCBCgaABEabCdbACE2AaABAaca5A2BAbABAB2aABABCcb2A2BADba","no2":"1|0!44HBkRrbMgJkD2FbZM!-28lAnI2bMkaAaGdCGrDGMk!28rigWOasUtkAGTCdzcQDceNreHUpaLgmCDcLdgcJIBTwgba!27iDJmi","o3":"1|0TAqVhOaeabAciJbnAL2CbIEBACAdEbiB2GCagehCAN2cBbHDAcgjHAGHfEBababCbBlCFHBLgDdGdede2HC2abcACGg","pm10":"1|0ZFIrNjeEAJmCSoL!27LqmdrKBnSlEgIGiAEfeNbg!26rBfFMehGmeBKUbAlqMbdAHbBDGqWRGumAcMphBNDKAvCbdHDcJbA","pm25":"1!54H!30!-40UojNdGnF!30xN!67V!-50!-27eqDboMhBAIFeEAerQCB!35zPwKHcbCzfMJ!40Bcl!-38LeiHDUlaMi!41!45I!-45!-30dg!28!-32tA!37BTh!-38dtFHFLQfJ","so2":"1|0LABaceBCaA2bCbCFDeA2aBa2BbB6A2BABaCbBadDaBAaABaC2A3a2C2AfaAEbaBAbaB2ABA2BA2Ba2BCbAbAbA"},"dh":24,"time":{"span":["2016-04-03T00:00:00Z","2016-04-03T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13866h5m2.019550579s"}
+
+
+        event: debug
+
+        data: "Fetching 2015-Q4"
+
+
+        event: data
+
+        data: {"msg":{"st":401016,"ps":{"co":"1|0E2B2A2aACcABA2B2aBACEcB2aAC2AaAFdcaCAa2ABa3AaCaAabACDacG4AaAba2AaAB2Aa2AB3Aa2AaAaAaDaBb$BaA","no2":"1|0!42VlEiGkIMsdQbCbAnhTLci!27eljfMBgiEcBMBkhCFCJACkpVhCOjqLVfoLcehNJceBjdEKDdBhgIbKcKsELmK2khQbRp$BjJ","o3":"1|0YfdToagHgHFbBAdFBdBefQjIiadGDcibaFCICAaHbBbFe2C2AbfHmCHefMFBcCEgBGAiAaHiIiciSiEaIa2B2aCAlKB$jCG","pm10":"1|0!28IOfncBGKrMake2HghGIDcFlAJModBUKkcfkcAbFaBHcicGAGabkHOlbKhbcAEGCecbIdEcaAeJEdPl2ebgLfdF!33smd$HlC","pm25":"1!66U!43s!-28efJW!-34!28dyoULodHKHpJfgMPthB!43!41!-36lksefAeGdKkagHcFJncP!37!-43GLgqcCJIFjhaQdACfcBQMtZpdrcQjflS!38wpi$Opf","so2":"1|0C3BAB2ABd3AaBAaA2BEbBba3BaAaCa2B2aAaB3ABbaCAaCbBaCAa2Aa2ABaABaABABaBa2AaB2AaB2AaBa2ABAB$aDB"},"dh":24,"time":{"span":["2015-10-01T00:00:00Z","2016-01-03T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"19313h6m35.36064715s"}
+
+
+        event: debug
+
+        data: "Fetching 2015-Q3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:23+01:00","st":398808,"ps":{"co":"1|0Iaca2AB2aCaC2AFfCaAB2A2aAD2AcbFbABb2BcBAa5ABaCBA2aBbBaBAaAaCAa3AaBA2BAaCAcD2aCBcaCaAa4A3B","no2":"1|0!86pycgOEnDXufHeBMJfibMBeF!-31XCdnGXpCeiNMflHkFfiPpDMICjCdDhJeGDgnDKBaBbhHAcNDhgEGfIZvaKfBClafIb2aVmF","o3":"1|0!69!-32ca2cBDFHmifaEPcFarG2DcCcaEcALgStCabDNenjKdGDdJiDjGQfpBCAECc2bCBcCHha2DIcgDBABjLEjfABEBCea2DgdU","pm10":"1|0!44.2kLiaCaJebgBaDLBhcIe2aFjEAdCKdGkEaCdDBeaBbLFkACFic2BCfEaDAdHkHACcaAcbFKInABDeFDiHdeGAHdj2EDcIOf","pm25":"1!104!-27x!28sbgGeJaeHfDKadiRjbfOpJghBAVdiJdIabda2cg!27T!-30bCMhfCBFkDBDdaKrQcCAiBiaGPQugEAhPbdVewEFGBoACEBU!43s","so2":"1|0FBbBAB2Aa2BaBbAaBAaB3AaA2B2aABAaBbaE2aB2Aa2B3ABaBaABCbAbAabACA2a2AaAC2BaACBbBAc2CbBAb2aBaAaCAB"},"dh":24,"time":{"span":["2015-10-04T00:00:00Z","2015-10-04T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"6ms"}},"status":"ok","cached":"13866h4m56.646477645s"}
+
+
+        event: debug
+
+        data: "Fetching 2015-Q2"
+
+
+        event: data
+
+        data: {"msg":{"st":396624,"ps":{"co":"1|0EBAaB2A$aAb$A2BabAOCdedC2bBABa4AaBCbBaCBa2A3BabAabBAaB3AaB2A2BcAB2AC2BbaC3aD2AaDA2aCaABacaA","no2":"1|0!35HgdbHE$YD!-30.2EICqBgCOBbMQxrEJQjifcAFLTCyHIfCberKLcn!27roFhJNoNfjJbA!27c!-28cJhMNKqoFWkrBNqLc!39fG!-29BMQJpybh","o3":"1|0!29cfBGAc$aJDBgHAlGFaBbcADbdhHCAabIEcabdLagF2eGIdbeBJqEDGcEAfBACBfHhHEjEFJanaBHpLajHfGHADfhLKY!-28kEd","pm10":"1|0UDaBbFd$!37B!-34bEDGjeBAMagDUxfIBUzDAfAIcBJjFcaFgEdBcbLABfdDcEdCbaHdEJEtBGCdFRmegJbJcgiECAKfcbBIK2kLi","pm25":"1!46JFGeJu$!100e!-79i2JPxm2BRbAH!49!-48pFeJgeHabKfDI!-27LDiEHdDhAgKNdibEeNsIAhJbCLS!-39EHkFO!29jsuScDEBr2BNGdkCDE!36!-27x!28s","so2":"1|0E2A2a2B$aCaA2BAbAa4A2C2aBAB2a2BAB2aAbABAbBa2ACBcEacBbA2BC2aB3AB2bBaACACbaCBcACaBbDB2aABAaBaAB"},"dh":24,"time":{"span":["2015-04-01T00:00:00Z","2015-07-05T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"19313h6m33.494126098s"}
+
+
+        event: debug
+
+        data: "Fetching 2015-Q1"
+
+
+        event: data
+
+        data: {"msg":{"st":394464,"ps":{"co":"1|0DBAD4ABbCACbBA$AcC2AEeEfDBcAabC2Aa2A2BCA2abCBdD2AaCBABcaba2CbC4AaCc2aADA2aCbADaCcBaABaABAaB","no2":"1|0TIKaGfDBanOAIdCjkCPKhDHwOh2DAbdhLKbjnTfFIkLbkCGmH2EmdPiGRlojQFaHegACLhCioBNbBFLqgQFElJoaEmOHgdb","o3":"1|0YEgmGKAEDadIeAFmiBcAEhCSkImP2bAGnFcDAaGhBEpTCkaHFDeDEa2fcDLEcabgK2ahaCaDEeibOIDfAlGgLBcHcD2cfBG","pm10":"1|0!28kaRdjDcBiIbBACFlDKRkKM!-31No2dcHcDKbImCAQaHaMnvXfoGa2deJbGFbkaBCFEeM2fJKb2hKHUfgaxFdFJtFdeEfHDaBb","pm25":"1!75!-33H!39puCcCtOaCcIBfIUZr!32S!-82TtatEMbeQIDpfVFSbN!29!-28!-46!47j!-37LbkaeHdHcKpbaDFOiVlab!38donPX!52m!-37E!-55k!27lX!-33FArFkQJFGe","so2":"1|0DAaCBa2ABc2BCaBbaABDbaFgDb2BCAabBaAbAa2BDaBa2ABdCB3AC2abDbaCBcDb3AaBAacBDabACaAC2A2Bb2AaB2A2a"},"dh":24,"time":{"span":["2015-01-01T00:00:00Z","2015-04-05T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"19313h6m32.337539478s"}
+
+
+        event: debug
+
+        data: "Fetching 2014-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:30+01:00","st":392256,"ps":{"co":"1|0FABcBACac2BaBAaDbaACdB|35GEbCbcAaAbAbABa2ADbACbaD2BaAaACbA","no2":"1|0!36ALtGCKfiDGmADCVkhaLrH|35.2Ek2AaPcfDLkBLDcbEnWeicEcDaBndKjB","o3":"1|0RgLbAcGcDhJADtBHE2CdDe|35lAcAICJ2bkaTiHJbEzTcqOFCdFAFbibGd","pm10":"1|0!34bElcBEaAcabcBNBAgaElKDB2eFIj!26gjgcDJLwDFfecHFDefEVCAfvVk2DCIeifABFCnBIAdcPjDGldaAbDbeFCeO","pm25":"1!69DLveCFAfdECoCXbe2fMuP2GhkLPm!51xylEFT!26!-50GSokCcNKbmI!46Ddt!-36!28kJFcTfrsiPIE!-31bNcdaZqEPwheDcFfhKLlL","so2":"1|0DABcBACAbABaBAaDabACbA|35DCbA2bAaCBAaADAaBAaDA2ab2ABAba2Bb"},"dh":24,"time":{"span":["2014-12-28T00:00:00Z","2014-12-28T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"3ms"}},"status":"ok","cached":"13866h4m49.213503524s"}
+
+
+        event: debug
+
+        data: "Fetching 2014-Q3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:34+01:00","st":390048,"ps":{"co":"1|0D2BAa2A2aAB4ABa4Aa2ABAa2AHeC2aB2AaBA$BabCcAEd2ACbA2Bb3A$DCc3ABa3BaAa2ABACBbaA$3AbBC2aABcB","no2":"1|0!48ELi!-46!31cEjFGfiKAMdNmtAiIkOfBdbGTFmAGDcAFk$KBpLdaZ!-27dCSneLfeImjcKXlHaN2gIHhcDmgSajIEiaDjDUbhbNCoALtG","o3":"1|0!29aIboFfbMgdVoFaCbScjfdMBhQlfMcfCbDcABadA$cHiBaKahDaB3CjMjCeADpMJiJdDAfdbIGCjDHAo2GibF2beHaJigLbA","pm10":"1|0QGAanLdCDbAFgACHcJgA2cD2ADfeAFGBedEBabId$bBfCA2bAbEFfaENlGhCgDKcLCNFmgAfMhfaEWACcfwRHmEdcHOfgbElc","pm25":"1!49LEb!-31YiMAfGIpdGLj!29nBeiEaEGmkbMNFklIHdbSl$fbnKbceAgGTtbP!32!-35LnBmK!26lZC!28W!-34wAm!27uiAD!54GElu!-44!39!27!-37oab2YtwDLve","so2":"1|0EB2AbB2Ab2A2BaBABaA2a2A2BABACBab2aC2AaBA$BABD2CjCdBCba2Bb2aABACb3A2BAbBbB$a2Ba2BbCRfj2AbACa2ABcB"},"dh":24,"time":{"span":["2014-10-05T00:00:00Z","2014-10-05T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13866h4m45.340330489s"}
+
+
+        event: debug
+
+        data: "Fetching 2014-Q2"
+
+
+        event: data
+
+        data: {"msg":{"st":387864,"ps":{"co":"1|0EB2Aba2ABABDcaCE2aACABaBaAaABA2cACABaBbaAB2aBA$BABbB2bA$DBAa2A2B2aB2ABAb3Aa3ACaABAaA2BabCaC2AaA","no2":"1|0!50bqHijKEKcLkoMaUeufAOKEahaeEHPflgNCDadeiCEDAbaqSKDkaBekJBjIgKhPeE!-31!32hBFbfEalhKcGaFcDIhAGEolXEFLj!-46!32","o3":"1|0RdbP2bBJgACAE2cIdDAdcCAeaLg2ALk2F2GmfACcCbgIAaEShckFAfDnGAcGLfahDaMCAbdbFDhbdHlfOIecD2AdhIDCaIaqG","pm10":"1|0!45SbwqfCALeDFkBaLFqA!30ghfcLmdPIbh2g2GecACeAaBcKB2ALjgcCacABWqAcFb2aiJDhFdCEC2gDFfJeBDaDjGHieHbGAanL","pm25":"1!105!39k!-34!-42hafWiGKsDgQO!-34F!68j!-29hdV!-30g!33Vcr2qPLmfBCfgDIcQHeBZuoeAahbCAThbMcChzWPnLgfGBhvHFfYpGEVk!-30MTvmRALEb!-31Y","so2":"1|0GabFdABaCabB2aACBdA2BDaAa2AaBCAe2BAD2A3aCabBAbC2BaBaA2aACAbABC2BdCAa2BbaBAbCAa4AB2aBCAbBAC2AbA"},"dh":24,"time":{"span":["2014-04-01T00:00:00Z","2014-07-06T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"3ms"}},"status":"ok","cached":"19313h6m30.551083895s"}
+
+
+        event: debug
+
+        data: "Fetching 2014-Q1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:45+01:00","st":385704,"ps":{"co":"1|0EB3AaC2ACBAbA3abBEBd2Aa2BaEHhcBaCABAbA2BdABCabC2bCBaABEfaBaBCBAB$abaC2AcABADbEAaBc2aBABaB2ABca","no2":"1|0XG2a2ABDAOSy2AdcHfa!29gnbKsCMaAEem2CHcHgmCTAiKegIBCikRGnMIDdajhXJbmbzINqOLI!-32CKaHjNsaSCBAcgGFBbqHij","o3":"1|0!29cFdcEAfCimKMiICDnEpOABdNaAcemNEAeJEaACAmHCAFAka2ACEaFbDqIfALdkDNiGE2aqICKCnIaIbDbcbebdQ2bjeaOba","pm10":"1|0QEHicIHfcGNfkDcB2bDRGqeFgbEcbJfiGACDacaBC2aDcBEBDAlHadGbGdgOlbSJke$NjcSQG!-44dLfHagiaHDBIUbgkLSbwqf","pm25":"1!37JDadbAfOL!45p!-37Fh2DcG!40K!-44bDjgGeD!26p!-37MKEBHfhaJCeBcDKCJDyI2fSiIeg!27!-27a!34Nvg$Zqp!48!42J!-95hVoHalsAUHDS!51es!-31X!39k!-34!-42h","so2":"1|0GFh3AaCaDbABAbCAcCDBcaAaAD2bCBbAaCABAbACACab2A2BbaC2aCACaABA2BacAdBAbDAEdBC2AbCbaBaAB4ACacFcA"},"dh":24,"time":{"span":["2014-04-06T00:00:00Z","2014-04-06T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13866h4m34.484112831s"}
+
+
+        event: done
+
+        data: "1.949196ms"
+
+
+        '
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Type:
+      - text/event-stream; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:16:19 GMT
+      Server:
+      - nginx
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_historical_data/test_return_value_and_format.yaml
+++ b/tests/cassettes/test_get_historical_data/test_return_value_and_format.yaml
@@ -1,0 +1,579 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://search.waqi.info/nsearch/station/london
+  response:
+    body:
+      string: "{\"dt\":\"33.569396ms\",\"term\":\"london\",\"results\":[{\"s\":{\"a\":\"57\",\"t\":[\"2022-04-21
+        00:00:00\",\"+01:00\"],\"n\":[\"London\"],\"u\":\"london\"},\"n\":[\"London\"],\"score\":8,\"x\":5724,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"72\",\"t\":[\"2022-04-21
+        00:00:00\",\"+01:00\"],\"n\":[\"London Honor Oak Park\"],\"u\":\"united-kingdom/london-honor-oak-park\"},\"n\":[\"London
+        Honor Oak Park, United Kingdom\"],\"score\":7,\"x\":11653,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"48\",\"t\":[\"2022-04-21
+        00:00:00\",\"+01:00\"],\"n\":[\"London Teddington Bushy Park\"],\"u\":\"united-kingdom/london-teddington-bushy-park\"},\"n\":[\"London
+        Teddington Bushy Park, United Kingdom\"],\"score\":7,\"x\":3195,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"46\",\"t\":[\"2022-04-20
+        23:00:00\",\"+01:00\"],\"n\":[\"London Bexley\"],\"u\":\"united-kingdom/london-bexley\"},\"n\":[\"London
+        Bexley, United Kingdom\"],\"score\":7,\"x\":3188,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"46\",\"t\":[\"2022-04-20
+        23:00:00\",\"+01:00\"],\"n\":[\"London Harrow Stanmore\"],\"u\":\"united-kingdom/london-harrow-stanmore\"},\"n\":[\"London
+        Harrow Stanmore, United Kingdom\"],\"score\":7,\"x\":3192,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"43\",\"t\":[\"2022-04-20
+        22:00:00\",\"+01:00\"],\"n\":[\"London Harlington\"],\"u\":\"united-kingdom/london-harlington\"},\"n\":[\"London
+        Harlington, United Kingdom\"],\"score\":7,\"x\":3191,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"39\",\"t\":[\"2022-04-20
+        19:00:00\",\"-05:00\"],\"n\":[\"London, Ohio\"],\"u\":\"usa/ohio/london\"},\"n\":[\"London,
+        Ohio, USA\"],\"score\":7,\"x\":7930,\"c\":\"US\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"38\",\"t\":[\"2022-04-21
+        00:00:00\",\"+01:00\"],\"n\":[\"London Westminster\"],\"u\":\"united-kingdom/london-westminster\"},\"n\":[\"London
+        Westminster, United Kingdom\"],\"score\":7,\"x\":10874,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"34\",\"t\":[\"2022-04-20
+        20:00:00\",\"-05:00\"],\"n\":[\"London, Ontario\"],\"u\":\"canada/ontario/london\"},\"n\":[\"London,
+        Ontario, Canada\"],\"score\":7,\"x\":15,\"c\":\"CA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"34\",\"t\":[\"2022-04-20
+        23:00:00\",\"+01:00\"],\"n\":[\"London Marylebone Road\"],\"u\":\"united-kingdom/london-marylebone-road\"},\"n\":[\"London
+        Marylebone Road, United Kingdom\"],\"score\":7,\"x\":3193,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"33\",\"t\":[\"2022-04-20
+        19:00:00\",\"-05:00\"],\"n\":[\"Londonderry - Moose Hill, New Hampshire\"],\"u\":\"usa/new-hampshire/londonderry-moose-hill\"},\"n\":[\"Londonderry
+        - Moose Hill, New Hampshire, USA\"],\"score\":7,\"x\":7449,\"c\":\"US\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"32\",\"t\":[\"2022-04-20
+        22:00:00\",\"+01:00\"],\"n\":[\"London Bloomsbury\"],\"u\":\"united-kingdom/london-bloomsbury\"},\"n\":[\"London
+        Bloomsbury, United Kingdom\"],\"score\":7,\"x\":3189,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"1\",\"t\":[\"2022-04-21
+        00:00:00\",\"+01:00\"],\"n\":[\"London N. Kensington\"],\"u\":\"united-kingdom/london-n.-kensington\"},\"n\":[\"London
+        N. Kensington, United Kingdom\"],\"score\":7,\"x\":3194,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"-\",\"t\":[\"2021-12-13
+        15:00:00\",\"+01:00\"],\"n\":[\"London Eltham\"],\"u\":\"united-kingdom/london-eltham\"},\"n\":[\"London
+        Eltham, United Kingdom\"],\"score\":7,\"x\":3190,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"-\",\"t\":[\"2022-04-20
+        05:00:00\",\"+01:00\"],\"n\":[\"London Hillingdon Harmondsworth Os\"],\"u\":\"united-kingdom/london-hillingdon-harmondsworth-os\"},\"n\":[\"London
+        Hillingdon Harmondsworth Os, United Kingdom\"],\"score\":7,\"x\":3390,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"157\",\"t\":[\"2022-04-21
+        09:00:00\",\"+09:00\"],\"n\":[\"Palbong-dong, Iksan-si, Jeonbuk\",\"\uC775\uC0B0\uC2DC
+        \uD314\uBD09\uB3D9 \uC804\uBD81\"],\"u\":\"korea/jeonbuk/iksan-si\"},\"n\":[\"Palbong-dong,
+        Iksan-si, Jeonbuk, South Korea\"],\"score\":5,\"x\":1802,\"c\":\"KR\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"109\",\"t\":[\"2022-04-21
+        09:00:00\",\"+09:00\"],\"n\":[\"Wolpyeong-dong, Daejeon\",\"\uC6D4\uD3C9\uB3D9
+        \uB300\uC804\"],\"u\":\"korea/daejeon/wolpyeong-dong\"},\"n\":[\"Wolpyeong-dong,
+        Daejeon, South Korea\"],\"score\":5,\"x\":4527,\"c\":\"KR\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"57\",\"t\":[\"2022-04-21
+        00:00:00\",\"+01:00\"],\"n\":[\"City of London - Farringdon Street\"],\"u\":\"united-kingdom/city-of-london-farringdon-street\"},\"n\":[\"City
+        of London - Farringdon Street, United Kingdom\"],\"score\":5,\"x\":7949,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"26\",\"t\":[\"2022-04-20
+        20:00:00\",\"-05:00\"],\"n\":[\"Hamilton Downtown, Ontario\"],\"u\":\"canada/ontario/hamilton-downtown\"},\"n\":[\"Hamilton
+        Downtown, Ontario, Canada\"],\"score\":5,\"x\":10,\"c\":\"CA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"-\",\"t\":[\"2021-09-15
+        20:00:00\",\"+02:00\"],\"n\":[\"East London, Buffalo City Metro\"],\"u\":\"south-africa/buffalo-city-metro/east-london\"},\"n\":[\"East
+        London, Buffalo City Metro, South Africa\"],\"score\":5,\"x\":11407,\"c\":\"ZA\",\"z\":0,\"$\":\"realtime\"}]}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:07:53 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      X-Gen-Time:
+      - 33.721889ms
+      X-Powered-By:
+      - waqi-search/1.2
+      content-length:
+      - '4439'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/api/attsse/5724/yd.json
+  response:
+    body:
+      string: 'event: debug
+
+        data: "Fetching 2022-P4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2022-04-20T22:21:53+01:00","st":457992,"ps":{"co":"1|0B2CAabDaCbAba2BaCACa","no2":"1|0LEFEcDjDaHMghEFdbeAc","o3":"1|0!32BbcDAhEbFiFBAFaJfae","pm10":"1|0OFBdCdCBaCMCnALNenaJ","pm25":"1!32PGjhgANDCNCrHP!36g!-34iP","so2":"1|0.3ABa5AB3AaBaABa"},"dh":24,"time":{"span":["2022-04-20T00:00:00Z","2022-04-20T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"1ms"}},"status":"ok","cached":"3h46m1.650980208s"}
+
+
+        event: debug
+
+        data: "Fetching 2022-P3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2022-04-06T19:38:10+01:00","st":457248,"ps":{"co":"1|0.2BAaAa2BABa2AB2AIfdBCbBCb2a2ACEcaC","no2":"1|0XCInfaJc2FdeBJAgHak2DM2GjgiHhgeFCF","o3":"1|0ScEFBA2aEBbGbGkaBEaDcGFABCsbJ2ACBb","pm10":"1|0QPKrgCDOge2bcHBEb2DAT2FGcqtI2DueFC","pm25":"1!53!45C!-36bhb!31qadnDKbMqENK!28RPEA!-48!-34RKD!-48kRK","so2":"1|0.7AB2ABaABaB2a2ABA2B3A2aAa3A"},"dh":24,"time":{"span":["2022-04-03T00:00:00Z","2022-04-03T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"342h29m44.647210641s"}
+
+
+        event: debug
+
+        data: "Fetching 2022-P2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2022-03-06T19:26:40Z","st":456576,"ps":{"co":"1|0FaCFaBCdADAb2afbHabcC2ADaA2abCAbAB","no2":"1|0HENcBkOaAbGieHEiFfGgAKDcAFhHdJDpgb","o3":"1|0WDBDBaAaAkCFDbBGcCeE2aCBeDcagcFECB","pm10":"1|0TDFdFnKlFBEB2dHgPde2AEjiJAdIaPNvfB","pm25":"1!42FCiAjPqAOCDBgEfKcD2AEruTIiQH!44E!-38Il","so2":"1|0B2Aa2ABaBa2AB4AaBa3ABAaABa2Bb2A"},"dh":24,"time":{"span":["2022-03-06T00:00:00Z","2022-03-06T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"1ms"}},"status":"ok","cached":"1085h41m14.646738659s"}
+
+
+        event: debug
+
+        data: "Fetching 2022-P1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2022-02-06T19:39:29Z","st":455880,"ps":{"co":"1|0C2aFEcBAdFCBcabGeBdcBaA3BbDBAaCF2a","no2":"1|0.3ELEjFPrL2ElfGHkeHe2BbIdFrEbHDFfBk","o3":"1|0!28iaIc2adbibcGIe2CEiLCbhCEAHADeCBE2A","pm10":"1|0NdDFeDFLkPEIcmAMlkBfL2BcbBdFeAEFfGn","pm25":"1!33iGVsETOlWFZhzo!40!-38lcCw!47ImndmICbEDefj","so2":"1|0CbAB5ABABa2ABcB7ABbB2ABAb2A"},"dh":24,"time":{"span":["2022-02-06T00:00:00Z","2022-02-06T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"1ms"}},"status":"ok","cached":"1757h28m25.221425519s"}
+
+
+        event: debug
+
+        data: "Fetching 2021-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2022-01-06T17:48:21Z","st":453624,"ps":{"co":"1|0C4ABaAB3A2BbC2abBCBAaBabBABA2C2aGgDacbCABcCEFedBba2DeCbDEABC2AcAfAB2AdBAB2aA2BaACbaCcEcaABA","no2":"1|0!26ahMfADfKlaDFDaFfaiFaGCeEAdEAahIGgkSiaL2aDfjbMJhDfAmGQBoEoCXigEPkoVaecdTq2DbdABbHCKncjN2eDeBaD","o3":"1|0ZCeEaegDCabCeKBjKhEGbaDCeDEdDcCboJAmQaiIabEdbiEBEaIaboICGFblPAjCEAfKaeCeFagECacDCApJDaB2FgABcK","pm10":"1|0SAcCdGEaSdo2Bb2FfAEgcAcECab2BeCaFBgMBiGhbEBhaIFBbgBdCMJk2gCLBfdGIl!30AufgHecFaiFCfbHOBkbJfjEaFHi","pm25":"1!34aAFdHIB!51h!-43EjIEMhAJrh2cCGAhMaBjaOMr!31e!-27RrEFBsDVKg2edmNXWxudAWAD!-27RYv!78b!-72zdNoBLGoMGon!26PJwBVrmj2GS!-27","so2":"1|0AB6Aa3ABAaB11A2B2AcC2aBaABAB2AbBAa2B3AaCBabABa3ACbaEBA3aAbBAa2ACAb2Ba2AaAB2ABA"},"dh":24,"time":{"span":["2022-01-02T00:00:00Z","2022-01-02T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"3ms"}},"status":"ok","cached":"2503h19m33.723336065s"}
+
+
+        event: debug
+
+        data: "Fetching 2021-Q3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2021-12-31T15:17:19Z","st":451416,"ps":{"co":"1|0GE2AfcAFBbA2aBaB2ABa2A2aAaCACAaA2BAaB3ADbaCabABa2ABaABaBa2ABa4Ab2A2aBa2A2BE2AbACB2A2aABAbc2A","no2":"1|0YekdDaGOC2eGbacbdHE2DkeD2CAkLdDhaADfaKaCBGeABeCEaDAFhFda2DeAkdBAJaC!26ErtAaHcCDRBcjfGBAFgeFEfI2ah","o3":"1|0!30EicEeCADoCaLCgKCMADCndCgOgkDcEbDGbBhEceHCjEHAehHCebHBFcAb2BbadDBdTAOb!-28DFcBiHCAHtIjOhFlKIdeDACe","pm10":"1|0UFheEbCaCaBdEcdHcHDGCdnObGpdFafBABDcAaFaBAaDCfHfaCcDaAHfADgcdACIHIDIKe!-30g2BAFcGeGJsKEcAcDeEcGeAc","pm25":"1!57NunC2dAJICcFfiEbEIHTb!-27UDdvcdfBdBQIdmdCBKeBcadPpeJAIEhbkDCE2gaLGR2CBWAxqBDk!26PozQPzIFgAfCfcACBaA","so2":"1|0Eba2BA3a16AB5AaBa43ABAa4A2Ba5AaBA"},"dh":24,"time":{"span":["2021-10-03T00:00:00Z","2021-10-03T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"5ms"}},"status":"ok","cached":"2649h50m35.650965264s"}
+
+
+        event: debug
+
+        data: "Fetching 2021-Q2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2021-12-31T15:17:24Z","st":449232,"ps":{"co":"1|0FCA3B2A2aBCBdA2BAd3BA2aCBbd2aBaADBadaBABbB2ACbDcACbBAB2aAa2AB4Aa9AB13AFE2A","no2":"1|0RhbIBbJ2AebLMmeFeBLDefFgjDRiAFfdeDFCAkBGFAEfCgHBdBcAbHbAFGngDGIgGhdBFagadH2aLhC2dCAIA2bcDHbBekd","o3":"1|0!29ECBdcaACaD2bGcDcACfDaAKdAaFgDCaEheCD2gMHbkGAbcAF2AcHgdHGfIcHMbprWqEKbqDMHlhSq2AaFCImFCB2iKIEic","pm10":"1|0!35sBHcg2FebdHKdiCbCQIL!-28bAecNEla2BcdaBEcbBDBacDcAFcGai2BCaBIAbDAEAiacCACbdbGeDHce3aCAJhCDcEg2Fhe","pm25":"1!68!-31FNbuJBEacLPh!-27AbERY!61!-83bGkj!26asgBFqCgEAFdRDQeHvpPDfGFieAHaHNJdFBCcqJlA2dcDfGEfMFfAhiCNjEaMdAnVNun","so2":"1|0Ba5ACAbA2Bb4AB5AaBABAa3ABAFAgA2Ba5ABaA2BAaABABAa2ABca4ABAa3ABAa3ABaABAa4AEbaB"},"dh":24,"time":{"span":["2021-07-04T00:00:00Z","2021-07-04T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"3ms"}},"status":"ok","cached":"2649h50m30.690962671s"}
+
+
+        event: debug
+
+        data: "Fetching 2021-Q1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2021-12-31T15:17:30Z","st":447144,"ps":{"co":"1|0HBA2CAa2bEcE2aAcaAC2BAc3aB2ABDbBaCBABACAacAeAaBACb2ADAcBADaAbAbFcACaAdDBAB2Aaea2A%ACADCAB","no2":"1|0MBDGaDb2BFgCBEdidDIadFdCgFjABIEiAFjEa2IbgcICgCBAaJiD2Eck2BGbdFBNhjbEf2aHIDlKnJFbac2fOSG!-33hbI","o3":"1|0RBfdAFANagbdDHFABbiDEdAhLEjDgPcgDfNb2AeDCBcBGbaBcqWbAdFi2dm!30baDmNcBDAdFfbAGiKfEcFa2CaHqGECB","pm10":"1|0KBAJHBgcdHjMgBEjBAFabCaBbBbEDBbabCbdbEOBgCcbAbBRfFmCDHEgLGHrqALHBmcAdAFEDdhBaLBIqcFaEKPpsBH","pm25":"1!53sC!36bNmowRcVpcHvAlWKBbdLqdbHSkAEcPqnkG!37GpHiaidbZCKzbIdaiVUM!-60kRZ!33zjqhGfNBEDqVjPCE!-27iAGF2Z!-31!-31FN","so2":"1|0.3ABAaB2ACbaBACAa2CaAbaACD3AfaABa4AB2Aa2BaACDAdE2ABAaCabd3ACa5AaB2aB2AB2aBa3A2B2a2A"},"dh":24,"time":{"span":["2021-04-04T00:00:00Z","2021-04-04T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"3ms"}},"status":"ok","cached":"2649h50m24.417584872s"}
+
+
+        event: debug
+
+        data: "Fetching 2020-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2021-01-06T19:09:19Z","st":444864,"ps":{"co":"1|0Fc2ABABbECb2abABaDba3AaAB2ACaAaCDCGcdabAaBAbABa3BbBCcBDC2aBaCaBaABDcaAaAaB2A2cABA3CbACaCAbAB","no2":"1|0YcfdEbABHAkOkbAFbAdeEIChCJbaBabeFJDFcfgFAeECjcHbAGDkGEeCH2adaEGcacbDFbjCaC2FdbgcbCFBjGfaJaIeB2d","o3":"1|0VdGAdabDeDBeBEeDdfTdC2aGfdB2DBa2AckiDbAFJ2Ec2Db3AbBgaFdjgB2JanNADdgdHDEcdDaJd2DBcABCdHdmDfDACA","pm10":"1|0KBCfGaEdFdbF2cC2aF2AdBAeADBAaCGebCF!28AqApDaCE2dEADcBcALhGBHMfjkMidC2DGcgACkFBbHdcaCDcfAc2DEAE!33rg","pm25":"1!31CbfRcGjOlkJfD2FJLeagHhgjRfIfEHjCBG!51!49!-56I!-40pacGfhDCHeLoFZpLINTgp!-36ZrAgOCNwgHnuHbdDPFiPKgsKeAUDNFIym","so2":"1|0DB2AbBbABbAC2a3ABCDAcaDBa2AbA3BcAB3Aab3ABCca2ABaACDAaDab2ACEC2bC2aCDdgC2aCcAaB2Aa2AHBbcB2bA"},"dh":24,"time":{"span":["2021-01-03T00:00:00Z","2021-01-03T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"5ms"}},"status":"ok","cached":"11261h58m35.647913857s"}
+
+
+        event: debug
+
+        data: "Fetching 2020-Q3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-12-31T18:40:16Z","st":442656,"ps":{"co":"1|0Fa5ABAda2AB5AaAB6ABABa5A2BaABAa6Aa11ADeBAaBAaA2BaAB2Aa3ABAaBaBaD2aDc2A","no2":"1|0RdeaBFKjaCBCB2aeIgdHeJGefb2AJCOubCHeH!27qtNAKyaFafGdeDCDEg2CBfaIKGkGiCacbdChBPNoeBfdQJiBjDeIcAIcfd","o3":"1|0GCGaLaBmHDEMqCdcAHBGBFEqeaBbMDW!-32DECAbYEKACDxueBKlkPdFAbCAgHb2aDEgAbBeabKacDEM2eDEblUjsL2BjaKadGA","pm10":"1|0MabBDBAcCbBEaf2AHebEaBDdcCbBFBUubaEdBIEbINGujAFkacO2cfDbBDeBEcHBeDabBfaFDgASUmnadgGCicFEbEabdBCf","pm25":"1!33deDbKIDbeHNsa2fNEiIadc2adCfPBUxgBJqO!28LeB!32d!-27!-39TX!-35mAL2DgHAgKiaEBRdgbaFcfwNKld!30!39q!-33FdjUH!-27pODAOHshCbf","so2":"1|0BaAEBa2Bbd8ABa2A3B2A2a2B2AaBaAaAaBA2BCaKhCeB2a2ACa2AbaDb2ABaBAaB3AaCBbaBAbABaBa4ABCB2A"},"dh":24,"time":{"span":["2020-10-04T00:00:00Z","2020-10-04T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"5ms"}},"status":"ok","cached":"11406h27m38.474473822s"}
+
+
+        event: debug
+
+        data: "Fetching 2020-Q2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-12-31T18:40:35Z","st":440472,"ps":{"co":"1|0F2AaAaBa4AB2aABAa7ABa4ABa3ABAaB5AaAB2Aa2AB3ABa6AaBaB2AB3AaBAaAaB4ABaA2Ba3A","no2":"1|0WJ3fMADadDglKHBmBbCA2Eag2Dc2ADad2aELgAlaGcCFEbEAEbieDCFBgCedAKEdFebcHChDaDFAEcfAdHGE2aobFAadeaB","o3":"1|0!31BACFfCD2ABElBaAcdNbCE2CmJigCAbFBDc2GECnjEABCAbFfHLmAdICbhEJdDbhgCebFGeFcDCaBdFfdbHM!32bt!-27dEdnCGaL","pm10":"1|0SdGBdBMWC2hijaNU!-28EdIBAEanBHqFcBcDFbGFgQkgc2bFabB2AdHab3B2DA2cAFkABbHBacJiAd2BaC2aJBIBdqBDcAabBD","pm25":"1!52zR2eDNUlTbmob!26!45!-65JbfiFHeoDWpAgAaNFyZFJnmlBAGAbDFhMKEmNCnjfCDeENlicHACADMQuHecGbBjaKdNdH!-31bCaHdeDb","so2":"1|0EDCAB2cABaBCcA2BaB4AB2ABaeBAa2A2aB2AC2aABaABaAaABAa4A2B2ABACbCA2bA3B7AaBaACB3Aa2baAEB"},"dh":24,"time":{"span":["2020-07-05T00:00:00Z","2020-07-05T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"5ms"}},"status":"ok","cached":"11406h27m19.004255208s"}
+
+
+        event: debug
+
+        data: "Fetching 2020-Q1"
+
+
+        event: data
+
+        data: {"msg":{"st":438288,"ps":{"co":"1|0GcAB5ABbBAbCaBCBDBfb3A2D3aB3ACba2b2CAbBcACBAaBbABCB3aDbEbdCBbBb3BbaDb2aBCACaBabAB","no2":"1|0!30caEbsOFcDdAEmQsLHcLbedIsaJNAfbaACaKCgdnSdGBCoCHAHhBgc2HcaBgBDJBoHDhJgJdbljJfCGf2aQbCidge","o3":"1|0KRalHEdbBAKcE2eaDlAjaLCdGFIAbAcGbBbra2LDbBeGebIcbEABacdC2AdHafnLHbIAecJg2AdkGFBDAaeNdGFag","pm10":"1|0!41yaBebFHQyFeBdBGcHGSckcAIhnDHhbJACaQDaojCD2bLpbLcCgKaiaFAaCFhbNdbIBmBgEFaecEBEDeCBGa2Lele","pm25":"1!116!-60kBjgMLpImeaAMGhNBUJFo!-27!39qsoLkeZDbe!27LK!-38kbaAGIqbJeFkKIpb2BFDCkaUbHDbsbdeNCpfPgKQvGMGCTUj!-34u","so2":"1|0BABaAB2AB2aCBaAa2ABCAdACaC2Ba5AbBaBA2B2ACcFabaABbBdACaAaB2AB2Aa6A2a3A2B3ABa2BEda"},"dh":24,"time":{"span":["2020-03-29T00:00:00Z","2020-03-29T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"7ms"}},"status":"ok","cached":"18059h54m4.873145392s"}
+
+
+        event: debug
+
+        data: "Fetching 2019-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:09:47+01:00","st":436080,"ps":{"co":"1|0BADb2aC2BabBAaDa2ABbaFA2bACAa2CbADAdEBA2aCBAbc2DdGbabaCc2AaABbE2BaeBaBAC2aAaBAabCaBAaCaBAa","no2":"1|0!29eT2hjVBABlTnDPeMkcrAZAjfgASeA2BnKNwRElHceJGJ!-30XCyOaga2jEBAaKJlKJGkcfgBEJCgBeKAfcIebBcbacFd","o3":"1|0ZfCdcKeFcDabHkBEAFeEAkjFTAjACblQAgbFdBf2ED2cGehcIkPkJfDJAcEhgPmAdVcEBdBeaDHA2eaIfH2dFbBgDA","pm10":"1|0SeLCgeEIgDfaBFbEb2abcNMglbBUvHMFlDBmKkKDjcCacCEKqXnFhB2cfEaHFnOJKewBc2CDAdBdFcFcdaAE2aB2DA","pm25":"1!47dNDkcCFhBaCoKDKcbcJuJSmrPA2gORkmUpNO!-27YkcodRdEVK!-51!42iFyOqCo2LMC!-29!35pR2vPdAGAhDFdELaAajD2C2APHa","so2":"1|0CaDb2aDAaBcCAaDbaABaAB2A2aAEAB4ABa2ACbAaABbBA2aCaA2aABbBa3A2CABca3ACA2aA2CbA2CAbd3AaA"},"dh":24,"time":{"span":["2019-12-29T00:00:00Z","2019-12-29T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"4ms"}},"status":"ok","cached":"13865h58m7.531935232s"}
+
+
+        event: debug
+
+        data: "Fetching 2019-Q3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:04+01:00","st":433872,"ps":{"co":"1|0DaB2AaAB2Aa3Aa3BAaBaABAbBbB5A2Bb2ABaA2BaABaBAB2Aa2B2AbAa2ABaC2DcB2AaAc2AaAb3AbB5AaCaADb2a","no2":"1|0SFGHIxGMDFmrEaFL!26!-40CoIh!33MojdedbBFCICfBDFifBGFaeBhbHOcCENBAJ!-29cBdgMAk2GmCRfcbDMmgEFKAcecnASafjNbeT2hj","o3":"1|0ZEeIHtFIBDjaAcGIFtfIac!30!-30Vxb2JhgEKBHmabCa2BeHkGgFCBGBdE!26cAC!-30cEabBbcDeEBcbdaLdEiHCbDdDcbahBGCcJfCdcK","pm10":"1|0PBDBCfBFba2cCaDGCmdJeGKFBkiBCcbEHaAcCGh2CfbacBFaAGc2BFPFiCsdEbfIbcAFfDCKjACFdHlFBGIkgHhbCebFCeLCge","pm25":"1!40SnENka2ABgCHfeKGunGdMOSdjqnSU!-29ELHFfcAbDAcelD2ABCBQcFJ!37Psb!-43hHDnIcbCGfCJGnCBPhHvc2GagigIGcfBHFdNDkc","so2":"1|0B2AaBAFdGcdAaA2B2aBaABaB2AC2BdAa3AB3Aa4ABaBaABaBaBa3AB6AGEBdDdeABb3AaA2BAaBbBCbAaCAaDb2a"},"dh":24,"time":{"span":["2019-10-06T00:00:00Z","2019-10-06T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"7ms"}},"status":"ok","cached":"13865h57m49.805855477s"}
+
+
+        event: debug
+
+        data: "Fetching 2019-Q2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:12+01:00","st":431688,"ps":{"co":"1|0IDAaAdACbC2baCAaCDAaBAaBaBAb2B2ca4AECBd2CbBAcC2a2CBda2BaCbAabCaBbBCAcbCD3aDaB2AaBCbc2ABA2aB2AaA","no2":"1|0!32LpiBFjOaCFCicIDGFcelUcabfkdNLfhdmEGSbfJlbHeciMEdBbVevbABDLfDOAEigAedEb2aKB2fRAdAcblTjdFeTvdFGHIxG","o3":"1|0!33gmKBFCcIeEcaCfm2NLFEexHaAd2bCFnAFDhGfdMBAdCDAhCGAFEDuBhGDAecSadhEA2cCDbAEAabIkfJEFMs2BCg!33!-29bEeIHtF","pm10":"1|0ZFnd2FZCiqA2aESMCdkbAQkgtEBgLIegcdIhG2AdbABANcbDaAgEacdCbaFAbCABFgBDaCkEDaCadECAbdaPFdoEHGmeBDBCfB","pm25":"1!36!31myIS!74E!-32!-45iPefQKJvDfL!44!-28!-41uEaEZYyzKgPdRCafDodB!31jdOL!-40hIEDsCabKDjEcDEBhBbdUtEcFAeDObgBfY2AtBGVxbSnENka","so2":"1|0.2C2aAa2AaA2B5AaAaBHAe2a2AaABaBaBAaCB2a6ABaAa2BbABa2BAaBbBaDABbA2a2B2aAB2ABaAaCb2AB5AaBAF"},"dh":24,"time":{"span":["2019-07-07T00:00:00Z","2019-07-07T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"16ms"}},"status":"ok","cached":"13865h57m42.029495289s"}
+
+
+        event: debug
+
+        data: "Fetching 2019-Q1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:19+01:00","st":429528,"ps":{"co":"1|0H2ACBA2aDAdBbBDbBDcCDeBFebaEBaDeaEcAaCaAaCBbCBc2AB2aBACB2Ade2A2a2EA$aBa2AbADaBa4ABCaAcCa","no2":"1|0V2FAbBGiDaBAhDSdhPpEGgCQkfoLQhKqlMGaDhFgBIClZCkhFBbCAcBPGc!-30c2eLahNbsOAEbCGfBGEAfEibaNcSgcq","o3":"1|0XaAhFfLadjbOJfaDfbChGEemGRac2fGD2bDfaJEC2dcgAHFGhGAbfhdcACRgHImKcDcECcCAFgKd2gFfF2GbcabIBA","pm10":"1|0PHENhbdabMihACbfELAHKyGNhncLHeEkEDgDCceDgNEaTEjdjCbHKAEGFAzBlgDCAiFDgGdGcbCdJGfDaB2aKeIKIv","pm25":"1!49Kd!37khmjd!27mktLceEOM!36N!-70U!34j!-35jDFIbG!27!-30CHI!-30BblNfO!34!34wp!-28BIbMV!30FLC!-51h!-28hiDJuDCDbCJieDBIMeECBFtZiQI!31!-80","so2":"1|0.3ABA2BbC3AaAC2aBa2BaBEDCBheACa2ABAaEdAaACa2Bba2BaACabA2Caba4AFadaB2ABa3ABABA2aABaBABA"},"dh":24,"time":{"span":["2019-03-31T00:00:00Z","2019-03-31T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"6ms"}},"status":"ok","cached":"13865h57m35.643072057s"}
+
+
+        event: debug
+
+        data: "Fetching 2018-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:34+01:00","st":427320,"ps":{"co":"1|0F2ADAcAEAabA2aADAa2EebAaCABaABDdEcaCb3AbCABa2ABa2AEB2ba2BcACabAFca2AaCDbDBcaAbBAaBbDEeGbdA","no2":"1|0!37JHIO!-39F!28Dji2bqbQciJPxeFdDbiBDB!26iIanBEAFcFhMCfdnBc2CJdCjcDHEaNhkCOhCAdpMNmAImOFlOcjBhDCeLgeb","o3":"1|0VbdB2EcbIlHE2ad2abCcDCgACEaDdbajIMfqSEaCcDcAclaBPbdhfAKaEfQCgC2BnK2E2AofKkDNaAGdCABdgdAiFMc","pm10":"1|0SA2FJod2EWveCjGOgdIPscDdDicaDEKcIgBYpqFabd2FAKlHigFLTdnfdDgCEfdFIfEjEfFQiFMrdHg2AFdgOCgYjpe","pm25":"1!50aKOT!-28mJH!52!-53lEjIWclM!34!-35sHAC2laAMUFDhC!46!-31!-35aGBhECIUoQusO!26!45n!-29.2nOqd2ElPEhajAdK!26iCNmvHebABDg!27Jp!51r!-39A","so2":"1|0Ba7AB2Aa2AEAdCEcB2aBAa2A2B2AbAC2Aa3ABAa3Aa2ABCAda2BHCgaAaDbB3aBCcCB2ADeCA3aACbDAcA"},"dh":24,"time":{"span":["2018-12-30T00:00:00Z","2018-12-30T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13865h57m20.136921813s"}
+
+
+        event: debug
+
+        data: "Fetching 2018-Q3"
+
+
+        event: data
+
+        data: {"msg":{"st":425112,"ps":{"co":"1|0DCAaAa3AaA3BaB2ABabB6Ab3BabA2B2AaBA2a2BABabBABa4ABa2ABA2aA2BAaBaACBbaBAaACabDFeEfE2a2ADBdB","no2":"1|0!34IB2InAlGqDLOHfIiHGaofUafQj!-27bCKFBctI!31asiB2beFHaCfhIEAjGhHfMjAGNhCoCFADaG2gLHbfLfdIGf!-27N!26bM!-38!27rcJ2HO!-39G","o3":"1|0!64qfaOgCgco2FCLCetJEAVyF2DKhu2eMGcPjCQiqlBI2bD2dFeAEHoJbD2cGdECRCDqEfbaHcfAbBF2GhfBahGBDAEfaCbaebGEc","pm10":"1|0!26da2HcEjBhJaCBeDg2CBDeABEQmgiC2DB2bcJCj3AcDADB2acBF2caABcHCaBDAGecChFeCbECeCc2BGbc2dJKdFoQncA2FJod","pm25":"1!64kaPVhQ!-32blTfDBgDnCIAQpbEL!31!-28ydDFDCahDQLzLmabFAFBe2AaCJfiBDfKMDkF2GpfGkFdCDCIgceFbGcfBJlTAJ!-30UlgaKOT!-28m","so2":"1|0FAb6AB5AB3AB2AaAbBAbAB3Aa2A2Ba2AaBaA2BA2aBAa2BaBaBb2AC3aAC3ABAbDA2aBAba4ABa6AaABaA"},"dh":24,"time":{"span":["2018-07-01T00:00:00Z","2018-10-07T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"20328h7m13.486886785s"}
+
+
+        event: debug
+
+        data: "Fetching 2018-Q2"
+
+
+        event: data
+
+        data: {"msg":{"st":422928,"ps":{"co":"1|0GbABEBabA2aBDAbC2aCc2ACa2BbcACFcDbadCB2ABb2AaA2B2AabA2Ba2AaBABb2Aa2AB3AaCAB2AaAaBABaBba4A","no2":"1|0!32NIbeIElCAncWBgLbNM!-31HgHeDIe!-27lP!37qIbdjMNjsKaneEeIKCGAtAQHoPxfRCNqamHBGgcfPnWmJfaCBh2a2ASbefc2a","o3":"1|0!27aGAbCbgeFiFBOaDABQngLmcEDjDFCaAbA2KMguBahIBJkabIAaDAjAWja2fDcEFhBCeIdAbfJcBdbAkbREBKU!-30eKcEX","pm10":"1|0RAEAeJLhaJMfdKlhbIRjIknabEbfeIDfKDGFEBrfGabdA3CIaLjcTgNbE!-29EKilACeOfbCf2AH2beaCcCJfCaGbAb2aC","pm25":"1!58Ab2fTVfOF!34sw!28v!-38B!31TqW!-27!-37HgEFbiHBgRGTPRl!-47hELAtJbdFLJ!28!-27gUHW!-30V!-30E!30w!-32cMnGDbCakFEDFneFeBdDKBHgALkfI","so2":"1|0D3AaOm2Ab2AEbaCbCA2aAC2ABac2ADaCba2ACBcBAa2Aa2AB4A2Bb4AaDbAa3ABaB2AB5ABAbBaBAB4AB"},"dh":24,"time":{"span":["2018-04-01T00:00:00Z","2018-07-01T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"20328h7m6.570474596s"}
+
+
+        event: debug
+
+        data: "Fetching 2018-Q1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:40+01:00","st":420768,"ps":{"co":"1|0DBa2Bab2CBcAa2B2AaCbBADcAbAaBCabBAaABADaDbEb2ADa3bDA2BAbDAaAabaDAaAbBaC2aC2ACbDfBaAEb2BbaA","no2":"1|0!39FlNJphBOIrJjIJGdjWmdcMEFsJoDXiyBWuPca!31!-39Z!-30!30iKaLjfpmNKchdFKAp2BMGTmgDfehLaHF!-32AFJ!39xBrfOCHBmjd","o3":"1|0!27aEeadAdmMjRfdK2DClBcGEadjKGBgHgadGabdL2d3BAEhDEhGfDb3DcabaiOCceFjFaBaKABeAJaeEDoJCBeDfCF","pm10":"1|0SIDgDCjLKeB2bFpbFaMm2CdbLIkiCQoDFehHPIjmClOhEGIBfbi!28ncIqJFiPGQ!-33eBCgJbEkEeAJeHEcCc2FDjlaEi2A","pm25":"1!48JEgCV!-31!27ZySgCH!-38iEbGCMlfaKYqsDSqd2KsIXeiqCnQaKcEOgLy!65!-31iN!-37gGU2X!38!-75zFGxVaGbehDEAJlhQic!37I!-35iAda2D","so2":"1|0EBACaeaEBCdBbBDB2aEfBAFcadBaBEabaDdaCBFeCbEc2BCcaBcaB2A2a2BAB2ABD2a2Aa2Aa2BcaAaDaBAaA2BAaBb"},"dh":24,"time":{"span":["2018-04-01T00:00:00Z","2018-04-01T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13865h57m14.283888427s"}
+
+
+        event: debug
+
+        data: "Fetching 2017-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:45+01:00","st":418560,"ps":{"co":"1|0CABaAC2AC2aC2aBABa2A2aDaBAbCdED3AeADbaDba2AEAbBcACAaBABaA2aAaFcBCA2aCAbFabeACAEb3a4ABbAa","no2":"1|0!35MjOtHBfRfAIjcDAJlCRvARfIgkGqTYaqN!-29eVdlPiAoHWfbFiaFBeLjdbEhAfATmIMKyBMne!30fH!-32CFaShAghejNhVAf!-32","o3":"1|0VD2aB2bBhHBcAaNAeqTaBAiHArKDFkabhJCGiOcqTkMhgbGAcCEGEAqHCDjEIBpAcNDBfeEabOcjgLbmaKaJGCbBqQ2C","pm10":"1|0.2NfDhEcCHdBQkBHFbGgmahJbFD2chNGDOCseKpaLiDkHJBdFfdAFDfEbfdDdDaPcaecaeOdmTmIiDCIOk2difEdbPdIt","pm25":"1!48MbaiGBCOlhRAHMAr!34l!-36BgMFGRninTEJ!26N!-35fM!-34APrIlOcRjOmkACDl!34jzcIeaB!30obhaBg!28wb!33!-28DdALI!31ujiojHlCQaG!-36","so2":"1|0DBbDd2BaDaAB2aA2Ba2AbAC2ABbBaBCADBRsD2bCcdaBE3aBaDBcDbAaBba2ADcCDabaDcbJaE3ACF2gdAD2IaoaAd"},"dh":24,"time":{"span":["2017-12-31T00:00:00Z","2017-12-31T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"8ms"}},"status":"ok","cached":"13865h57m9.5540771s"}
+
+
+        event: debug
+
+        data: "Fetching 2017-Q3"
+
+
+        event: data
+
+        data: {"msg":{"st":416352,"ps":{"co":"1|0CA2BbCa2BbBbCBAb3BbBaA2aC2Bc2AaA2BaCA2a3AaB7ABAaB2ABaAa3ABa%Ba6ABAa6AB2Aa3A","no2":"1|0!33h!28KjOtp!28lKz!30!-34Jl2NceAafhFMedEjHDdbKqIEkCESwDZmHfClEAEbGKnhSgpQiId2C%!-31GNJFbjEjbKGNBAmcGbJGdeo","o3":"1|0!27EeAFZvAJnhEKi2fVHijFcbAGh3BEaCdC2BDg!47C!-45bAJaeJifFBkbSJOreOzdHDCBja%b2D2BJHbsFcfAGcDIsaPceFa","pm10":"1|0WdDAFJldFcabHdAfJKbhcdBcGECAebNjfNecbBdbKDnDHcBaBeBCPJwOgaSmX!-28dAeAa%lEIBaAcBAbICFeAdKOAGxDhg","pm25":"1!63lFEGSqiFfadIEejFOGoAiEbMbdeadG2aBFadEKh2EpEGabAbgCD!36C!-35U2B!38!-34lhKgnFe%!-28BVHcABGFiRIjeAd!29!32a!27!-81Iqh","so2":"1|0CaDBb2AaBABbDcC2aBABaABbACAaBa2BAaAbABA2aDbaCaBABbABAaCAbaBCbCb2ACA%bA2B2AbB2aABDaCcaBA2BA2a"},"dh":24,"time":{"span":["2017-07-01T00:00:00Z","2017-10-01T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"20224h57m24.977945547s"}
+
+
+        event: debug
+
+        data: "Fetching 2017-Q2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:53+01:00","st":414168,"ps":{"co":"1|0EbCbA2BDab2BaBbCaBb3a2BaAC4AaAa5A2BA2a2BABABaBAaBAa2ABbB2aAB3ABa3AaBaCABaBAbA2aBaAa2A","no2":"1|0!50rYsAIe!27.2rHCeDiAaGVbpd2DkDNdKrcHaCagdDHSCdcmN2cb2EcPmANehiBIhOatDIaDFbldLBDCpDKTcAkfkgJIlZyBi","o3":"1|0!37cCiFcDKBjBaAdKebDdBK!26ynbcEdLBfaDABdHeabeMCehaiKGCFEt!70!-37nafBgfOcBcacBbCBDdAPkbJZD!-28!45!-39reAIhabHCE","pm10":"1|0YaLgBHBLavBCafcABFCHEnDEiAIAbBkRCEjEcB2AQnbjD2CAfabKfDJebeBdFAFgeDb!70!-67FecCDFCfCBLGbgnbeIFgaACd","pm25":"1!60F!28wHKBWh!-40eIBodHebMSEubPrDEIfDvZHBu!32kpaG!45!-28luGDSfkhbVmMCcDkBeBEWzkFbCJBdfC2GEhLDPNioydhIPBjDCl","so2":"1|0DbCbaCaC2a2BbCbAaABDabBCbaCaCbAaAaB2AaADBA2a2BAa2AaABaBA2aBCaC2a2ABaBA2aC2aCb4AB2AaAaBACbaA"},"dh":24,"time":{"span":["2017-07-02T00:00:00Z","2017-07-02T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"20ms"}},"status":"ok","cached":"13865h57m1.127753482s"}
+
+
+        event: debug
+
+        data: "Fetching 2017-Q1"
+
+
+        event: data
+
+        data: {"msg":{"st":412032,"ps":{"co":"1|0.2CbFAcBaAaBbB2ABDbaBICcbeA2aA2BbBCbDbcA3BaAa2BaBaBcA2BACac8ACAaA3Ba2A2BAda2ACBa3Aa","no2":"1|0!32RdMP!-34.2HbhJpBDNHNkcdJLcgqAbdAaEeLOuLBkI2iBALEHcefcHDpKcgRbGgAcfbKEeKflEBJbcjeOEBjdCfIJAJBjq","o3":"1|0XjGhCAbIfOcB2fbBfAEac2ABFfTaheHIFlbDEnHeFd2bKCaHcfFHCbBCDcABeJ2bcHglBcMgcBIbDaCAdALehKBGcAd","pm10":"1|0!27BFMBtDeKW!-32.3AGPQakBXKqsMDwpICiCFCeOgGAJgGKio2BAge2cCEDmCIEDAfiJBAcEJCjaIBkecFDb2Iqd!27EwBaca","pm25":"1!72hJZDoDrLhfCbdQT!26H!-35H!60Nv!-36YA!-74s!29SxneOKZxMN!29jKL!-36zmLMokiCkNBoGCFALknLEQiBVM!-37HJL!-36ceF2B!31K!-37f!65D!-56aBeF","so2":"1|0CEcBDc2BAaCBd2ABCbaBDFb2c2AaBABaABbCabaB3ABACAbAB2AbaBaDB3aBa2ACbBA2aC2BbAaCAb2a2ABCaABAb"},"dh":24,"time":{"span":["2017-01-02T00:00:00Z","2017-04-02T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"20224h57m22.57811205s"}
+
+
+        event: debug
+
+        data: "Fetching 2016-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:58+01:00","st":409800,"ps":{"co":"1|0DaDb2aBa2AC2BABaD2ba4ABC2aCB2AcCabaA3B2AaBAcAD2aAE2acEaBDIfedAECdaAaCABAaACb2A2BcAaBICdbcb","no2":"1|0!47oUlbHAncIGfAFJjTqfaGgbL2IbjIg2CLPm!-28lMNhJB2gVmKCImpIFgbEhaMPXlsgbFIafAjGBCEhCFBajIPpew!49Ua2uh!-28","o3":"1|0SFebDGjKBcfBgAPCaAg2cEahcNFbodaPb2cMcCm2Ed2DdBGFBiHCagIagECsbACMfjDGCbQoHgce2aBAIKkQEabwbDADU","pm10":"1|0XbIAafEdeG2ADHbjHgBDabCJLchCLJDkmKhCmcLlJGiDJ2fD2biIA!30!-32AGfDR!40whwC!27BmfA2fECJBJgjLgeDoJpE!27Nhfnp","pm25":"1!63AIambRenKCaHMftIkMaJhEQXnoGU!34B!-33sNrCloVvHShgRmjAcbFX!-32RvEYij!40!54lo!-66J!63R!-43hcklFMLEXgrMj!-30EtCsI!53!41og!-36!-35","so2":"1|0GdEDbdB2A4BDBeDcaBA2B2A2a2BGcfdF2aBaCbBb2aFa2ABa2BbBcAC2aCHbAaB2Ededa2ABab2BbA3BcaABCB2Aba"},"dh":24,"time":{"span":["2017-01-01T00:00:00Z","2017-01-01T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13865h56m56.168025855s"}
+
+
+        event: debug
+
+        data: "Fetching 2016-Q3"
+
+
+        event: data
+
+        data: {"msg":{"st":407592,"ps":{"co":"1|0F3AacFDaABadbDaBC2BcBAaDC2baBaDBabAaBbaDBbcbB3ABa3A2BaADcCaADaACA2acaABAaCaD2AaDAbdC4ABab","no2":"1|0!54oBGtJ!29wdfJblFQrdXNbyLFpaHaKBtcUeCdAbfc2ADRkhNBJeGscNUCpfdfd!35.2idemQaPA2h2FRCi!-31g2GEZdGkmMeAbKio","o3":"1|0XaFeGDb2fHdcCGfbDWbItgVobcdFfIBiaFBHFhcBaeLeDbGFBgcAaONojGgDJpDkHAjc!28iceJeUbFuhNkcTmFIfkaBDAcE","pm10":"1|0!26gBCcCGcbd2EeaDfaIGHoNghBDA2CehIBC2bDdAEcAEga2DI2BhjMBJClDfbH3acdIEBAgbADRdBdrCNfHaefBNjIiFhb","pm25":"1!59BeIqHRBAgFEfBeiB2KMpXsuBHFebJsIDcADElJCeCFkaCEOaN!-28jQFWKqgjFacdDejNPeCobcF!31BGsuKWiCgobgHBHjGbA","so2":"1|0Fa2AaAD2aC3AaBaA3Bac3ABaACcACAa3AaAa3BabC3AB2a3BbBaAaCBAaABaAbCAa3AaAaAB2A4B3ABCB2d"},"dh":24,"time":{"span":["2016-07-01T00:00:00Z","2016-10-02T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"3ms"}},"status":"ok","cached":"19312h58m13.649650516s"}
+
+
+        event: debug
+
+        data: "Fetching 2016-Q2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:10+01:00","st":405408,"ps":{"co":"1|0HbaAb3BbADb2A2aBDcAa3ABaACBbEcbCAB2aBCDe2aBABAaBA2aABCab6Aa3BAcCABAEda2ADCBbCdc2AGbcB2A","no2":"1|0!68miOkMjCegHNaEcvcWmABahdKh2JdnJmL!28FdqbHjAEqbKDOajFljaEDUghtdFCJFdeU!26oiVrnAHECodCAQFcAsgdZcKepB","o3":"1|0!29GgCBbi2FEsQeHhAGdFeC2AFhDCacFEfDFEgKHnra!33mcEcaAhAaEbaFbEF3d2CbcHjdPpUA2kBFEAfIjCdhQaACAgGbaF","pm10":"1|0!34bAcbabFibYoCDehAKfHDeiBFf2FDkDACHGFBpJbGAhlHFdcAadbcAJ2EbjceEaILcaQjdDdfFfBcBE2fG2DchbaMdBCgB","pm25":"1!83fJpehCLua!55!-40KACocKkEJdhDLpHKHpfDHBJTO!-38LJVourUAcfBfeajbT2GJqhjBcZUrhYcieGqBcBcKajkLJGmjAhTdGfBe","so2":"1|0FbAC4AaA2BaABabCbABaBACAaBab2A2Ba2BABa2Bba2ABCaABAcbABAaB5ABaAB2A2BABCAaAbaCabBAbaA2CbA2a"},"dh":24,"time":{"span":["2016-07-03T00:00:00Z","2016-07-03T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"7ms"}},"status":"ok","cached":"13865h56m44.428506372s"}
+
+
+        event: debug
+
+        data: "Fetching 2016-Q1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:17+01:00","st":403296,"ps":{"co":"1|0F2BbCcBCAacBDaB2Ffb2c2Aa2B2Ca2BAbcCBCBCgaABEabCdbACE2AaABAaca5A2BAbABAB2aABABCcb2A2BADba","no2":"1|0!44HBkRrbMgJkD2FbZM!-28lAnI2bMkaAaGdCGrDGMk!28rigWOasUtkAGTCdzcQDceNreHUpaLgmCDcLdgcJIBTwgba!27iDJmi","o3":"1|0TAqVhOaeabAciJbnAL2CbIEBACAdEbiB2GCagehCAN2cBbHDAcgjHAGHfEBababCbBlCFHBLgDdGdede2HC2abcACGg","pm10":"1|0ZFIrNjeEAJmCSoL!27LqmdrKBnSlEgIGiAEfeNbg!26rBfFMehGmeBKUbAlqMbdAHbBDGqWRGumAcMphBNDKAvCbdHDcJbA","pm25":"1!54H!30!-40UojNdGnF!30xN!67V!-50!-27eqDboMhBAIFeEAerQCB!35zPwKHcbCzfMJ!40Bcl!-38LeiHDUlaMi!41!45I!-45!-30dg!28!-32tA!37BTh!-38dtFHFLQfJ","so2":"1|0LABaceBCaA2bCbCFDeA2aBa2BbB6A2BABaCbBadDaBAaABaC2A3a2C2AfaAEbaBAbaB2ABA2BA2Ba2BCbAbAbA"},"dh":24,"time":{"span":["2016-04-03T00:00:00Z","2016-04-03T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13865h56m37.16876308s"}
+
+
+        event: debug
+
+        data: "Fetching 2015-Q4"
+
+
+        event: data
+
+        data: {"msg":{"st":401016,"ps":{"co":"1|0E2B2A2aACcABA2B2aBACEcB2aAC2AaAFdcaCAa2ABa3AaCaAabACDacG4AaAba2AaAB2Aa2AB3Aa2AaAaAaDaBb$BaA","no2":"1|0!42VlEiGkIMsdQbCbAnhTLci!27eljfMBgiEcBMBkhCFCJACkpVhCOjqLVfoLcehNJceBjdEKDdBhgIbKcKsELmK2khQbRp$BjJ","o3":"1|0YfdToagHgHFbBAdFBdBefQjIiadGDcibaFCICAaHbBbFe2C2AbfHmCHefMFBcCEgBGAiAaHiIiciSiEaIa2B2aCAlKB$jCG","pm10":"1|0!28IOfncBGKrMake2HghGIDcFlAJModBUKkcfkcAbFaBHcicGAGabkHOlbKhbcAEGCecbIdEcaAeJEdPl2ebgLfdF!33smd$HlC","pm25":"1!66U!43s!-28efJW!-34!28dyoULodHKHpJfgMPthB!43!41!-36lksefAeGdKkagHcFJncP!37!-43GLgqcCJIFjhaQdACfcBQMtZpdrcQjflS!38wpi$Opf","so2":"1|0C3BAB2ABd3AaBAaA2BEbBba3BaAaCa2B2aAaB3ABbaCAaCbBaCAa2Aa2ABaABaABABaBa2AaB2AaB2AaBa2ABAB$aDB"},"dh":24,"time":{"span":["2015-10-01T00:00:00Z","2016-01-03T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"19312h58m10.509849891s"}
+
+
+        event: debug
+
+        data: "Fetching 2015-Q3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:23+01:00","st":398808,"ps":{"co":"1|0Iaca2AB2aCaC2AFfCaAB2A2aAD2AcbFbABb2BcBAa5ABaCBA2aBbBaBAaAaCAa3AaBA2BAaCAcD2aCBcaCaAa4A3B","no2":"1|0!86pycgOEnDXufHeBMJfibMBeF!-31XCdnGXpCeiNMflHkFfiPpDMICjCdDhJeGDgnDKBaBbhHAcNDhgEGfIZvaKfBClafIb2aVmF","o3":"1|0!69!-32ca2cBDFHmifaEPcFarG2DcCcaEcALgStCabDNenjKdGDdJiDjGQfpBCAECc2bCBcCHha2DIcgDBABjLEjfABEBCea2DgdU","pm10":"1|0!44.2kLiaCaJebgBaDLBhcIe2aFjEAdCKdGkEaCdDBeaBbLFkACFic2BCfEaDAdHkHACcaAcbFKInABDeFDiHdeGAHdj2EDcIOf","pm25":"1!104!-27x!28sbgGeJaeHfDKadiRjbfOpJghBAVdiJdIabda2cg!27T!-30bCMhfCBFkDBDdaKrQcCAiBiaGPQugEAhPbdVewEFGBoACEBU!43s","so2":"1|0FBbBAB2Aa2BaBbAaBAaB3AaA2B2aABAaBbaE2aB2Aa2B3ABaBaABCbAbAabACA2a2AaAC2BaACBbBAc2CbBAb2aBaAaCAB"},"dh":24,"time":{"span":["2015-10-04T00:00:00Z","2015-10-04T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"6ms"}},"status":"ok","cached":"13865h56m31.795667487s"}
+
+
+        event: debug
+
+        data: "Fetching 2015-Q2"
+
+
+        event: data
+
+        data: {"msg":{"st":396624,"ps":{"co":"1|0EBAaB2A$aAb$A2BabAOCdedC2bBABa4AaBCbBaCBa2A3BabAabBAaB3AaB2A2BcAB2AC2BbaC3aD2AaDA2aCaABacaA","no2":"1|0!35HgdbHE$YD!-30.2EICqBgCOBbMQxrEJQjifcAFLTCyHIfCberKLcn!27roFhJNoNfjJbA!27c!-28cJhMNKqoFWkrBNqLc!39fG!-29BMQJpybh","o3":"1|0!29cfBGAc$aJDBgHAlGFaBbcADbdhHCAabIEcabdLagF2eGIdbeBJqEDGcEAfBACBfHhHEjEFJanaBHpLajHfGHADfhLKY!-28kEd","pm10":"1|0UDaBbFd$!37B!-34bEDGjeBAMagDUxfIBUzDAfAIcBJjFcaFgEdBcbLABfdDcEdCbaHdEJEtBGCdFRmegJbJcgiECAKfcbBIK2kLi","pm25":"1!46JFGeJu$!100e!-79i2JPxm2BRbAH!49!-48pFeJgeHabKfDI!-27LDiEHdDhAgKNdibEeNsIAhJbCLS!-39EHkFO!29jsuScDEBr2BNGdkCDE!36!-27x!28s","so2":"1|0E2A2a2B$aCaA2BAbAa4A2C2aBAB2a2BAB2aAbABAbBa2ACBcEacBbA2BC2aB3AB2bBaACACbaCBcACaBbDB2aABAaBaAB"},"dh":24,"time":{"span":["2015-04-01T00:00:00Z","2015-07-05T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"19312h58m8.643322358s"}
+
+
+        event: debug
+
+        data: "Fetching 2015-Q1"
+
+
+        event: data
+
+        data: {"msg":{"st":394464,"ps":{"co":"1|0DBAD4ABbCACbBA$AcC2AEeEfDBcAabC2Aa2A2BCA2abCBdD2AaCBABcaba2CbC4AaCc2aADA2aCbADaCcBaABaABAaB","no2":"1|0TIKaGfDBanOAIdCjkCPKhDHwOh2DAbdhLKbjnTfFIkLbkCGmH2EmdPiGRlojQFaHegACLhCioBNbBFLqgQFElJoaEmOHgdb","o3":"1|0YEgmGKAEDadIeAFmiBcAEhCSkImP2bAGnFcDAaGhBEpTCkaHFDeDEa2fcDLEcabgK2ahaCaDEeibOIDfAlGgLBcHcD2cfBG","pm10":"1|0!28kaRdjDcBiIbBACFlDKRkKM!-31No2dcHcDKbImCAQaHaMnvXfoGa2deJbGFbkaBCFEeM2fJKb2hKHUfgaxFdFJtFdeEfHDaBb","pm25":"1!75!-33H!39puCcCtOaCcIBfIUZr!32S!-82TtatEMbeQIDpfVFSbN!29!-28!-46!47j!-37LbkaeHdHcKpbaDFOiVlab!38donPX!52m!-37E!-55k!27lX!-33FArFkQJFGe","so2":"1|0DAaCBa2ABc2BCaBbaABDbaFgDb2BCAabBaAbAa2BDaBa2ABdCB3AC2abDbaCBcDb3AaBAacBDabACaAC2A2Bb2AaB2A2a"},"dh":24,"time":{"span":["2015-01-01T00:00:00Z","2015-04-05T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"19312h58m7.48673204s"}
+
+
+        event: debug
+
+        data: "Fetching 2014-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:30+01:00","st":392256,"ps":{"co":"1|0FABcBACac2BaBAaDbaACdB|35GEbCbcAaAbAbABa2ADbACbaD2BaAaACbA","no2":"1|0!36ALtGCKfiDGmADCVkhaLrH|35.2Ek2AaPcfDLkBLDcbEnWeicEcDaBndKjB","o3":"1|0RgLbAcGcDhJADtBHE2CdDe|35lAcAICJ2bkaTiHJbEzTcqOFCdFAFbibGd","pm10":"1|0!34bElcBEaAcabcBNBAgaElKDB2eFIj!26gjgcDJLwDFfecHFDefEVCAfvVk2DCIeifABFCnBIAdcPjDGldaAbDbeFCeO","pm25":"1!69DLveCFAfdECoCXbe2fMuP2GhkLPm!51xylEFT!26!-50GSokCcNKbmI!46Ddt!-36!28kJFcTfrsiPIE!-31bNcdaZqEPwheDcFfhKLlL","so2":"1|0DABcBACAbABaBAaDabACbA|35DCbA2bAaCBAaADAaBAaDA2ab2ABAba2Bb"},"dh":24,"time":{"span":["2014-12-28T00:00:00Z","2014-12-28T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"3ms"}},"status":"ok","cached":"13865h56m24.362695796s"}
+
+
+        event: debug
+
+        data: "Fetching 2014-Q3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:34+01:00","st":390048,"ps":{"co":"1|0D2BAa2A2aAB4ABa4Aa2ABAa2AHeC2aB2AaBA$BabCcAEd2ACbA2Bb3A$DCc3ABa3BaAa2ABACBbaA$3AbBC2aABcB","no2":"1|0!48ELi!-46!31cEjFGfiKAMdNmtAiIkOfBdbGTFmAGDcAFk$KBpLdaZ!-27dCSneLfeImjcKXlHaN2gIHhcDmgSajIEiaDjDUbhbNCoALtG","o3":"1|0!29aIboFfbMgdVoFaCbScjfdMBhQlfMcfCbDcABadA$cHiBaKahDaB3CjMjCeADpMJiJdDAfdbIGCjDHAo2GibF2beHaJigLbA","pm10":"1|0QGAanLdCDbAFgACHcJgA2cD2ADfeAFGBedEBabId$bBfCA2bAbEFfaENlGhCgDKcLCNFmgAfMhfaEWACcfwRHmEdcHOfgbElc","pm25":"1!49LEb!-31YiMAfGIpdGLj!29nBeiEaEGmkbMNFklIHdbSl$fbnKbceAgGTtbP!32!-35LnBmK!26lZC!28W!-34wAm!27uiAD!54GElu!-44!39!27!-37oab2YtwDLve","so2":"1|0EB2AbB2Ab2A2BaBABaA2a2A2BABACBab2aC2AaBA$BABD2CjCdBCba2Bb2aABACb3A2BAbBbB$a2Ba2BbCRfj2AbACa2ABcB"},"dh":24,"time":{"span":["2014-10-05T00:00:00Z","2014-10-05T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13865h56m20.48953056s"}
+
+
+        event: debug
+
+        data: "Fetching 2014-Q2"
+
+
+        event: data
+
+        data: {"msg":{"st":387864,"ps":{"co":"1|0EB2Aba2ABABDcaCE2aACABaBaAaABA2cACABaBbaAB2aBA$BABbB2bA$DBAa2A2B2aB2ABAb3Aa3ACaABAaA2BabCaC2AaA","no2":"1|0!50bqHijKEKcLkoMaUeufAOKEahaeEHPflgNCDadeiCEDAbaqSKDkaBekJBjIgKhPeE!-31!32hBFbfEalhKcGaFcDIhAGEolXEFLj!-46!32","o3":"1|0RdbP2bBJgACAE2cIdDAdcCAeaLg2ALk2F2GmfACcCbgIAaEShckFAfDnGAcGLfahDaMCAbdbFDhbdHlfOIecD2AdhIDCaIaqG","pm10":"1|0!45SbwqfCALeDFkBaLFqA!30ghfcLmdPIbh2g2GecACeAaBcKB2ALjgcCacABWqAcFb2aiJDhFdCEC2gDFfJeBDaDjGHieHbGAanL","pm25":"1!105!39k!-34!-42hafWiGKsDgQO!-34F!68j!-29hdV!-30g!33Vcr2qPLmfBCfgDIcQHeBZuoeAahbCAThbMcChzWPnLgfGBhvHFfYpGEVk!-30MTvmRALEb!-31Y","so2":"1|0GabFdABaCabB2aACBdA2BDaAa2AaBCAe2BAD2A3aCabBAbC2BaBaA2aACAbABC2BdCAa2BbaBAbCAa4AB2aBCAbBAC2AbA"},"dh":24,"time":{"span":["2014-04-01T00:00:00Z","2014-07-06T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"3ms"}},"status":"ok","cached":"19312h58m5.700260946s"}
+
+
+        event: debug
+
+        data: "Fetching 2014-Q1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:45+01:00","st":385704,"ps":{"co":"1|0EB3AaC2ACBAbA3abBEBd2Aa2BaEHhcBaCABAbA2BdABCabC2bCBaABEfaBaBCBAB$abaC2AcABADbEAaBc2aBABaB2ABca","no2":"1|0XG2a2ABDAOSy2AdcHfa!29gnbKsCMaAEem2CHcHgmCTAiKegIBCikRGnMIDdajhXJbmbzINqOLI!-32CKaHjNsaSCBAcgGFBbqHij","o3":"1|0!29cFdcEAfCimKMiICDnEpOABdNaAcemNEAeJEaACAmHCAFAka2ACEaFbDqIfALdkDNiGE2aqICKCnIaIbDbcbebdQ2bjeaOba","pm10":"1|0QEHicIHfcGNfkDcB2bDRGqeFgbEcbJfiGACDacaBC2aDcBEBDAlHadGbGdgOlbSJke$NjcSQG!-44dLfHagiaHDBIUbgkLSbwqf","pm25":"1!37JDadbAfOL!45p!-37Fh2DcG!40K!-44bDjgGeD!26p!-37MKEBHfhaJCeBcDKCJDyI2fSiIeg!27!-27a!34Nvg$Zqp!48!42J!-95hVoHalsAUHDS!51es!-31X!39k!-34!-42h","so2":"1|0GFh3AaCaDbABAbCAcCDBcaAaAD2bCBbAaCABAbACACab2A2BbaC2aCACaABA2BacAdBAbDAEdBC2AbCbaBaAB4ACacFcA"},"dh":24,"time":{"span":["2014-04-06T00:00:00Z","2014-04-06T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13865h56m9.633288552s"}
+
+
+        event: done
+
+        data: "1.985686ms"
+
+
+        '
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Type:
+      - text/event-stream; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:07:54 GMT
+      Server:
+      - nginx
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_historical_data/test_warnings_on_input_combo.yaml
+++ b/tests/cassettes/test_get_historical_data/test_warnings_on_input_combo.yaml
@@ -1,0 +1,1575 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://search.waqi.info/nsearch/station/london
+  response:
+    body:
+      string: "{\"dt\":\"32.34701ms\",\"term\":\"london\",\"results\":[{\"s\":{\"a\":\"57\",\"t\":[\"2022-04-21
+        00:00:00\",\"+01:00\"],\"n\":[\"London\"],\"u\":\"london\"},\"n\":[\"London\"],\"score\":8,\"x\":5724,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"72\",\"t\":[\"2022-04-21
+        00:00:00\",\"+01:00\"],\"n\":[\"London Honor Oak Park\"],\"u\":\"united-kingdom/london-honor-oak-park\"},\"n\":[\"London
+        Honor Oak Park, United Kingdom\"],\"score\":7,\"x\":11653,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"48\",\"t\":[\"2022-04-21
+        00:00:00\",\"+01:00\"],\"n\":[\"London Teddington Bushy Park\"],\"u\":\"united-kingdom/london-teddington-bushy-park\"},\"n\":[\"London
+        Teddington Bushy Park, United Kingdom\"],\"score\":7,\"x\":3195,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"46\",\"t\":[\"2022-04-20
+        23:00:00\",\"+01:00\"],\"n\":[\"London Bexley\"],\"u\":\"united-kingdom/london-bexley\"},\"n\":[\"London
+        Bexley, United Kingdom\"],\"score\":7,\"x\":3188,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"46\",\"t\":[\"2022-04-20
+        23:00:00\",\"+01:00\"],\"n\":[\"London Harrow Stanmore\"],\"u\":\"united-kingdom/london-harrow-stanmore\"},\"n\":[\"London
+        Harrow Stanmore, United Kingdom\"],\"score\":7,\"x\":3192,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"43\",\"t\":[\"2022-04-20
+        22:00:00\",\"+01:00\"],\"n\":[\"London Harlington\"],\"u\":\"united-kingdom/london-harlington\"},\"n\":[\"London
+        Harlington, United Kingdom\"],\"score\":7,\"x\":3191,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"39\",\"t\":[\"2022-04-20
+        19:00:00\",\"-05:00\"],\"n\":[\"London, Ohio\"],\"u\":\"usa/ohio/london\"},\"n\":[\"London,
+        Ohio, USA\"],\"score\":7,\"x\":7930,\"c\":\"US\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"38\",\"t\":[\"2022-04-21
+        00:00:00\",\"+01:00\"],\"n\":[\"London Westminster\"],\"u\":\"united-kingdom/london-westminster\"},\"n\":[\"London
+        Westminster, United Kingdom\"],\"score\":7,\"x\":10874,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"34\",\"t\":[\"2022-04-20
+        20:00:00\",\"-05:00\"],\"n\":[\"London, Ontario\"],\"u\":\"canada/ontario/london\"},\"n\":[\"London,
+        Ontario, Canada\"],\"score\":7,\"x\":15,\"c\":\"CA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"34\",\"t\":[\"2022-04-20
+        23:00:00\",\"+01:00\"],\"n\":[\"London Marylebone Road\"],\"u\":\"united-kingdom/london-marylebone-road\"},\"n\":[\"London
+        Marylebone Road, United Kingdom\"],\"score\":7,\"x\":3193,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"33\",\"t\":[\"2022-04-20
+        19:00:00\",\"-05:00\"],\"n\":[\"Londonderry - Moose Hill, New Hampshire\"],\"u\":\"usa/new-hampshire/londonderry-moose-hill\"},\"n\":[\"Londonderry
+        - Moose Hill, New Hampshire, USA\"],\"score\":7,\"x\":7449,\"c\":\"US\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"32\",\"t\":[\"2022-04-20
+        22:00:00\",\"+01:00\"],\"n\":[\"London Bloomsbury\"],\"u\":\"united-kingdom/london-bloomsbury\"},\"n\":[\"London
+        Bloomsbury, United Kingdom\"],\"score\":7,\"x\":3189,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"1\",\"t\":[\"2022-04-21
+        00:00:00\",\"+01:00\"],\"n\":[\"London N. Kensington\"],\"u\":\"united-kingdom/london-n.-kensington\"},\"n\":[\"London
+        N. Kensington, United Kingdom\"],\"score\":7,\"x\":3194,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"-\",\"t\":[\"2021-12-13
+        15:00:00\",\"+01:00\"],\"n\":[\"London Eltham\"],\"u\":\"united-kingdom/london-eltham\"},\"n\":[\"London
+        Eltham, United Kingdom\"],\"score\":7,\"x\":3190,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"-\",\"t\":[\"2022-04-20
+        05:00:00\",\"+01:00\"],\"n\":[\"London Hillingdon Harmondsworth Os\"],\"u\":\"united-kingdom/london-hillingdon-harmondsworth-os\"},\"n\":[\"London
+        Hillingdon Harmondsworth Os, United Kingdom\"],\"score\":7,\"x\":3390,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"157\",\"t\":[\"2022-04-21
+        09:00:00\",\"+09:00\"],\"n\":[\"Palbong-dong, Iksan-si, Jeonbuk\",\"\uC775\uC0B0\uC2DC
+        \uD314\uBD09\uB3D9 \uC804\uBD81\"],\"u\":\"korea/jeonbuk/iksan-si\"},\"n\":[\"Palbong-dong,
+        Iksan-si, Jeonbuk, South Korea\"],\"score\":5,\"x\":1802,\"c\":\"KR\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"109\",\"t\":[\"2022-04-21
+        09:00:00\",\"+09:00\"],\"n\":[\"Wolpyeong-dong, Daejeon\",\"\uC6D4\uD3C9\uB3D9
+        \uB300\uC804\"],\"u\":\"korea/daejeon/wolpyeong-dong\"},\"n\":[\"Wolpyeong-dong,
+        Daejeon, South Korea\"],\"score\":5,\"x\":4527,\"c\":\"KR\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"57\",\"t\":[\"2022-04-21
+        00:00:00\",\"+01:00\"],\"n\":[\"City of London - Farringdon Street\"],\"u\":\"united-kingdom/city-of-london-farringdon-street\"},\"n\":[\"City
+        of London - Farringdon Street, United Kingdom\"],\"score\":5,\"x\":7949,\"c\":\"GB\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"26\",\"t\":[\"2022-04-20
+        20:00:00\",\"-05:00\"],\"n\":[\"Hamilton Downtown, Ontario\"],\"u\":\"canada/ontario/hamilton-downtown\"},\"n\":[\"Hamilton
+        Downtown, Ontario, Canada\"],\"score\":5,\"x\":10,\"c\":\"CA\",\"z\":0,\"$\":\"realtime\"},{\"s\":{\"a\":\"-\",\"t\":[\"2021-09-15
+        20:00:00\",\"+02:00\"],\"n\":[\"East London, Buffalo City Metro\"],\"u\":\"south-africa/buffalo-city-metro/east-london\"},\"n\":[\"East
+        London, Buffalo City Metro, South Africa\"],\"score\":5,\"x\":11407,\"c\":\"ZA\",\"z\":0,\"$\":\"realtime\"}]}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:09:13 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      X-Gen-Time:
+      - 32.536366ms
+      X-Powered-By:
+      - waqi-search/1.2
+      content-length:
+      - '4438'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/api/attsse/5724/yd.json
+  response:
+    body:
+      string: 'event: debug
+
+        data: "Fetching 2022-P4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2022-04-20T22:21:53+01:00","st":457992,"ps":{"co":"1|0B2CAabDaCbAba2BaCACa","no2":"1|0LEFEcDjDaHMghEFdbeAc","o3":"1|0!32BbcDAhEbFiFBAFaJfae","pm10":"1|0OFBdCdCBaCMCnALNenaJ","pm25":"1!32PGjhgANDCNCrHP!36g!-34iP","so2":"1|0.3ABa5AB3AaBaABa"},"dh":24,"time":{"span":["2022-04-20T00:00:00Z","2022-04-20T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"1ms"}},"status":"ok","cached":"3h47m21.703277846s"}
+
+
+        event: debug
+
+        data: "Fetching 2022-P3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2022-04-06T19:38:10+01:00","st":457248,"ps":{"co":"1|0.2BAaAa2BABa2AB2AIfdBCbBCb2a2ACEcaC","no2":"1|0XCInfaJc2FdeBJAgHak2DM2GjgiHhgeFCF","o3":"1|0ScEFBA2aEBbGbGkaBEaDcGFABCsbJ2ACBb","pm10":"1|0QPKrgCDOge2bcHBEb2DAT2FGcqtI2DueFC","pm25":"1!53!45C!-36bhb!31qadnDKbMqENK!28RPEA!-48!-34RKD!-48kRK","so2":"1|0.7AB2ABaABaB2a2ABA2B3A2aAa3A"},"dh":24,"time":{"span":["2022-04-03T00:00:00Z","2022-04-03T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"342h31m4.69956549s"}
+
+
+        event: debug
+
+        data: "Fetching 2022-P2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2022-03-06T19:26:40Z","st":456576,"ps":{"co":"1|0FaCFaBCdADAb2afbHabcC2ADaA2abCAbAB","no2":"1|0HENcBkOaAbGieHEiFfGgAKDcAFhHdJDpgb","o3":"1|0WDBDBaAaAkCFDbBGcCeE2aCBeDcagcFECB","pm10":"1|0TDFdFnKlFBEB2dHgPde2AEjiJAdIaPNvfB","pm25":"1!42FCiAjPqAOCDBgEfKcD2AEruTIiQH!44E!-38Il","so2":"1|0B2Aa2ABaBa2AB4AaBa3ABAaABa2Bb2A"},"dh":24,"time":{"span":["2022-03-06T00:00:00Z","2022-03-06T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"1ms"}},"status":"ok","cached":"1085h42m34.699103397s"}
+
+
+        event: debug
+
+        data: "Fetching 2022-P1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2022-02-06T19:39:29Z","st":455880,"ps":{"co":"1|0C2aFEcBAdFCBcabGeBdcBaA3BbDBAaCF2a","no2":"1|0.3ELEjFPrL2ElfGHkeHe2BbIdFrEbHDFfBk","o3":"1|0!28iaIc2adbibcGIe2CEiLCbhCEAHADeCBE2A","pm10":"1|0NdDFeDFLkPEIcmAMlkBfL2BcbBdFeAEFfGn","pm25":"1!33iGVsETOlWFZhzo!40!-38lcCw!47ImndmICbEDefj","so2":"1|0CbAB5ABABa2ABcB7ABbB2ABAb2A"},"dh":24,"time":{"span":["2022-02-06T00:00:00Z","2022-02-06T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"1ms"}},"status":"ok","cached":"1757h29m45.273786968s"}
+
+
+        event: debug
+
+        data: "Fetching 2021-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2022-01-06T17:48:21Z","st":453624,"ps":{"co":"1|0C4ABaAB3A2BbC2abBCBAaBabBABA2C2aGgDacbCABcCEFedBba2DeCbDEABC2AcAfAB2AdBAB2aA2BaACbaCcEcaABA","no2":"1|0!26ahMfADfKlaDFDaFfaiFaGCeEAdEAahIGgkSiaL2aDfjbMJhDfAmGQBoEoCXigEPkoVaecdTq2DbdABbHCKncjN2eDeBaD","o3":"1|0ZCeEaegDCabCeKBjKhEGbaDCeDEdDcCboJAmQaiIabEdbiEBEaIaboICGFblPAjCEAfKaeCeFagECacDCApJDaB2FgABcK","pm10":"1|0SAcCdGEaSdo2Bb2FfAEgcAcECab2BeCaFBgMBiGhbEBhaIFBbgBdCMJk2gCLBfdGIl!30AufgHecFaiFCfbHOBkbJfjEaFHi","pm25":"1!34aAFdHIB!51h!-43EjIEMhAJrh2cCGAhMaBjaOMr!31e!-27RrEFBsDVKg2edmNXWxudAWAD!-27RYv!78b!-72zdNoBLGoMGon!26PJwBVrmj2GS!-27","so2":"1|0AB6Aa3ABAaB11A2B2AcC2aBaABAB2AbBAa2B3AaCBabABa3ACbaEBA3aAbBAa2ACAb2Ba2AaAB2ABA"},"dh":24,"time":{"span":["2022-01-02T00:00:00Z","2022-01-02T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"3ms"}},"status":"ok","cached":"2503h20m53.775705233s"}
+
+
+        event: debug
+
+        data: "Fetching 2021-Q3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2021-12-31T15:17:19Z","st":451416,"ps":{"co":"1|0GE2AfcAFBbA2aBaB2ABa2A2aAaCACAaA2BAaB3ADbaCabABa2ABaABaBa2ABa4Ab2A2aBa2A2BE2AbACB2A2aABAbc2A","no2":"1|0YekdDaGOC2eGbacbdHE2DkeD2CAkLdDhaADfaKaCBGeABeCEaDAFhFda2DeAkdBAJaC!26ErtAaHcCDRBcjfGBAFgeFEfI2ah","o3":"1|0!30EicEeCADoCaLCgKCMADCndCgOgkDcEbDGbBhEceHCjEHAehHCebHBFcAb2BbadDBdTAOb!-28DFcBiHCAHtIjOhFlKIdeDACe","pm10":"1|0UFheEbCaCaBdEcdHcHDGCdnObGpdFafBABDcAaFaBAaDCfHfaCcDaAHfADgcdACIHIDIKe!-30g2BAFcGeGJsKEcAcDeEcGeAc","pm25":"1!57NunC2dAJICcFfiEbEIHTb!-27UDdvcdfBdBQIdmdCBKeBcadPpeJAIEhbkDCE2gaLGR2CBWAxqBDk!26PozQPzIFgAfCfcACBaA","so2":"1|0Eba2BA3a16AB5AaBa43ABAa4A2Ba5AaBA"},"dh":24,"time":{"span":["2021-10-03T00:00:00Z","2021-10-03T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"5ms"}},"status":"ok","cached":"2649h51m55.703357433s"}
+
+
+        event: debug
+
+        data: "Fetching 2021-Q2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2021-12-31T15:17:24Z","st":449232,"ps":{"co":"1|0FCA3B2A2aBCBdA2BAd3BA2aCBbd2aBaADBadaBABbB2ACbDcACbBAB2aAa2AB4Aa9AB13AFE2A","no2":"1|0RhbIBbJ2AebLMmeFeBLDefFgjDRiAFfdeDFCAkBGFAEfCgHBdBcAbHbAFGngDGIgGhdBFagadH2aLhC2dCAIA2bcDHbBekd","o3":"1|0!29ECBdcaACaD2bGcDcACfDaAKdAaFgDCaEheCD2gMHbkGAbcAF2AcHgdHGfIcHMbprWqEKbqDMHlhSq2AaFCImFCB2iKIEic","pm10":"1|0!35sBHcg2FebdHKdiCbCQIL!-28bAecNEla2BcdaBEcbBDBacDcAFcGai2BCaBIAbDAEAiacCACbdbGeDHce3aCAJhCDcEg2Fhe","pm25":"1!68!-31FNbuJBEacLPh!-27AbERY!61!-83bGkj!26asgBFqCgEAFdRDQeHvpPDfGFieAHaHNJdFBCcqJlA2dcDfGEfMFfAhiCNjEaMdAnVNun","so2":"1|0Ba5ACAbA2Bb4AB5AaBABAa3ABAFAgA2Ba5ABaA2BAaABABAa2ABca4ABAa3ABAa3ABaABAa4AEbaB"},"dh":24,"time":{"span":["2021-07-04T00:00:00Z","2021-07-04T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"3ms"}},"status":"ok","cached":"2649h51m50.74336297s"}
+
+
+        event: debug
+
+        data: "Fetching 2021-Q1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2021-12-31T15:17:30Z","st":447144,"ps":{"co":"1|0HBA2CAa2bEcE2aAcaAC2BAc3aB2ABDbBaCBABACAacAeAaBACb2ADAcBADaAbAbFcACaAdDBAB2Aaea2A%ACADCAB","no2":"1|0MBDGaDb2BFgCBEdidDIadFdCgFjABIEiAFjEa2IbgcICgCBAaJiD2Eck2BGbdFBNhjbEf2aHIDlKnJFbac2fOSG!-33hbI","o3":"1|0RBfdAFANagbdDHFABbiDEdAhLEjDgPcgDfNb2AeDCBcBGbaBcqWbAdFi2dm!30baDmNcBDAdFfbAGiKfEcFa2CaHqGECB","pm10":"1|0KBAJHBgcdHjMgBEjBAFabCaBbBbEDBbabCbdbEOBgCcbAbBRfFmCDHEgLGHrqALHBmcAdAFEDdhBaLBIqcFaEKPpsBH","pm25":"1!53sC!36bNmowRcVpcHvAlWKBbdLqdbHSkAEcPqnkG!37GpHiaidbZCKzbIdaiVUM!-60kRZ!33zjqhGfNBEDqVjPCE!-27iAGF2Z!-31!-31FN","so2":"1|0.3ABAaB2ACbaBACAa2CaAbaACD3AfaABa4AB2Aa2BaACDAdE2ABAaCabd3ACa5AaB2aB2AB2aBa3A2B2a2A"},"dh":24,"time":{"span":["2021-04-04T00:00:00Z","2021-04-04T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"3ms"}},"status":"ok","cached":"2649h51m44.470033782s"}
+
+
+        event: debug
+
+        data: "Fetching 2020-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2021-01-06T19:09:19Z","st":444864,"ps":{"co":"1|0Fc2ABABbECb2abABaDba3AaAB2ACaAaCDCGcdabAaBAbABa3BbBCcBDC2aBaCaBaABDcaAaAaB2A2cABA3CbACaCAbAB","no2":"1|0YcfdEbABHAkOkbAFbAdeEIChCJbaBabeFJDFcfgFAeECjcHbAGDkGEeCH2adaEGcacbDFbjCaC2FdbgcbCFBjGfaJaIeB2d","o3":"1|0VdGAdabDeDBeBEeDdfTdC2aGfdB2DBa2AckiDbAFJ2Ec2Db3AbBgaFdjgB2JanNADdgdHDEcdDaJd2DBcABCdHdmDfDACA","pm10":"1|0KBCfGaEdFdbF2cC2aF2AdBAeADBAaCGebCF!28AqApDaCE2dEADcBcALhGBHMfjkMidC2DGcgACkFBbHdcaCDcfAc2DEAE!33rg","pm25":"1!31CbfRcGjOlkJfD2FJLeagHhgjRfIfEHjCBG!51!49!-56I!-40pacGfhDCHeLoFZpLINTgp!-36ZrAgOCNwgHnuHbdDPFiPKgsKeAUDNFIym","so2":"1|0DB2AbBbABbAC2a3ABCDAcaDBa2AbA3BcAB3Aab3ABCca2ABaACDAaDab2ACEC2bC2aCDdgC2aCcAaB2Aa2AHBbcB2bA"},"dh":24,"time":{"span":["2021-01-03T00:00:00Z","2021-01-03T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"5ms"}},"status":"ok","cached":"11261h59m55.700359107s"}
+
+
+        event: debug
+
+        data: "Fetching 2020-Q3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-12-31T18:40:16Z","st":442656,"ps":{"co":"1|0Fa5ABAda2AB5AaAB6ABABa5A2BaABAa6Aa11ADeBAaBAaA2BaAB2Aa3ABAaBaBaD2aDc2A","no2":"1|0RdeaBFKjaCBCB2aeIgdHeJGefb2AJCOubCHeH!27qtNAKyaFafGdeDCDEg2CBfaIKGkGiCacbdChBPNoeBfdQJiBjDeIcAIcfd","o3":"1|0GCGaLaBmHDEMqCdcAHBGBFEqeaBbMDW!-32DECAbYEKACDxueBKlkPdFAbCAgHb2aDEgAbBeabKacDEM2eDEblUjsL2BjaKadGA","pm10":"1|0MabBDBAcCbBEaf2AHebEaBDdcCbBFBUubaEdBIEbINGujAFkacO2cfDbBDeBEcHBeDabBfaFDgASUmnadgGCicFEbEabdBCf","pm25":"1!33deDbKIDbeHNsa2fNEiIadc2adCfPBUxgBJqO!28LeB!32d!-27!-39TX!-35mAL2DgHAgKiaEBRdgbaFcfwNKld!30!39q!-33FdjUH!-27pODAOHshCbf","so2":"1|0BaAEBa2Bbd8ABa2A3B2A2a2B2AaBaAaAaBA2BCaKhCeB2a2ACa2AbaDb2ABaBAaB3AaCBbaBAbABaBa4ABCB2A"},"dh":24,"time":{"span":["2020-10-04T00:00:00Z","2020-10-04T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"5ms"}},"status":"ok","cached":"11406h28m58.526923612s"}
+
+
+        event: debug
+
+        data: "Fetching 2020-Q2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-12-31T18:40:35Z","st":440472,"ps":{"co":"1|0F2AaAaBa4AB2aABAa7ABa4ABa3ABAaB5AaAB2Aa2AB3ABa6AaBaB2AB3AaBAaAaB4ABaA2Ba3A","no2":"1|0WJ3fMADadDglKHBmBbCA2Eag2Dc2ADad2aELgAlaGcCFEbEAEbieDCFBgCedAKEdFebcHChDaDFAEcfAdHGE2aobFAadeaB","o3":"1|0!31BACFfCD2ABElBaAcdNbCE2CmJigCAbFBDc2GECnjEABCAbFfHLmAdICbhEJdDbhgCebFGeFcDCaBdFfdbHM!32bt!-27dEdnCGaL","pm10":"1|0SdGBdBMWC2hijaNU!-28EdIBAEanBHqFcBcDFbGFgQkgc2bFabB2AdHab3B2DA2cAFkABbHBacJiAd2BaC2aJBIBdqBDcAabBD","pm25":"1!52zR2eDNUlTbmob!26!45!-65JbfiFHeoDWpAgAaNFyZFJnmlBAGAbDFhMKEmNCnjfCDeENlicHACADMQuHecGbBjaKdNdH!-31bCaHdeDb","so2":"1|0EDCAB2cABaBCcA2BaB4AB2ABaeBAa2A2aB2AC2aABaABaAaABAa4A2B2ABACbCA2bA3B7AaBaACB3Aa2baAEB"},"dh":24,"time":{"span":["2020-07-05T00:00:00Z","2020-07-05T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"5ms"}},"status":"ok","cached":"11406h28m39.056682896s"}
+
+
+        event: debug
+
+        data: "Fetching 2020-Q1"
+
+
+        event: data
+
+        data: {"msg":{"st":438288,"ps":{"co":"1|0GcAB5ABbBAbCaBCBDBfb3A2D3aB3ACba2b2CAbBcACBAaBbABCB3aDbEbdCBbBb3BbaDb2aBCACaBabAB","no2":"1|0!30caEbsOFcDdAEmQsLHcLbedIsaJNAfbaACaKCgdnSdGBCoCHAHhBgc2HcaBgBDJBoHDhJgJdbljJfCGf2aQbCidge","o3":"1|0KRalHEdbBAKcE2eaDlAjaLCdGFIAbAcGbBbra2LDbBeGebIcbEABacdC2AdHafnLHbIAecJg2AdkGFBDAaeNdGFag","pm10":"1|0!41yaBebFHQyFeBdBGcHGSckcAIhnDHhbJACaQDaojCD2bLpbLcCgKaiaFAaCFhbNdbIBmBgEFaecEBEDeCBGa2Lele","pm25":"1!116!-60kBjgMLpImeaAMGhNBUJFo!-27!39qsoLkeZDbe!27LK!-38kbaAGIqbJeFkKIpb2BFDCkaUbHDbsbdeNCpfPgKQvGMGCTUj!-34u","so2":"1|0BABaAB2AB2aCBaAa2ABCAdACaC2Ba5AbBaBA2B2ACcFabaABbBdACaAaB2AB2Aa6A2a3A2B3ABa2BEda"},"dh":24,"time":{"span":["2020-03-29T00:00:00Z","2020-03-29T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"7ms"}},"status":"ok","cached":"18059h55m24.925573951s"}
+
+
+        event: debug
+
+        data: "Fetching 2019-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:09:47+01:00","st":436080,"ps":{"co":"1|0BADb2aC2BabBAaDa2ABbaFA2bACAa2CbADAdEBA2aCBAbc2DdGbabaCc2AaABbE2BaeBaBAC2aAaBAabCaBAaCaBAa","no2":"1|0!29eT2hjVBABlTnDPeMkcrAZAjfgASeA2BnKNwRElHceJGJ!-30XCyOaga2jEBAaKJlKJGkcfgBEJCgBeKAfcIebBcbacFd","o3":"1|0ZfCdcKeFcDabHkBEAFeEAkjFTAjACblQAgbFdBf2ED2cGehcIkPkJfDJAcEhgPmAdVcEBdBeaDHA2eaIfH2dFbBgDA","pm10":"1|0SeLCgeEIgDfaBFbEb2abcNMglbBUvHMFlDBmKkKDjcCacCEKqXnFhB2cfEaHFnOJKewBc2CDAdBdFcFcdaAE2aB2DA","pm25":"1!47dNDkcCFhBaCoKDKcbcJuJSmrPA2gORkmUpNO!-27YkcodRdEVK!-51!42iFyOqCo2LMC!-29!35pR2vPdAGAhDFdELaAajD2C2APHa","so2":"1|0CaDb2aDAaBcCAaDbaABaAB2A2aAEAB4ABa2ACbAaABbBA2aCaA2aABbBa3A2CABca3ACA2aA2CbA2CAbd3AaA"},"dh":24,"time":{"span":["2019-12-29T00:00:00Z","2019-12-29T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"4ms"}},"status":"ok","cached":"13865h59m27.584369212s"}
+
+
+        event: debug
+
+        data: "Fetching 2019-Q3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:04+01:00","st":433872,"ps":{"co":"1|0DaB2AaAB2Aa3Aa3BAaBaABAbBbB5A2Bb2ABaA2BaABaBAB2Aa2B2AbAa2ABaC2DcB2AaAc2AaAb3AbB5AaCaADb2a","no2":"1|0SFGHIxGMDFmrEaFL!26!-40CoIh!33MojdedbBFCICfBDFifBGFaeBhbHOcCENBAJ!-29cBdgMAk2GmCRfcbDMmgEFKAcecnASafjNbeT2hj","o3":"1|0ZEeIHtFIBDjaAcGIFtfIac!30!-30Vxb2JhgEKBHmabCa2BeHkGgFCBGBdE!26cAC!-30cEabBbcDeEBcbdaLdEiHCbDdDcbahBGCcJfCdcK","pm10":"1|0PBDBCfBFba2cCaDGCmdJeGKFBkiBCcbEHaAcCGh2CfbacBFaAGc2BFPFiCsdEbfIbcAFfDCKjACFdHlFBGIkgHhbCebFCeLCge","pm25":"1!40SnENka2ABgCHfeKGunGdMOSdjqnSU!-29ELHFfcAbDAcelD2ABCBQcFJ!37Psb!-43hHDnIcbCGfCJGnCBPhHvc2GagigIGcfBHFdNDkc","so2":"1|0B2AaBAFdGcdAaA2B2aBaABaB2AC2BdAa3AB3Aa4ABaBaABaBaBa3AB6AGEBdDdeABb3AaA2BAaBbBCbAaCAaDb2a"},"dh":24,"time":{"span":["2019-10-06T00:00:00Z","2019-10-06T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"7ms"}},"status":"ok","cached":"13865h59m9.858305427s"}
+
+
+        event: debug
+
+        data: "Fetching 2019-Q2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:12+01:00","st":431688,"ps":{"co":"1|0IDAaAdACbC2baCAaCDAaBAaBaBAb2B2ca4AECBd2CbBAcC2a2CBda2BaCbAabCaBbBCAcbCD3aDaB2AaBCbc2ABA2aB2AaA","no2":"1|0!32LpiBFjOaCFCicIDGFcelUcabfkdNLfhdmEGSbfJlbHeciMEdBbVevbABDLfDOAEigAedEb2aKB2fRAdAcblTjdFeTvdFGHIxG","o3":"1|0!33gmKBFCcIeEcaCfm2NLFEexHaAd2bCFnAFDhGfdMBAdCDAhCGAFEDuBhGDAecSadhEA2cCDbAEAabIkfJEFMs2BCg!33!-29bEeIHtF","pm10":"1|0ZFnd2FZCiqA2aESMCdkbAQkgtEBgLIegcdIhG2AdbABANcbDaAgEacdCbaFAbCABFgBDaCkEDaCadECAbdaPFdoEHGmeBDBCfB","pm25":"1!36!31myIS!74E!-32!-45iPefQKJvDfL!44!-28!-41uEaEZYyzKgPdRCafDodB!31jdOL!-40hIEDsCabKDjEcDEBhBbdUtEcFAeDObgBfY2AtBGVxbSnENka","so2":"1|0.2C2aAa2AaA2B5AaAaBHAe2a2AaABaBaBAaCB2a6ABaAa2BbABa2BAaBbBaDABbA2a2B2aAB2ABaAaCb2AB5AaBAF"},"dh":24,"time":{"span":["2019-07-07T00:00:00Z","2019-07-07T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"16ms"}},"status":"ok","cached":"13865h59m2.081928528s"}
+
+
+        event: debug
+
+        data: "Fetching 2019-Q1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:19+01:00","st":429528,"ps":{"co":"1|0H2ACBA2aDAdBbBDbBDcCDeBFebaEBaDeaEcAaCaAaCBbCBc2AB2aBACB2Ade2A2a2EA$aBa2AbADaBa4ABCaAcCa","no2":"1|0V2FAbBGiDaBAhDSdhPpEGgCQkfoLQhKqlMGaDhFgBIClZCkhFBbCAcBPGc!-30c2eLahNbsOAEbCGfBGEAfEibaNcSgcq","o3":"1|0XaAhFfLadjbOJfaDfbChGEemGRac2fGD2bDfaJEC2dcgAHFGhGAbfhdcACRgHImKcDcECcCAFgKd2gFfF2GbcabIBA","pm10":"1|0PHENhbdabMihACbfELAHKyGNhncLHeEkEDgDCceDgNEaTEjdjCbHKAEGFAzBlgDCAiFDgGdGcbCdJGfDaB2aKeIKIv","pm25":"1!49Kd!37khmjd!27mktLceEOM!36N!-70U!34j!-35jDFIbG!27!-30CHI!-30BblNfO!34!34wp!-28BIbMV!30FLC!-51h!-28hiDJuDCDbCJieDBIMeECBFtZiQI!31!-80","so2":"1|0.3ABA2BbC3AaAC2aBa2BaBEDCBheACa2ABAaEdAaACa2Bba2BaACabA2Caba4AFadaB2ABa3ABABA2aABaBABA"},"dh":24,"time":{"span":["2019-03-31T00:00:00Z","2019-03-31T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"6ms"}},"status":"ok","cached":"13865h58m55.695519418s"}
+
+
+        event: debug
+
+        data: "Fetching 2018-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:34+01:00","st":427320,"ps":{"co":"1|0F2ADAcAEAabA2aADAa2EebAaCABaABDdEcaCb3AbCABa2ABa2AEB2ba2BcACabAFca2AaCDbDBcaAbBAaBbDEeGbdA","no2":"1|0!37JHIO!-39F!28Dji2bqbQciJPxeFdDbiBDB!26iIanBEAFcFhMCfdnBc2CJdCjcDHEaNhkCOhCAdpMNmAImOFlOcjBhDCeLgeb","o3":"1|0VbdB2EcbIlHE2ad2abCcDCgACEaDdbajIMfqSEaCcDcAclaBPbdhfAKaEfQCgC2BnK2E2AofKkDNaAGdCABdgdAiFMc","pm10":"1|0SA2FJod2EWveCjGOgdIPscDdDicaDEKcIgBYpqFabd2FAKlHigFLTdnfdDgCEfdFIfEjEfFQiFMrdHg2AFdgOCgYjpe","pm25":"1!50aKOT!-28mJH!52!-53lEjIWclM!34!-35sHAC2laAMUFDhC!46!-31!-35aGBhECIUoQusO!26!45n!-29.2nOqd2ElPEhajAdK!26iCNmvHebABDg!27Jp!51r!-39A","so2":"1|0Ba7AB2Aa2AEAdCEcB2aBAa2A2B2AbAC2Aa3ABAa3Aa2ABCAda2BHCgaAaDbB3aBCcCB2ADeCA3aACbDAcA"},"dh":24,"time":{"span":["2018-12-30T00:00:00Z","2018-12-30T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13865h58m40.189392004s"}
+
+
+        event: debug
+
+        data: "Fetching 2018-Q3"
+
+
+        event: data
+
+        data: {"msg":{"st":425112,"ps":{"co":"1|0DCAaAa3AaA3BaB2ABabB6Ab3BabA2B2AaBA2a2BABabBABa4ABa2ABA2aA2BAaBaACBbaBAaACabDFeEfE2a2ADBdB","no2":"1|0!34IB2InAlGqDLOHfIiHGaofUafQj!-27bCKFBctI!31asiB2beFHaCfhIEAjGhHfMjAGNhCoCFADaG2gLHbfLfdIGf!-27N!26bM!-38!27rcJ2HO!-39G","o3":"1|0!64qfaOgCgco2FCLCetJEAVyF2DKhu2eMGcPjCQiqlBI2bD2dFeAEHoJbD2cGdECRCDqEfbaHcfAbBF2GhfBahGBDAEfaCbaebGEc","pm10":"1|0!26da2HcEjBhJaCBeDg2CBDeABEQmgiC2DB2bcJCj3AcDADB2acBF2caABcHCaBDAGecChFeCbECeCc2BGbc2dJKdFoQncA2FJod","pm25":"1!64kaPVhQ!-32blTfDBgDnCIAQpbEL!31!-28ydDFDCahDQLzLmabFAFBe2AaCJfiBDfKMDkF2GpfGkFdCDCIgceFbGcfBJlTAJ!-30UlgaKOT!-28m","so2":"1|0FAb6AB5AB3AB2AaAbBAbAB3Aa2A2Ba2AaBaA2BA2aBAa2BaBaBb2AC3aAC3ABAbDA2aBAba4ABa6AaABaA"},"dh":24,"time":{"span":["2018-07-01T00:00:00Z","2018-10-07T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"20328h8m33.539366905s"}
+
+
+        event: debug
+
+        data: "Fetching 2018-Q2"
+
+
+        event: data
+
+        data: {"msg":{"st":422928,"ps":{"co":"1|0GbABEBabA2aBDAbC2aCc2ACa2BbcACFcDbadCB2ABb2AaA2B2AabA2Ba2AaBABb2Aa2AB3AaCAB2AaAaBABaBba4A","no2":"1|0!32NIbeIElCAncWBgLbNM!-31HgHeDIe!-27lP!37qIbdjMNjsKaneEeIKCGAtAQHoPxfRCNqamHBGgcfPnWmJfaCBh2a2ASbefc2a","o3":"1|0!27aGAbCbgeFiFBOaDABQngLmcEDjDFCaAbA2KMguBahIBJkabIAaDAjAWja2fDcEFhBCeIdAbfJcBdbAkbREBKU!-30eKcEX","pm10":"1|0RAEAeJLhaJMfdKlhbIRjIknabEbfeIDfKDGFEBrfGabdA3CIaLjcTgNbE!-29EKilACeOfbCf2AH2beaCcCJfCaGbAb2aC","pm25":"1!58Ab2fTVfOF!34sw!28v!-38B!31TqW!-27!-37HgEFbiHBgRGTPRl!-47hELAtJbdFLJ!28!-27gUHW!-30V!-30E!30w!-32cMnGDbCakFEDFneFeBdDKBHgALkfI","so2":"1|0D3AaOm2Ab2AEbaCbCA2aAC2ABac2ADaCba2ACBcBAa2Aa2AB4A2Bb4AaDbAa3ABaB2AB5ABAbBaBAB4AB"},"dh":24,"time":{"span":["2018-04-01T00:00:00Z","2018-07-01T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"20328h8m26.622972876s"}
+
+
+        event: debug
+
+        data: "Fetching 2018-Q1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:40+01:00","st":420768,"ps":{"co":"1|0DBa2Bab2CBcAa2B2AaCbBADcAbAaBCabBAaABADaDbEb2ADa3bDA2BAbDAaAabaDAaAbBaC2aC2ACbDfBaAEb2BbaA","no2":"1|0!39FlNJphBOIrJjIJGdjWmdcMEFsJoDXiyBWuPca!31!-39Z!-30!30iKaLjfpmNKchdFKAp2BMGTmgDfehLaHF!-32AFJ!39xBrfOCHBmjd","o3":"1|0!27aEeadAdmMjRfdK2DClBcGEadjKGBgHgadGabdL2d3BAEhDEhGfDb3DcabaiOCceFjFaBaKABeAJaeEDoJCBeDfCF","pm10":"1|0SIDgDCjLKeB2bFpbFaMm2CdbLIkiCQoDFehHPIjmClOhEGIBfbi!28ncIqJFiPGQ!-33eBCgJbEkEeAJeHEcCc2FDjlaEi2A","pm25":"1!48JEgCV!-31!27ZySgCH!-38iEbGCMlfaKYqsDSqd2KsIXeiqCnQaKcEOgLy!65!-31iN!-37gGU2X!38!-75zFGxVaGbehDEAJlhQic!37I!-35iAda2D","so2":"1|0EBACaeaEBCdBbBDB2aEfBAFcadBaBEabaDdaCBFeCbEc2BCcaBcaB2A2a2BAB2ABD2a2Aa2Aa2BcaAaDaBAaA2BAaBb"},"dh":24,"time":{"span":["2018-04-01T00:00:00Z","2018-04-01T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13865h58m34.336400758s"}
+
+
+        event: debug
+
+        data: "Fetching 2017-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:45+01:00","st":418560,"ps":{"co":"1|0CABaAC2AC2aC2aBABa2A2aDaBAbCdED3AeADbaDba2AEAbBcACAaBABaA2aAaFcBCA2aCAbFabeACAEb3a4ABbAa","no2":"1|0!35MjOtHBfRfAIjcDAJlCRvARfIgkGqTYaqN!-29eVdlPiAoHWfbFiaFBeLjdbEhAfATmIMKyBMne!30fH!-32CFaShAghejNhVAf!-32","o3":"1|0VD2aB2bBhHBcAaNAeqTaBAiHArKDFkabhJCGiOcqTkMhgbGAcCEGEAqHCDjEIBpAcNDBfeEabOcjgLbmaKaJGCbBqQ2C","pm10":"1|0.2NfDhEcCHdBQkBHFbGgmahJbFD2chNGDOCseKpaLiDkHJBdFfdAFDfEbfdDdDaPcaecaeOdmTmIiDCIOk2difEdbPdIt","pm25":"1!48MbaiGBCOlhRAHMAr!34l!-36BgMFGRninTEJ!26N!-35fM!-34APrIlOcRjOmkACDl!34jzcIeaB!30obhaBg!28wb!33!-28DdALI!31ujiojHlCQaG!-36","so2":"1|0DBbDd2BaDaAB2aA2Ba2AbAC2ABbBaBCADBRsD2bCcdaBE3aBaDBcDbAaBba2ADcCDabaDcbJaE3ACF2gdAD2IaoaAd"},"dh":24,"time":{"span":["2017-12-31T00:00:00Z","2017-12-31T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"8ms"}},"status":"ok","cached":"13865h58m29.606596741s"}
+
+
+        event: debug
+
+        data: "Fetching 2017-Q3"
+
+
+        event: data
+
+        data: {"msg":{"st":416352,"ps":{"co":"1|0CA2BbCa2BbBbCBAb3BbBaA2aC2Bc2AaA2BaCA2a3AaB7ABAaB2ABaAa3ABa%Ba6ABAa6AB2Aa3A","no2":"1|0!33h!28KjOtp!28lKz!30!-34Jl2NceAafhFMedEjHDdbKqIEkCESwDZmHfClEAEbGKnhSgpQiId2C%!-31GNJFbjEjbKGNBAmcGbJGdeo","o3":"1|0!27EeAFZvAJnhEKi2fVHijFcbAGh3BEaCdC2BDg!47C!-45bAJaeJifFBkbSJOreOzdHDCBja%b2D2BJHbsFcfAGcDIsaPceFa","pm10":"1|0WdDAFJldFcabHdAfJKbhcdBcGECAebNjfNecbBdbKDnDHcBaBeBCPJwOgaSmX!-28dAeAa%lEIBaAcBAbICFeAdKOAGxDhg","pm25":"1!63lFEGSqiFfadIEejFOGoAiEbMbdeadG2aBFadEKh2EpEGabAbgCD!36C!-35U2B!38!-34lhKgnFe%!-28BVHcABGFiRIjeAd!29!32a!27!-81Iqh","so2":"1|0CaDBb2AaBABbDcC2aBABaABbACAaBa2BAaAbABA2aDbaCaBABbABAaCAbaBCbCb2ACA%bA2B2AbB2aABDaCcaBA2BA2a"},"dh":24,"time":{"span":["2017-07-01T00:00:00Z","2017-10-01T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"20224h58m45.030478228s"}
+
+
+        event: debug
+
+        data: "Fetching 2017-Q2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:53+01:00","st":414168,"ps":{"co":"1|0EbCbA2BDab2BaBbCaBb3a2BaAC4AaAa5A2BA2a2BABABaBAaBAa2ABbB2aAB3ABa3AaBaCABaBAbA2aBaAa2A","no2":"1|0!50rYsAIe!27.2rHCeDiAaGVbpd2DkDNdKrcHaCagdDHSCdcmN2cb2EcPmANehiBIhOatDIaDFbldLBDCpDKTcAkfkgJIlZyBi","o3":"1|0!37cCiFcDKBjBaAdKebDdBK!26ynbcEdLBfaDABdHeabeMCehaiKGCFEt!70!-37nafBgfOcBcacBbCBDdAPkbJZD!-28!45!-39reAIhabHCE","pm10":"1|0YaLgBHBLavBCafcABFCHEnDEiAIAbBkRCEjEcB2AQnbjD2CAfabKfDJebeBdFAFgeDb!70!-67FecCDFCfCBLGbgnbeIFgaACd","pm25":"1!60F!28wHKBWh!-40eIBodHebMSEubPrDEIfDvZHBu!32kpaG!45!-28luGDSfkhbVmMCcDkBeBEWzkFbCJBdfC2GEhLDPNioydhIPBjDCl","so2":"1|0DbCbaCaC2a2BbCbAaABDabBCbaCaCbAaAaB2AaADBA2a2BAa2AaABaBA2aBCaC2a2ABaBA2aC2aCb4AB2AaAaBACbaA"},"dh":24,"time":{"span":["2017-07-02T00:00:00Z","2017-07-02T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"20ms"}},"status":"ok","cached":"13865h58m21.180298994s"}
+
+
+        event: debug
+
+        data: "Fetching 2017-Q1"
+
+
+        event: data
+
+        data: {"msg":{"st":412032,"ps":{"co":"1|0.2CbFAcBaAaBbB2ABDbaBICcbeA2aA2BbBCbDbcA3BaAa2BaBaBcA2BACac8ACAaA3Ba2A2BAda2ACBa3Aa","no2":"1|0!32RdMP!-34.2HbhJpBDNHNkcdJLcgqAbdAaEeLOuLBkI2iBALEHcefcHDpKcgRbGgAcfbKEeKflEBJbcjeOEBjdCfIJAJBjq","o3":"1|0XjGhCAbIfOcB2fbBfAEac2ABFfTaheHIFlbDEnHeFd2bKCaHcfFHCbBCDcABeJ2bcHglBcMgcBIbDaCAdALehKBGcAd","pm10":"1|0!27BFMBtDeKW!-32.3AGPQakBXKqsMDwpICiCFCeOgGAJgGKio2BAge2cCEDmCIEDAfiJBAcEJCjaIBkecFDb2Iqd!27EwBaca","pm25":"1!72hJZDoDrLhfCbdQT!26H!-35H!60Nv!-36YA!-74s!29SxneOKZxMN!29jKL!-36zmLMokiCkNBoGCFALknLEQiBVM!-37HJL!-36ceF2B!31K!-37f!65D!-56aBeF","so2":"1|0CEcBDc2BAaCBd2ABCbaBDFb2c2AaBABaABbCabaB3ABACAbAB2AbaBaDB3aBa2ACbBA2aC2BbAaCAb2a2ABCaABAb"},"dh":24,"time":{"span":["2017-01-02T00:00:00Z","2017-04-02T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"20224h58m42.630657742s"}
+
+
+        event: debug
+
+        data: "Fetching 2016-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:58+01:00","st":409800,"ps":{"co":"1|0DaDb2aBa2AC2BABaD2ba4ABC2aCB2AcCabaA3B2AaBAcAD2aAE2acEaBDIfedAECdaAaCABAaACb2A2BcAaBICdbcb","no2":"1|0!47oUlbHAncIGfAFJjTqfaGgbL2IbjIg2CLPm!-28lMNhJB2gVmKCImpIFgbEhaMPXlsgbFIafAjGBCEhCFBajIPpew!49Ua2uh!-28","o3":"1|0SFebDGjKBcfBgAPCaAg2cEahcNFbodaPb2cMcCm2Ed2DdBGFBiHCagIagECsbACMfjDGCbQoHgce2aBAIKkQEabwbDADU","pm10":"1|0XbIAafEdeG2ADHbjHgBDabCJLchCLJDkmKhCmcLlJGiDJ2fD2biIA!30!-32AGfDR!40whwC!27BmfA2fECJBJgjLgeDoJpE!27Nhfnp","pm25":"1!63AIambRenKCaHMftIkMaJhEQXnoGU!34B!-33sNrCloVvHShgRmjAcbFX!-32RvEYij!40!54lo!-66J!63R!-43hcklFMLEXgrMj!-30EtCsI!53!41og!-36!-35","so2":"1|0GdEDbdB2A4BDBeDcaBA2B2A2a2BGcfdF2aBaCbBb2aFa2ABa2BbBcAC2aCHbAaB2Ededa2ABab2BbA3BcaABCB2Aba"},"dh":24,"time":{"span":["2017-01-01T00:00:00Z","2017-01-01T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13865h58m16.220558646s"}
+
+
+        event: debug
+
+        data: "Fetching 2016-Q3"
+
+
+        event: data
+
+        data: {"msg":{"st":407592,"ps":{"co":"1|0F3AacFDaABadbDaBC2BcBAaDC2baBaDBabAaBbaDBbcbB3ABa3A2BaADcCaADaACA2acaABAaCaD2AaDAbdC4ABab","no2":"1|0!54oBGtJ!29wdfJblFQrdXNbyLFpaHaKBtcUeCdAbfc2ADRkhNBJeGscNUCpfdfd!35.2idemQaPA2h2FRCi!-31g2GEZdGkmMeAbKio","o3":"1|0XaFeGDb2fHdcCGfbDWbItgVobcdFfIBiaFBHFhcBaeLeDbGFBgcAaONojGgDJpDkHAjc!28iceJeUbFuhNkcTmFIfkaBDAcE","pm10":"1|0!26gBCcCGcbd2EeaDfaIGHoNghBDA2CehIBC2bDdAEcAEga2DI2BhjMBJClDfbH3acdIEBAgbADRdBdrCNfHaefBNjIiFhb","pm25":"1!59BeIqHRBAgFEfBeiB2KMpXsuBHFebJsIDcADElJCeCFkaCEOaN!-28jQFWKqgjFacdDejNPeCobcF!31BGsuKWiCgobgHBHjGbA","so2":"1|0Fa2AaAD2aC3AaBaA3Bac3ABaACcACAa3AaAa3BabC3AB2a3BbBaAaCBAaABaAbCAa3AaAaAB2A4B3ABCB2d"},"dh":24,"time":{"span":["2016-07-01T00:00:00Z","2016-10-02T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"3ms"}},"status":"ok","cached":"19312h59m33.702154337s"}
+
+
+        event: debug
+
+        data: "Fetching 2016-Q2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:10+01:00","st":405408,"ps":{"co":"1|0HbaAb3BbADb2A2aBDcAa3ABaACBbEcbCAB2aBCDe2aBABAaBA2aABCab6Aa3BAcCABAEda2ADCBbCdc2AGbcB2A","no2":"1|0!68miOkMjCegHNaEcvcWmABahdKh2JdnJmL!28FdqbHjAEqbKDOajFljaEDUghtdFCJFdeU!26oiVrnAHECodCAQFcAsgdZcKepB","o3":"1|0!29GgCBbi2FEsQeHhAGdFeC2AFhDCacFEfDFEgKHnra!33mcEcaAhAaEbaFbEF3d2CbcHjdPpUA2kBFEAfIjCdhQaACAgGbaF","pm10":"1|0!34bAcbabFibYoCDehAKfHDeiBFf2FDkDACHGFBpJbGAhlHFdcAadbcAJ2EbjceEaILcaQjdDdfFfBcBE2fG2DchbaMdBCgB","pm25":"1!83fJpehCLua!55!-40KACocKkEJdhDLpHKHpfDHBJTO!-38LJVourUAcfBfeajbT2GJqhjBcZUrhYcieGqBcBcKajkLJGmjAhTdGfBe","so2":"1|0FbAC4AaA2BaABabCbABaBACAaBab2A2Ba2BABa2Bba2ABCaABAcbABAaB5ABaAB2A2BABCAaAbaCabBAbaA2CbA2a"},"dh":24,"time":{"span":["2016-07-03T00:00:00Z","2016-07-03T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"7ms"}},"status":"ok","cached":"13865h58m4.481032483s"}
+
+
+        event: debug
+
+        data: "Fetching 2016-Q1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:17+01:00","st":403296,"ps":{"co":"1|0F2BbCcBCAacBDaB2Ffb2c2Aa2B2Ca2BAbcCBCBCgaABEabCdbACE2AaABAaca5A2BAbABAB2aABABCcb2A2BADba","no2":"1|0!44HBkRrbMgJkD2FbZM!-28lAnI2bMkaAaGdCGrDGMk!28rigWOasUtkAGTCdzcQDceNreHUpaLgmCDcLdgcJIBTwgba!27iDJmi","o3":"1|0TAqVhOaeabAciJbnAL2CbIEBACAdEbiB2GCagehCAN2cBbHDAcgjHAGHfEBababCbBlCFHBLgDdGdede2HC2abcACGg","pm10":"1|0ZFIrNjeEAJmCSoL!27LqmdrKBnSlEgIGiAEfeNbg!26rBfFMehGmeBKUbAlqMbdAHbBDGqWRGumAcMphBNDKAvCbdHDcJbA","pm25":"1!54H!30!-40UojNdGnF!30xN!67V!-50!-27eqDboMhBAIFeEAerQCB!35zPwKHcbCzfMJ!40Bcl!-38LeiHDUlaMi!41!45I!-45!-30dg!28!-32tA!37BTh!-38dtFHFLQfJ","so2":"1|0LABaceBCaA2bCbCFDeA2aBa2BbB6A2BABaCbBadDaBAaABaC2A3a2C2AfaAEbaBAbaB2ABA2BA2Ba2BCbAbAbA"},"dh":24,"time":{"span":["2016-04-03T00:00:00Z","2016-04-03T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13865h57m57.221321072s"}
+
+
+        event: debug
+
+        data: "Fetching 2015-Q4"
+
+
+        event: data
+
+        data: {"msg":{"st":401016,"ps":{"co":"1|0E2B2A2aACcABA2B2aBACEcB2aAC2AaAFdcaCAa2ABa3AaCaAabACDacG4AaAba2AaAB2Aa2AB3Aa2AaAaAaDaBb$BaA","no2":"1|0!42VlEiGkIMsdQbCbAnhTLci!27eljfMBgiEcBMBkhCFCJACkpVhCOjqLVfoLcehNJceBjdEKDdBhgIbKcKsELmK2khQbRp$BjJ","o3":"1|0YfdToagHgHFbBAdFBdBefQjIiadGDcibaFCICAaHbBbFe2C2AbfHmCHefMFBcCEgBGAiAaHiIiciSiEaIa2B2aCAlKB$jCG","pm10":"1|0!28IOfncBGKrMake2HghGIDcFlAJModBUKkcfkcAbFaBHcicGAGabkHOlbKhbcAEGCecbIdEcaAeJEdPl2ebgLfdF!33smd$HlC","pm25":"1!66U!43s!-28efJW!-34!28dyoULodHKHpJfgMPthB!43!41!-36lksefAeGdKkagHcFJncP!37!-43GLgqcCJIFjhaQdACfcBQMtZpdrcQjflS!38wpi$Opf","so2":"1|0C3BAB2ABd3AaBAaA2BEbBba3BaAaCa2B2aAaB3ABbaCAaCbBaCAa2Aa2ABaABaABABaBa2AaB2AaB2AaBa2ABAB$aDB"},"dh":24,"time":{"span":["2015-10-01T00:00:00Z","2016-01-03T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"19312h59m30.562428713s"}
+
+
+        event: debug
+
+        data: "Fetching 2015-Q3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:23+01:00","st":398808,"ps":{"co":"1|0Iaca2AB2aCaC2AFfCaAB2A2aAD2AcbFbABb2BcBAa5ABaCBA2aBbBaBAaAaCAa3AaBA2BAaCAcD2aCBcaCaAa4A3B","no2":"1|0!86pycgOEnDXufHeBMJfibMBeF!-31XCdnGXpCeiNMflHkFfiPpDMICjCdDhJeGDgnDKBaBbhHAcNDhgEGfIZvaKfBClafIb2aVmF","o3":"1|0!69!-32ca2cBDFHmifaEPcFarG2DcCcaEcALgStCabDNenjKdGDdJiDjGQfpBCAECc2bCBcCHha2DIcgDBABjLEjfABEBCea2DgdU","pm10":"1|0!44.2kLiaCaJebgBaDLBhcIe2aFjEAdCKdGkEaCdDBeaBbLFkACFic2BCfEaDAdHkHACcaAcbFKInABDeFDiHdeGAHdj2EDcIOf","pm25":"1!104!-27x!28sbgGeJaeHfDKadiRjbfOpJghBAVdiJdIabda2cg!27T!-30bCMhfCBFkDBDdaKrQcCAiBiaGPQugEAhPbdVewEFGBoACEBU!43s","so2":"1|0FBbBAB2Aa2BaBbAaBAaB3AaA2B2aABAaBbaE2aB2Aa2B3ABaBaABCbAbAabACA2a2AaAC2BaACBbBAc2CbBAb2aBaAaCAB"},"dh":24,"time":{"span":["2015-10-04T00:00:00Z","2015-10-04T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"6ms"}},"status":"ok","cached":"13865h57m51.848268409s"}
+
+
+        event: debug
+
+        data: "Fetching 2015-Q2"
+
+
+        event: data
+
+        data: {"msg":{"st":396624,"ps":{"co":"1|0EBAaB2A$aAb$A2BabAOCdedC2bBABa4AaBCbBaCBa2A3BabAabBAaB3AaB2A2BcAB2AC2BbaC3aD2AaDA2aCaABacaA","no2":"1|0!35HgdbHE$YD!-30.2EICqBgCOBbMQxrEJQjifcAFLTCyHIfCberKLcn!27roFhJNoNfjJbA!27c!-28cJhMNKqoFWkrBNqLc!39fG!-29BMQJpybh","o3":"1|0!29cfBGAc$aJDBgHAlGFaBbcADbdhHCAabIEcabdLagF2eGIdbeBJqEDGcEAfBACBfHhHEjEFJanaBHpLajHfGHADfhLKY!-28kEd","pm10":"1|0UDaBbFd$!37B!-34bEDGjeBAMagDUxfIBUzDAfAIcBJjFcaFgEdBcbLABfdDcEdCbaHdEJEtBGCdFRmegJbJcgiECAKfcbBIK2kLi","pm25":"1!46JFGeJu$!100e!-79i2JPxm2BRbAH!49!-48pFeJgeHabKfDI!-27LDiEHdDhAgKNdibEeNsIAhJbCLS!-39EHkFO!29jsuScDEBr2BNGdkCDE!36!-27x!28s","so2":"1|0E2A2a2B$aCaA2BAbAa4A2C2aBAB2a2BAB2aAbABAbBa2ACBcEacBbA2BC2aB3AB2bBaACACbaCBcACaBbDB2aABAaBaAB"},"dh":24,"time":{"span":["2015-04-01T00:00:00Z","2015-07-05T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"19312h59m28.695977263s"}
+
+
+        event: debug
+
+        data: "Fetching 2015-Q1"
+
+
+        event: data
+
+        data: {"msg":{"st":394464,"ps":{"co":"1|0DBAD4ABbCACbBA$AcC2AEeEfDBcAabC2Aa2A2BCA2abCBdD2AaCBABcaba2CbC4AaCc2aADA2aCbADaCcBaABaABAaB","no2":"1|0TIKaGfDBanOAIdCjkCPKhDHwOh2DAbdhLKbjnTfFIkLbkCGmH2EmdPiGRlojQFaHegACLhCioBNbBFLqgQFElJoaEmOHgdb","o3":"1|0YEgmGKAEDadIeAFmiBcAEhCSkImP2bAGnFcDAaGhBEpTCkaHFDeDEa2fcDLEcabgK2ahaCaDEeibOIDfAlGgLBcHcD2cfBG","pm10":"1|0!28kaRdjDcBiIbBACFlDKRkKM!-31No2dcHcDKbImCAQaHaMnvXfoGa2deJbGFbkaBCFEeM2fJKb2hKHUfgaxFdFJtFdeEfHDaBb","pm25":"1!75!-33H!39puCcCtOaCcIBfIUZr!32S!-82TtatEMbeQIDpfVFSbN!29!-28!-46!47j!-37LbkaeHdHcKpbaDFOiVlab!38donPX!52m!-37E!-55k!27lX!-33FArFkQJFGe","so2":"1|0DAaCBa2ABc2BCaBbaABDbaFgDb2BCAabBaAbAa2BDaBa2ABdCB3AC2abDbaCBcDb3AaBAacBDabACaAC2A2Bb2AaB2A2a"},"dh":24,"time":{"span":["2015-01-01T00:00:00Z","2015-04-05T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"19312h59m27.539407284s"}
+
+
+        event: debug
+
+        data: "Fetching 2014-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:30+01:00","st":392256,"ps":{"co":"1|0FABcBACac2BaBAaDbaACdB|35GEbCbcAaAbAbABa2ADbACbaD2BaAaACbA","no2":"1|0!36ALtGCKfiDGmADCVkhaLrH|35.2Ek2AaPcfDLkBLDcbEnWeicEcDaBndKjB","o3":"1|0RgLbAcGcDhJADtBHE2CdDe|35lAcAICJ2bkaTiHJbEzTcqOFCdFAFbibGd","pm10":"1|0!34bElcBEaAcabcBNBAgaElKDB2eFIj!26gjgcDJLwDFfecHFDefEVCAfvVk2DCIeifABFCnBIAdcPjDGldaAbDbeFCeO","pm25":"1!69DLveCFAfdECoCXbe2fMuP2GhkLPm!51xylEFT!26!-50GSokCcNKbmI!46Ddt!-36!28kJFcTfrsiPIE!-31bNcdaZqEPwheDcFfhKLlL","so2":"1|0DABcBACAbABaBAaDabACbA|35DCbA2bAaCBAaADAaBAaDA2ab2ABAba2Bb"},"dh":24,"time":{"span":["2014-12-28T00:00:00Z","2014-12-28T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"3ms"}},"status":"ok","cached":"13865h57m44.41538436s"}
+
+
+        event: debug
+
+        data: "Fetching 2014-Q3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:34+01:00","st":390048,"ps":{"co":"1|0D2BAa2A2aAB4ABa4Aa2ABAa2AHeC2aB2AaBA$BabCcAEd2ACbA2Bb3A$DCc3ABa3BaAa2ABACBbaA$3AbBC2aABcB","no2":"1|0!48ELi!-46!31cEjFGfiKAMdNmtAiIkOfBdbGTFmAGDcAFk$KBpLdaZ!-27dCSneLfeImjcKXlHaN2gIHhcDmgSajIEiaDjDUbhbNCoALtG","o3":"1|0!29aIboFfbMgdVoFaCbScjfdMBhQlfMcfCbDcABadA$cHiBaKahDaB3CjMjCeADpMJiJdDAfdbIGCjDHAo2GibF2beHaJigLbA","pm10":"1|0QGAanLdCDbAFgACHcJgA2cD2ADfeAFGBedEBabId$bBfCA2bAbEFfaENlGhCgDKcLCNFmgAfMhfaEWACcfwRHmEdcHOfgbElc","pm25":"1!49LEb!-31YiMAfGIpdGLj!29nBeiEaEGmkbMNFklIHdbSl$fbnKbceAgGTtbP!32!-35LnBmK!26lZC!28W!-34wAm!27uiAD!54GElu!-44!39!27!-37oab2YtwDLve","so2":"1|0EB2AbB2Ab2A2BaBABaA2a2A2BABACBab2aC2AaBA$BABD2CjCdBCba2Bb2aABACb3A2BAbBbB$a2Ba2BbCRfj2AbACa2ABcB"},"dh":24,"time":{"span":["2014-10-05T00:00:00Z","2014-10-05T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13865h57m40.542226164s"}
+
+
+        event: debug
+
+        data: "Fetching 2014-Q2"
+
+
+        event: data
+
+        data: {"msg":{"st":387864,"ps":{"co":"1|0EB2Aba2ABABDcaCE2aACABaBaAaABA2cACABaBbaAB2aBA$BABbB2bA$DBAa2A2B2aB2ABAb3Aa3ACaABAaA2BabCaC2AaA","no2":"1|0!50bqHijKEKcLkoMaUeufAOKEahaeEHPflgNCDadeiCEDAbaqSKDkaBekJBjIgKhPeE!-31!32hBFbfEalhKcGaFcDIhAGEolXEFLj!-46!32","o3":"1|0RdbP2bBJgACAE2cIdDAdcCAeaLg2ALk2F2GmfACcCbgIAaEShckFAfDnGAcGLfahDaMCAbdbFDhbdHlfOIecD2AdhIDCaIaqG","pm10":"1|0!45SbwqfCALeDFkBaLFqA!30ghfcLmdPIbh2g2GecACeAaBcKB2ALjgcCacABWqAcFb2aiJDhFdCEC2gDFfJeBDaDjGHieHbGAanL","pm25":"1!105!39k!-34!-42hafWiGKsDgQO!-34F!68j!-29hdV!-30g!33Vcr2qPLmfBCfgDIcQHeBZuoeAahbCAThbMcChzWPnLgfGBhvHFfYpGEVk!-30MTvmRALEb!-31Y","so2":"1|0GabFdABaCabB2aACBdA2BDaAa2AaBCAe2BAD2A3aCabBAbC2BaBaA2aACAbABC2BdCAa2BbaBAbCAa4AB2aBCAbBAC2AbA"},"dh":24,"time":{"span":["2014-04-01T00:00:00Z","2014-07-06T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"3ms"}},"status":"ok","cached":"19312h59m25.75296863s"}
+
+
+        event: debug
+
+        data: "Fetching 2014-Q1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:45+01:00","st":385704,"ps":{"co":"1|0EB3AaC2ACBAbA3abBEBd2Aa2BaEHhcBaCABAbA2BdABCabC2bCBaABEfaBaBCBAB$abaC2AcABADbEAaBc2aBABaB2ABca","no2":"1|0XG2a2ABDAOSy2AdcHfa!29gnbKsCMaAEem2CHcHgmCTAiKegIBCikRGnMIDdajhXJbmbzINqOLI!-32CKaHjNsaSCBAcgGFBbqHij","o3":"1|0!29cFdcEAfCimKMiICDnEpOABdNaAcemNEAeJEaACAmHCAFAka2ACEaFbDqIfALdkDNiGE2aqICKCnIaIbDbcbebdQ2bjeaOba","pm10":"1|0QEHicIHfcGNfkDcB2bDRGqeFgbEcbJfiGACDacaBC2aDcBEBDAlHadGbGdgOlbSJke$NjcSQG!-44dLfHagiaHDBIUbgkLSbwqf","pm25":"1!37JDadbAfOL!45p!-37Fh2DcG!40K!-44bDjgGeD!26p!-37MKEBHfhaJCeBcDKCJDyI2fSiIeg!27!-27a!34Nvg$Zqp!48!42J!-95hVoHalsAUHDS!51es!-31X!39k!-34!-42h","so2":"1|0GFh3AaCaDbABAbCAcCDBcaAaAD2bCBbAaCABAbACACab2A2BbaC2aCACaABA2BacAdBAbDAEdBC2AbCbaBaAB4ACacFcA"},"dh":24,"time":{"span":["2014-04-06T00:00:00Z","2014-04-06T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13865h57m29.686023657s"}
+
+
+        event: done
+
+        data: "2.351814ms"
+
+
+        '
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Type:
+      - text/event-stream; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:09:14 GMT
+      Server:
+      - nginx
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/api/attsse/5724/yd.json
+  response:
+    body:
+      string: 'event: debug
+
+        data: "Fetching 2022-P4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2022-04-20T22:21:53+01:00","st":457992,"ps":{"co":"1|0B2CAabDaCbAba2BaCACa","no2":"1|0LEFEcDjDaHMghEFdbeAc","o3":"1|0!32BbcDAhEbFiFBAFaJfae","pm10":"1|0OFBdCdCBaCMCnALNenaJ","pm25":"1!32PGjhgANDCNCrHP!36g!-34iP","so2":"1|0.3ABa5AB3AaBaABa"},"dh":24,"time":{"span":["2022-04-20T00:00:00Z","2022-04-20T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"1ms"}},"status":"ok","cached":"3h48m49.404282324s"}
+
+
+        event: debug
+
+        data: "Fetching 2022-P3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2022-04-06T19:38:10+01:00","st":457248,"ps":{"co":"1|0.2BAaAa2BABa2AB2AIfdBCbBCb2a2ACEcaC","no2":"1|0XCInfaJc2FdeBJAgHak2DM2GjgiHhgeFCF","o3":"1|0ScEFBA2aEBbGbGkaBEaDcGFABCsbJ2ACBb","pm10":"1|0QPKrgCDOge2bcHBEb2DAT2FGcqtI2DueFC","pm25":"1!53!45C!-36bhb!31qadnDKbMqENK!28RPEA!-48!-34RKD!-48kRK","so2":"1|0.7AB2ABaABaB2a2ABA2B3A2aAa3A"},"dh":24,"time":{"span":["2022-04-03T00:00:00Z","2022-04-03T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"342h32m32.400503148s"}
+
+
+        event: debug
+
+        data: "Fetching 2022-P2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2022-03-06T19:26:40Z","st":456576,"ps":{"co":"1|0FaCFaBCdADAb2afbHabcC2ADaA2abCAbAB","no2":"1|0HENcBkOaAbGieHEiFfGgAKDcAFhHdJDpgb","o3":"1|0WDBDBaAaAkCFDbBGcCeE2aCBeDcagcFECB","pm10":"1|0TDFdFnKlFBEB2dHgPde2AEjiJAdIaPNvfB","pm25":"1!42FCiAjPqAOCDBgEfKcD2AEruTIiQH!44E!-38Il","so2":"1|0B2Aa2ABaBa2AB4AaBa3ABAaABa2Bb2A"},"dh":24,"time":{"span":["2022-03-06T00:00:00Z","2022-03-06T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"1ms"}},"status":"ok","cached":"1085h44m2.400009824s"}
+
+
+        event: debug
+
+        data: "Fetching 2022-P1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2022-02-06T19:39:29Z","st":455880,"ps":{"co":"1|0C2aFEcBAdFCBcabGeBdcBaA3BbDBAaCF2a","no2":"1|0.3ELEjFPrL2ElfGHkeHe2BbIdFrEbHDFfBk","o3":"1|0!28iaIc2adbibcGIe2CEiLCbhCEAHADeCBE2A","pm10":"1|0NdDFeDFLkPEIcmAMlkBfL2BcbBdFeAEFfGn","pm25":"1!33iGVsETOlWFZhzo!40!-38lcCw!47ImndmICbEDefj","so2":"1|0CbAB5ABABa2ABcB7ABbB2ABAb2A"},"dh":24,"time":{"span":["2022-02-06T00:00:00Z","2022-02-06T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"1ms"}},"status":"ok","cached":"1757h31m12.974687315s"}
+
+
+        event: debug
+
+        data: "Fetching 2021-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2022-01-06T17:48:21Z","st":453624,"ps":{"co":"1|0C4ABaAB3A2BbC2abBCBAaBabBABA2C2aGgDacbCABcCEFedBba2DeCbDEABC2AcAfAB2AdBAB2aA2BaACbaCcEcaABA","no2":"1|0!26ahMfADfKlaDFDaFfaiFaGCeEAdEAahIGgkSiaL2aDfjbMJhDfAmGQBoEoCXigEPkoVaecdTq2DbdABbHCKncjN2eDeBaD","o3":"1|0ZCeEaegDCabCeKBjKhEGbaDCeDEdDcCboJAmQaiIabEdbiEBEaIaboICGFblPAjCEAfKaeCeFagECacDCApJDaB2FgABcK","pm10":"1|0SAcCdGEaSdo2Bb2FfAEgcAcECab2BeCaFBgMBiGhbEBhaIFBbgBdCMJk2gCLBfdGIl!30AufgHecFaiFCfbHOBkbJfjEaFHi","pm25":"1!34aAFdHIB!51h!-43EjIEMhAJrh2cCGAhMaBjaOMr!31e!-27RrEFBsDVKg2edmNXWxudAWAD!-27RYv!78b!-72zdNoBLGoMGon!26PJwBVrmj2GS!-27","so2":"1|0AB6Aa3ABAaB11A2B2AcC2aBaABAB2AbBAa2B3AaCBabABa3ACbaEBA3aAbBAa2ACAb2Ba2AaAB2ABA"},"dh":24,"time":{"span":["2022-01-02T00:00:00Z","2022-01-02T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"3ms"}},"status":"ok","cached":"2503h22m21.476603041s"}
+
+
+        event: debug
+
+        data: "Fetching 2021-Q3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2021-12-31T15:17:19Z","st":451416,"ps":{"co":"1|0GE2AfcAFBbA2aBaB2ABa2A2aAaCACAaA2BAaB3ADbaCabABa2ABaABaBa2ABa4Ab2A2aBa2A2BE2AbACB2A2aABAbc2A","no2":"1|0YekdDaGOC2eGbacbdHE2DkeD2CAkLdDhaADfaKaCBGeABeCEaDAFhFda2DeAkdBAJaC!26ErtAaHcCDRBcjfGBAFgeFEfI2ah","o3":"1|0!30EicEeCADoCaLCgKCMADCndCgOgkDcEbDGbBhEceHCjEHAehHCebHBFcAb2BbadDBdTAOb!-28DFcBiHCAHtIjOhFlKIdeDACe","pm10":"1|0UFheEbCaCaBdEcdHcHDGCdnObGpdFafBABDcAaFaBAaDCfHfaCcDaAHfADgcdACIHIDIKe!-30g2BAFcGeGJsKEcAcDeEcGeAc","pm25":"1!57NunC2dAJICcFfiEbEIHTb!-27UDdvcdfBdBQIdmdCBKeBcadPpeJAIEhbkDCE2gaLGR2CBWAxqBDk!26PozQPzIFgAfCfcACBaA","so2":"1|0Eba2BA3a16AB5AaBa43ABAa4A2Ba5AaBA"},"dh":24,"time":{"span":["2021-10-03T00:00:00Z","2021-10-03T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"5ms"}},"status":"ok","cached":"2649h53m23.404232909s"}
+
+
+        event: debug
+
+        data: "Fetching 2021-Q2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2021-12-31T15:17:24Z","st":449232,"ps":{"co":"1|0FCA3B2A2aBCBdA2BAd3BA2aCBbd2aBaADBadaBABbB2ACbDcACbBAB2aAa2AB4Aa9AB13AFE2A","no2":"1|0RhbIBbJ2AebLMmeFeBLDefFgjDRiAFfdeDFCAkBGFAEfCgHBdBcAbHbAFGngDGIgGhdBFagadH2aLhC2dCAIA2bcDHbBekd","o3":"1|0!29ECBdcaACaD2bGcDcACfDaAKdAaFgDCaEheCD2gMHbkGAbcAF2AcHgdHGfIcHMbprWqEKbqDMHlhSq2AaFCImFCB2iKIEic","pm10":"1|0!35sBHcg2FebdHKdiCbCQIL!-28bAecNEla2BcdaBEcbBDBacDcAFcGai2BCaBIAbDAEAiacCACbdbGeDHce3aCAJhCDcEg2Fhe","pm25":"1!68!-31FNbuJBEacLPh!-27AbERY!61!-83bGkj!26asgBFqCgEAFdRDQeHvpPDfGFieAHaHNJdFBCcqJlA2dcDfGEfMFfAhiCNjEaMdAnVNun","so2":"1|0Ba5ACAbA2Bb4AB5AaBABAa3ABAFAgA2Ba5ABaA2BAaABABAa2ABca4ABAa3ABAa3ABaABAa4AEbaB"},"dh":24,"time":{"span":["2021-07-04T00:00:00Z","2021-07-04T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"3ms"}},"status":"ok","cached":"2649h53m18.444216846s"}
+
+
+        event: debug
+
+        data: "Fetching 2021-Q1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2021-12-31T15:17:30Z","st":447144,"ps":{"co":"1|0HBA2CAa2bEcE2aAcaAC2BAc3aB2ABDbBaCBABACAacAeAaBACb2ADAcBADaAbAbFcACaAdDBAB2Aaea2A%ACADCAB","no2":"1|0MBDGaDb2BFgCBEdidDIadFdCgFjABIEiAFjEa2IbgcICgCBAaJiD2Eck2BGbdFBNhjbEf2aHIDlKnJFbac2fOSG!-33hbI","o3":"1|0RBfdAFANagbdDHFABbiDEdAhLEjDgPcgDfNb2AeDCBcBGbaBcqWbAdFi2dm!30baDmNcBDAdFfbAGiKfEcFa2CaHqGECB","pm10":"1|0KBAJHBgcdHjMgBEjBAFabCaBbBbEDBbabCbdbEOBgCcbAbBRfFmCDHEgLGHrqALHBmcAdAFEDdhBaLBIqcFaEKPpsBH","pm25":"1!53sC!36bNmowRcVpcHvAlWKBbdLqdbHSkAEcPqnkG!37GpHiaidbZCKzbIdaiVUM!-60kRZ!33zjqhGfNBEDqVjPCE!-27iAGF2Z!-31!-31FN","so2":"1|0.3ABAaB2ACbaBACAa2CaAbaACD3AfaABa4AB2Aa2BaACDAdE2ABAaCabd3ACa5AaB2aB2AB2aBa3A2B2a2A"},"dh":24,"time":{"span":["2021-04-04T00:00:00Z","2021-04-04T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"3ms"}},"status":"ok","cached":"2649h53m12.170835598s"}
+
+
+        event: debug
+
+        data: "Fetching 2020-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2021-01-06T19:09:19Z","st":444864,"ps":{"co":"1|0Fc2ABABbECb2abABaDba3AaAB2ACaAaCDCGcdabAaBAbABa3BbBCcBDC2aBaCaBaABDcaAaAaB2A2cABA3CbACaCAbAB","no2":"1|0YcfdEbABHAkOkbAFbAdeEIChCJbaBabeFJDFcfgFAeECjcHbAGDkGEeCH2adaEGcacbDFbjCaC2FdbgcbCFBjGfaJaIeB2d","o3":"1|0VdGAdabDeDBeBEeDdfTdC2aGfdB2DBa2AckiDbAFJ2Ec2Db3AbBgaFdjgB2JanNADdgdHDEcdDaJd2DBcABCdHdmDfDACA","pm10":"1|0KBCfGaEdFdbF2cC2aF2AdBAeADBAaCGebCF!28AqApDaCE2dEADcBcALhGBHMfjkMidC2DGcgACkFBbHdcaCDcfAc2DEAE!33rg","pm25":"1!31CbfRcGjOlkJfD2FJLeagHhgjRfIfEHjCBG!51!49!-56I!-40pacGfhDCHeLoFZpLINTgp!-36ZrAgOCNwgHnuHbdDPFiPKgsKeAUDNFIym","so2":"1|0DB2AbBbABbAC2a3ABCDAcaDBa2AbA3BcAB3Aab3ABCca2ABaACDAaDab2ACEC2bC2aCDdgC2aCcAaB2Aa2AHBbcB2bA"},"dh":24,"time":{"span":["2021-01-03T00:00:00Z","2021-01-03T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"5ms"}},"status":"ok","cached":"11262h1m23.401157601s"}
+
+
+        event: debug
+
+        data: "Fetching 2020-Q3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-12-31T18:40:16Z","st":442656,"ps":{"co":"1|0Fa5ABAda2AB5AaAB6ABABa5A2BaABAa6Aa11ADeBAaBAaA2BaAB2Aa3ABAaBaBaD2aDc2A","no2":"1|0RdeaBFKjaCBCB2aeIgdHeJGefb2AJCOubCHeH!27qtNAKyaFafGdeDCDEg2CBfaIKGkGiCacbdChBPNoeBfdQJiBjDeIcAIcfd","o3":"1|0GCGaLaBmHDEMqCdcAHBGBFEqeaBbMDW!-32DECAbYEKACDxueBKlkPdFAbCAgHb2aDEgAbBeabKacDEM2eDEblUjsL2BjaKadGA","pm10":"1|0MabBDBAcCbBEaf2AHebEaBDdcCbBFBUubaEdBIEbINGujAFkacO2cfDbBDeBEcHBeDabBfaFDgASUmnadgGCicFEbEabdBCf","pm25":"1!33deDbKIDbeHNsa2fNEiIadc2adCfPBUxgBJqO!28LeB!32d!-27!-39TX!-35mAL2DgHAgKiaEBRdgbaFcfwNKld!30!39q!-33FdjUH!-27pODAOHshCbf","so2":"1|0BaAEBa2Bbd8ABa2A3B2A2a2B2AaBaAaAaBA2BCaKhCeB2a2ACa2AbaDb2ABaBAaB3AaCBbaBAbABaBa4ABCB2A"},"dh":24,"time":{"span":["2020-10-04T00:00:00Z","2020-10-04T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"5ms"}},"status":"ok","cached":"11406h30m26.227717557s"}
+
+
+        event: debug
+
+        data: "Fetching 2020-Q2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-12-31T18:40:35Z","st":440472,"ps":{"co":"1|0F2AaAaBa4AB2aABAa7ABa4ABa3ABAaB5AaAB2Aa2AB3ABa6AaBaB2AB3AaBAaAaB4ABaA2Ba3A","no2":"1|0WJ3fMADadDglKHBmBbCA2Eag2Dc2ADad2aELgAlaGcCFEbEAEbieDCFBgCedAKEdFebcHChDaDFAEcfAdHGE2aobFAadeaB","o3":"1|0!31BACFfCD2ABElBaAcdNbCE2CmJigCAbFBDc2GECnjEABCAbFfHLmAdICbhEJdDbhgCebFGeFcDCaBdFfdbHM!32bt!-27dEdnCGaL","pm10":"1|0SdGBdBMWC2hijaNU!-28EdIBAEanBHqFcBcDFbGFgQkgc2bFabB2AdHab3B2DA2cAFkABbHBacJiAd2BaC2aJBIBdqBDcAabBD","pm25":"1!52zR2eDNUlTbmob!26!45!-65JbfiFHeoDWpAgAaNFyZFJnmlBAGAbDFhMKEmNCnjfCDeENlicHACADMQuHecGbBjaKdNdH!-31bCaHdeDb","so2":"1|0EDCAB2cABaBCcA2BaB4AB2ABaeBAa2A2aB2AC2aABaABaAaABAa4A2B2ABACbCA2bA3B7AaBaACB3Aa2baAEB"},"dh":24,"time":{"span":["2020-07-05T00:00:00Z","2020-07-05T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"5ms"}},"status":"ok","cached":"11406h30m6.757464172s"}
+
+
+        event: debug
+
+        data: "Fetching 2020-Q1"
+
+
+        event: data
+
+        data: {"msg":{"st":438288,"ps":{"co":"1|0GcAB5ABbBAbCaBCBDBfb3A2D3aB3ACba2b2CAbBcACBAaBbABCB3aDbEbdCBbBb3BbaDb2aBCACaBabAB","no2":"1|0!30caEbsOFcDdAEmQsLHcLbedIsaJNAfbaACaKCgdnSdGBCoCHAHhBgc2HcaBgBDJBoHDhJgJdbljJfCGf2aQbCidge","o3":"1|0KRalHEdbBAKcE2eaDlAjaLCdGFIAbAcGbBbra2LDbBeGebIcbEABacdC2AdHafnLHbIAecJg2AdkGFBDAaeNdGFag","pm10":"1|0!41yaBebFHQyFeBdBGcHGSckcAIhnDHhbJACaQDaojCD2bLpbLcCgKaiaFAaCFhbNdbIBmBgEFaecEBEDeCBGa2Lele","pm25":"1!116!-60kBjgMLpImeaAMGhNBUJFo!-27!39qsoLkeZDbe!27LK!-38kbaAGIqbJeFkKIpb2BFDCkaUbHDbsbdeNCpfPgKQvGMGCTUj!-34u","so2":"1|0BABaAB2AB2aCBaAa2ABCAdACaC2Ba5AbBaBA2B2ACcFabaABbBdACaAaB2AB2Aa6A2a3A2B3ABa2BEda"},"dh":24,"time":{"span":["2020-03-29T00:00:00Z","2020-03-29T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"7ms"}},"status":"ok","cached":"18059h56m52.626344396s"}
+
+
+        event: debug
+
+        data: "Fetching 2019-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:09:47+01:00","st":436080,"ps":{"co":"1|0BADb2aC2BabBAaDa2ABbaFA2bACAa2CbADAdEBA2aCBAbc2DdGbabaCc2AaABbE2BaeBaBAC2aAaBAabCaBAaCaBAa","no2":"1|0!29eT2hjVBABlTnDPeMkcrAZAjfgASeA2BnKNwRElHceJGJ!-30XCyOaga2jEBAaKJlKJGkcfgBEJCgBeKAfcIebBcbacFd","o3":"1|0ZfCdcKeFcDabHkBEAFeEAkjFTAjACblQAgbFdBf2ED2cGehcIkPkJfDJAcEhgPmAdVcEBdBeaDHA2eaIfH2dFbBgDA","pm10":"1|0SeLCgeEIgDfaBFbEb2abcNMglbBUvHMFlDBmKkKDjcCacCEKqXnFhB2cfEaHFnOJKewBc2CDAdBdFcFcdaAE2aB2DA","pm25":"1!47dNDkcCFhBaCoKDKcbcJuJSmrPA2gORkmUpNO!-27YkcodRdEVK!-51!42iFyOqCo2LMC!-29!35pR2vPdAGAhDFdELaAajD2C2APHa","so2":"1|0CaDb2aDAaBcCAaDbaABaAB2A2aAEAB4ABa2ACbAaABbBA2aCaA2aABbBa3A2CABca3ACA2aA2CbA2CAbd3AaA"},"dh":24,"time":{"span":["2019-12-29T00:00:00Z","2019-12-29T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"4ms"}},"status":"ok","cached":"13866h0m55.285132077s"}
+
+
+        event: debug
+
+        data: "Fetching 2019-Q3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:04+01:00","st":433872,"ps":{"co":"1|0DaB2AaAB2Aa3Aa3BAaBaABAbBbB5A2Bb2ABaA2BaABaBAB2Aa2B2AbAa2ABaC2DcB2AaAc2AaAb3AbB5AaCaADb2a","no2":"1|0SFGHIxGMDFmrEaFL!26!-40CoIh!33MojdedbBFCICfBDFifBGFaeBhbHOcCENBAJ!-29cBdgMAk2GmCRfcbDMmgEFKAcecnASafjNbeT2hj","o3":"1|0ZEeIHtFIBDjaAcGIFtfIac!30!-30Vxb2JhgEKBHmabCa2BeHkGgFCBGBdE!26cAC!-30cEabBbcDeEBcbdaLdEiHCbDdDcbahBGCcJfCdcK","pm10":"1|0PBDBCfBFba2cCaDGCmdJeGKFBkiBCcbEHaAcCGh2CfbacBFaAGc2BFPFiCsdEbfIbcAFfDCKjACFdHlFBGIkgHhbCebFCeLCge","pm25":"1!40SnENka2ABgCHfeKGunGdMOSdjqnSU!-29ELHFfcAbDAcelD2ABCBQcFJ!37Psb!-43hHDnIcbCGfCJGnCBPhHvc2GagigIGcfBHFdNDkc","so2":"1|0B2AaBAFdGcdAaA2B2aBaABaB2AC2BdAa3AB3Aa4ABaBaABaBaBa3AB6AGEBdDdeABb3AaA2BAaBbBCbAaCAaDb2a"},"dh":24,"time":{"span":["2019-10-06T00:00:00Z","2019-10-06T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"7ms"}},"status":"ok","cached":"13866h0m37.559061001s"}
+
+
+        event: debug
+
+        data: "Fetching 2019-Q2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:12+01:00","st":431688,"ps":{"co":"1|0IDAaAdACbC2baCAaCDAaBAaBaBAb2B2ca4AECBd2CbBAcC2a2CBda2BaCbAabCaBbBCAcbCD3aDaB2AaBCbc2ABA2aB2AaA","no2":"1|0!32LpiBFjOaCFCicIDGFcelUcabfkdNLfhdmEGSbfJlbHeciMEdBbVevbABDLfDOAEigAedEb2aKB2fRAdAcblTjdFeTvdFGHIxG","o3":"1|0!33gmKBFCcIeEcaCfm2NLFEexHaAd2bCFnAFDhGfdMBAdCDAhCGAFEDuBhGDAecSadhEA2cCDbAEAabIkfJEFMs2BCg!33!-29bEeIHtF","pm10":"1|0ZFnd2FZCiqA2aESMCdkbAQkgtEBgLIegcdIhG2AdbABANcbDaAgEacdCbaFAbCABFgBDaCkEDaCadECAbdaPFdoEHGmeBDBCfB","pm25":"1!36!31myIS!74E!-32!-45iPefQKJvDfL!44!-28!-41uEaEZYyzKgPdRCafDodB!31jdOL!-40hIEDsCabKDjEcDEBhBbdUtEcFAeDObgBfY2AtBGVxbSnENka","so2":"1|0.2C2aAa2AaA2B5AaAaBHAe2a2AaABaBaBAaCB2a6ABaAa2BbABa2BAaBbBaDABbA2a2B2aAB2ABaAaCb2AB5AaBAF"},"dh":24,"time":{"span":["2019-07-07T00:00:00Z","2019-07-07T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"16ms"}},"status":"ok","cached":"13866h0m29.782676702s"}
+
+
+        event: debug
+
+        data: "Fetching 2019-Q1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:19+01:00","st":429528,"ps":{"co":"1|0H2ACBA2aDAdBbBDbBDcCDeBFebaEBaDeaEcAaCaAaCBbCBc2AB2aBACB2Ade2A2a2EA$aBa2AbADaBa4ABCaAcCa","no2":"1|0V2FAbBGiDaBAhDSdhPpEGgCQkfoLQhKqlMGaDhFgBIClZCkhFBbCAcBPGc!-30c2eLahNbsOAEbCGfBGEAfEibaNcSgcq","o3":"1|0XaAhFfLadjbOJfaDfbChGEemGRac2fGD2bDfaJEC2dcgAHFGhGAbfhdcACRgHImKcDcECcCAFgKd2gFfF2GbcabIBA","pm10":"1|0PHENhbdabMihACbfELAHKyGNhncLHeEkEDgDCceDgNEaTEjdjCbHKAEGFAzBlgDCAiFDgGdGcbCdJGfDaB2aKeIKIv","pm25":"1!49Kd!37khmjd!27mktLceEOM!36N!-70U!34j!-35jDFIbG!27!-30CHI!-30BblNfO!34!34wp!-28BIbMV!30FLC!-51h!-28hiDJuDCDbCJieDBIMeECBFtZiQI!31!-80","so2":"1|0.3ABA2BbC3AaAC2aBa2BaBEDCBheACa2ABAaEdAaACa2Bba2BaACabA2Caba4AFadaB2ABa3ABABA2aABaBABA"},"dh":24,"time":{"span":["2019-03-31T00:00:00Z","2019-03-31T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"6ms"}},"status":"ok","cached":"13866h0m23.396258591s"}
+
+
+        event: debug
+
+        data: "Fetching 2018-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:34+01:00","st":427320,"ps":{"co":"1|0F2ADAcAEAabA2aADAa2EebAaCABaABDdEcaCb3AbCABa2ABa2AEB2ba2BcACabAFca2AaCDbDBcaAbBAaBbDEeGbdA","no2":"1|0!37JHIO!-39F!28Dji2bqbQciJPxeFdDbiBDB!26iIanBEAFcFhMCfdnBc2CJdCjcDHEaNhkCOhCAdpMNmAImOFlOcjBhDCeLgeb","o3":"1|0VbdB2EcbIlHE2ad2abCcDCgACEaDdbajIMfqSEaCcDcAclaBPbdhfAKaEfQCgC2BnK2E2AofKkDNaAGdCABdgdAiFMc","pm10":"1|0SA2FJod2EWveCjGOgdIPscDdDicaDEKcIgBYpqFabd2FAKlHigFLTdnfdDgCEfdFIfEjEfFQiFMrdHg2AFdgOCgYjpe","pm25":"1!50aKOT!-28mJH!52!-53lEjIWclM!34!-35sHAC2laAMUFDhC!46!-31!-35aGBhECIUoQusO!26!45n!-29.2nOqd2ElPEhajAdK!26iCNmvHebABDg!27Jp!51r!-39A","so2":"1|0Ba7AB2Aa2AEAdCEcB2aBAa2A2B2AbAC2Aa3ABAa3Aa2ABCAda2BHCgaAaDbB3aBCcCB2ADeCA3aACbDAcA"},"dh":24,"time":{"span":["2018-12-30T00:00:00Z","2018-12-30T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13866h0m7.890110007s"}
+
+
+        event: debug
+
+        data: "Fetching 2018-Q3"
+
+
+        event: data
+
+        data: {"msg":{"st":425112,"ps":{"co":"1|0DCAaAa3AaA3BaB2ABabB6Ab3BabA2B2AaBA2a2BABabBABa4ABa2ABA2aA2BAaBaACBbaBAaACabDFeEfE2a2ADBdB","no2":"1|0!34IB2InAlGqDLOHfIiHGaofUafQj!-27bCKFBctI!31asiB2beFHaCfhIEAjGhHfMjAGNhCoCFADaG2gLHbfLfdIGf!-27N!26bM!-38!27rcJ2HO!-39G","o3":"1|0!64qfaOgCgco2FCLCetJEAVyF2DKhu2eMGcPjCQiqlBI2bD2dFeAEHoJbD2cGdECRCDqEfbaHcfAbBF2GhfBahGBDAEfaCbaebGEc","pm10":"1|0!26da2HcEjBhJaCBeDg2CBDeABEQmgiC2DB2bcJCj3AcDADB2acBF2caABcHCaBDAGecChFeCbECeCc2BGbc2dJKdFoQncA2FJod","pm25":"1!64kaPVhQ!-32blTfDBgDnCIAQpbEL!31!-28ydDFDCahDQLzLmabFAFBe2AaCJfiBDfKMDkF2GpfGkFdCDCIgceFbGcfBJlTAJ!-30UlgaKOT!-28m","so2":"1|0FAb6AB5AB3AB2AaAbBAbAB3Aa2A2Ba2AaBaA2BA2aBAa2BaBaBb2AC3aAC3ABAbDA2aBAba4ABa6AaABaA"},"dh":24,"time":{"span":["2018-07-01T00:00:00Z","2018-10-07T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"20328h10m1.240075818s"}
+
+
+        event: debug
+
+        data: "Fetching 2018-Q2"
+
+
+        event: data
+
+        data: {"msg":{"st":422928,"ps":{"co":"1|0GbABEBabA2aBDAbC2aCc2ACa2BbcACFcDbadCB2ABb2AaA2B2AabA2Ba2AaBABb2Aa2AB3AaCAB2AaAaBABaBba4A","no2":"1|0!32NIbeIElCAncWBgLbNM!-31HgHeDIe!-27lP!37qIbdjMNjsKaneEeIKCGAtAQHoPxfRCNqamHBGgcfPnWmJfaCBh2a2ASbefc2a","o3":"1|0!27aGAbCbgeFiFBOaDABQngLmcEDjDFCaAbA2KMguBahIBJkabIAaDAjAWja2fDcEFhBCeIdAbfJcBdbAkbREBKU!-30eKcEX","pm10":"1|0RAEAeJLhaJMfdKlhbIRjIknabEbfeIDfKDGFEBrfGabdA3CIaLjcTgNbE!-29EKilACeOfbCf2AH2beaCcCJfCaGbAb2aC","pm25":"1!58Ab2fTVfOF!34sw!28v!-38B!31TqW!-27!-37HgEFbiHBgRGTPRl!-47hELAtJbdFLJ!28!-27gUHW!-30V!-30E!30w!-32cMnGDbCakFEDFneFeBdDKBHgALkfI","so2":"1|0D3AaOm2Ab2AEbaCbCA2aAC2ABac2ADaCba2ACBcBAa2Aa2AB4A2Bb4AaDbAa3ABaB2AB5ABAbBaBAB4AB"},"dh":24,"time":{"span":["2018-04-01T00:00:00Z","2018-07-01T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"20328h9m54.323690569s"}
+
+
+        event: debug
+
+        data: "Fetching 2018-Q1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:40+01:00","st":420768,"ps":{"co":"1|0DBa2Bab2CBcAa2B2AaCbBADcAbAaBCabBAaABADaDbEb2ADa3bDA2BAbDAaAabaDAaAbBaC2aC2ACbDfBaAEb2BbaA","no2":"1|0!39FlNJphBOIrJjIJGdjWmdcMEFsJoDXiyBWuPca!31!-39Z!-30!30iKaLjfpmNKchdFKAp2BMGTmgDfehLaHF!-32AFJ!39xBrfOCHBmjd","o3":"1|0!27aEeadAdmMjRfdK2DClBcGEadjKGBgHgadGabdL2d3BAEhDEhGfDb3DcabaiOCceFjFaBaKABeAJaeEDoJCBeDfCF","pm10":"1|0SIDgDCjLKeB2bFpbFaMm2CdbLIkiCQoDFehHPIjmClOhEGIBfbi!28ncIqJFiPGQ!-33eBCgJbEkEeAJeHEcCc2FDjlaEi2A","pm25":"1!48JEgCV!-31!27ZySgCH!-38iEbGCMlfaKYqsDSqd2KsIXeiqCnQaKcEOgLy!65!-31iN!-37gGU2X!38!-75zFGxVaGbehDEAJlhQic!37I!-35iAda2D","so2":"1|0EBACaeaEBCdBbBDB2aEfBAFcadBaBEabaDdaCBFeCbEc2BCcaBcaB2A2a2BAB2ABD2a2Aa2Aa2BcaAaDaBAaA2BAaBb"},"dh":24,"time":{"span":["2018-04-01T00:00:00Z","2018-04-01T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13866h0m2.037105602s"}
+
+
+        event: debug
+
+        data: "Fetching 2017-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:45+01:00","st":418560,"ps":{"co":"1|0CABaAC2AC2aC2aBABa2A2aDaBAbCdED3AeADbaDba2AEAbBcACAaBABaA2aAaFcBCA2aCAbFabeACAEb3a4ABbAa","no2":"1|0!35MjOtHBfRfAIjcDAJlCRvARfIgkGqTYaqN!-29eVdlPiAoHWfbFiaFBeLjdbEhAfATmIMKyBMne!30fH!-32CFaShAghejNhVAf!-32","o3":"1|0VD2aB2bBhHBcAaNAeqTaBAiHArKDFkabhJCGiOcqTkMhgbGAcCEGEAqHCDjEIBpAcNDBfeEabOcjgLbmaKaJGCbBqQ2C","pm10":"1|0.2NfDhEcCHdBQkBHFbGgmahJbFD2chNGDOCseKpaLiDkHJBdFfdAFDfEbfdDdDaPcaecaeOdmTmIiDCIOk2difEdbPdIt","pm25":"1!48MbaiGBCOlhRAHMAr!34l!-36BgMFGRninTEJ!26N!-35fM!-34APrIlOcRjOmkACDl!34jzcIeaB!30obhaBg!28wb!33!-28DdALI!31ujiojHlCQaG!-36","so2":"1|0DBbDd2BaDaAB2aA2Ba2AbAC2ABbBaBCADBRsD2bCcdaBE3aBaDBcDbAaBba2ADcCDabaDcbJaE3ACF2gdAD2IaoaAd"},"dh":24,"time":{"span":["2017-12-31T00:00:00Z","2017-12-31T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"8ms"}},"status":"ok","cached":"13865h59m57.307306485s"}
+
+
+        event: debug
+
+        data: "Fetching 2017-Q3"
+
+
+        event: data
+
+        data: {"msg":{"st":416352,"ps":{"co":"1|0CA2BbCa2BbBbCBAb3BbBaA2aC2Bc2AaA2BaCA2a3AaB7ABAaB2ABaAa3ABa%Ba6ABAa6AB2Aa3A","no2":"1|0!33h!28KjOtp!28lKz!30!-34Jl2NceAafhFMedEjHDdbKqIEkCESwDZmHfClEAEbGKnhSgpQiId2C%!-31GNJFbjEjbKGNBAmcGbJGdeo","o3":"1|0!27EeAFZvAJnhEKi2fVHijFcbAGh3BEaCdC2BDg!47C!-45bAJaeJifFBkbSJOreOzdHDCBja%b2D2BJHbsFcfAGcDIsaPceFa","pm10":"1|0WdDAFJldFcabHdAfJKbhcdBcGECAebNjfNecbBdbKDnDHcBaBeBCPJwOgaSmX!-28dAeAa%lEIBaAcBAbICFeAdKOAGxDhg","pm25":"1!63lFEGSqiFfadIEejFOGoAiEbMbdeadG2aBFadEKh2EpEGabAbgCD!36C!-35U2B!38!-34lhKgnFe%!-28BVHcABGFiRIjeAd!29!32a!27!-81Iqh","so2":"1|0CaDBb2AaBABbDcC2aBABaABbACAaBa2BAaAbABA2aDbaCaBABbABAaCAbaBCbCb2ACA%bA2B2AbB2aABDaCcaBA2BA2a"},"dh":24,"time":{"span":["2017-07-01T00:00:00Z","2017-10-01T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"20225h0m12.731174851s"}
+
+
+        event: debug
+
+        data: "Fetching 2017-Q2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:53+01:00","st":414168,"ps":{"co":"1|0EbCbA2BDab2BaBbCaBb3a2BaAC4AaAa5A2BA2a2BABABaBAaBAa2ABbB2aAB3ABa3AaBaCABaBAbA2aBaAa2A","no2":"1|0!50rYsAIe!27.2rHCeDiAaGVbpd2DkDNdKrcHaCagdDHSCdcmN2cb2EcPmANehiBIhOatDIaDFbldLBDCpDKTcAkfkgJIlZyBi","o3":"1|0!37cCiFcDKBjBaAdKebDdBK!26ynbcEdLBfaDABdHeabeMCehaiKGCFEt!70!-37nafBgfOcBcacBbCBDdAPkbJZD!-28!45!-39reAIhabHCE","pm10":"1|0YaLgBHBLavBCafcABFCHEnDEiAIAbBkRCEjEcB2AQnbjD2CAfabKfDJebeBdFAFgeDb!70!-67FecCDFCfCBLGbgnbeIFgaACd","pm25":"1!60F!28wHKBWh!-40eIBodHebMSEubPrDEIfDvZHBu!32kpaG!45!-28luGDSfkhbVmMCcDkBeBEWzkFbCJBdfC2GEhLDPNioydhIPBjDCl","so2":"1|0DbCbaCaC2a2BbCbAaABDabBCbaCaCbAaAaB2AaADBA2a2BAa2AaABaBA2aBCaC2a2ABaBA2aC2aCb4AB2AaAaBACbaA"},"dh":24,"time":{"span":["2017-07-02T00:00:00Z","2017-07-02T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"20ms"}},"status":"ok","cached":"13865h59m48.881107328s"}
+
+
+        event: debug
+
+        data: "Fetching 2017-Q1"
+
+
+        event: data
+
+        data: {"msg":{"st":412032,"ps":{"co":"1|0.2CbFAcBaAaBbB2ABDbaBICcbeA2aA2BbBCbDbcA3BaAa2BaBaBcA2BACac8ACAaA3Ba2A2BAda2ACBa3Aa","no2":"1|0!32RdMP!-34.2HbhJpBDNHNkcdJLcgqAbdAaEeLOuLBkI2iBALEHcefcHDpKcgRbGgAcfbKEeKflEBJbcjeOEBjdCfIJAJBjq","o3":"1|0XjGhCAbIfOcB2fbBfAEac2ABFfTaheHIFlbDEnHeFd2bKCaHcfFHCbBCDcABeJ2bcHglBcMgcBIbDaCAdALehKBGcAd","pm10":"1|0!27BFMBtDeKW!-32.3AGPQakBXKqsMDwpICiCFCeOgGAJgGKio2BAge2cCEDmCIEDAfiJBAcEJCjaIBkecFDb2Iqd!27EwBaca","pm25":"1!72hJZDoDrLhfCbdQT!26H!-35H!60Nv!-36YA!-74s!29SxneOKZxMN!29jKL!-36zmLMokiCkNBoGCFALknLEQiBVM!-37HJL!-36ceF2B!31K!-37f!65D!-56aBeF","so2":"1|0CEcBDc2BAaCBd2ABCbaBDFb2c2AaBABaABbCabaB3ABACAbAB2AbaBaDB3aBa2ACbBA2aC2BbAaCAb2a2ABCaABAb"},"dh":24,"time":{"span":["2017-01-02T00:00:00Z","2017-04-02T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"20225h0m10.331467827s"}
+
+
+        event: debug
+
+        data: "Fetching 2016-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:58+01:00","st":409800,"ps":{"co":"1|0DaDb2aBa2AC2BABaD2ba4ABC2aCB2AcCabaA3B2AaBAcAD2aAE2acEaBDIfedAECdaAaCABAaACb2A2BcAaBICdbcb","no2":"1|0!47oUlbHAncIGfAFJjTqfaGgbL2IbjIg2CLPm!-28lMNhJB2gVmKCImpIFgbEhaMPXlsgbFIafAjGBCEhCFBajIPpew!49Ua2uh!-28","o3":"1|0SFebDGjKBcfBgAPCaAg2cEahcNFbodaPb2cMcCm2Ed2DdBGFBiHCagIagECsbACMfjDGCbQoHgce2aBAIKkQEabwbDADU","pm10":"1|0XbIAafEdeG2ADHbjHgBDabCJLchCLJDkmKhCmcLlJGiDJ2fD2biIA!30!-32AGfDR!40whwC!27BmfA2fECJBJgjLgeDoJpE!27Nhfnp","pm25":"1!63AIambRenKCaHMftIkMaJhEQXnoGU!34B!-33sNrCloVvHShgRmjAcbFX!-32RvEYij!40!54lo!-66J!63R!-43hcklFMLEXgrMj!-30EtCsI!53!41og!-36!-35","so2":"1|0GdEDbdB2A4BDBeDcaBA2B2A2a2BGcfdF2aBaCbBb2aFa2ABa2BbBcAC2aCHbAaB2Ededa2ABab2BbA3BcaABCB2Aba"},"dh":24,"time":{"span":["2017-01-01T00:00:00Z","2017-01-01T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13865h59m43.921379132s"}
+
+
+        event: debug
+
+        data: "Fetching 2016-Q3"
+
+
+        event: data
+
+        data: {"msg":{"st":407592,"ps":{"co":"1|0F3AacFDaABadbDaBC2BcBAaDC2baBaDBabAaBbaDBbcbB3ABa3A2BaADcCaADaACA2acaABAaCaD2AaDAbdC4ABab","no2":"1|0!54oBGtJ!29wdfJblFQrdXNbyLFpaHaKBtcUeCdAbfc2ADRkhNBJeGscNUCpfdfd!35.2idemQaPA2h2FRCi!-31g2GEZdGkmMeAbKio","o3":"1|0XaFeGDb2fHdcCGfbDWbItgVobcdFfIBiaFBHFhcBaeLeDbGFBgcAaONojGgDJpDkHAjc!28iceJeUbFuhNkcTmFIfkaBDAcE","pm10":"1|0!26gBCcCGcbd2EeaDfaIGHoNghBDA2CehIBC2bDdAEcAEga2DI2BhjMBJClDfbH3acdIEBAgbADRdBdrCNfHaefBNjIiFhb","pm25":"1!59BeIqHRBAgFEfBeiB2KMpXsuBHFebJsIDcADElJCeCFkaCEOaN!-28jQFWKqgjFacdDejNPeCobcF!31BGsuKWiCgobgHBHjGbA","so2":"1|0Fa2AaAD2aC3AaBaA3Bac3ABaACcACAa3AaAa3BabC3AB2a3BbBaAaCBAaABaAbCAa3AaAaAB2A4B3ABCB2d"},"dh":24,"time":{"span":["2016-07-01T00:00:00Z","2016-10-02T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"3ms"}},"status":"ok","cached":"19313h1m1.402964963s"}
+
+
+        event: debug
+
+        data: "Fetching 2016-Q2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:10+01:00","st":405408,"ps":{"co":"1|0HbaAb3BbADb2A2aBDcAa3ABaACBbEcbCAB2aBCDe2aBABAaBA2aABCab6Aa3BAcCABAEda2ADCBbCdc2AGbcB2A","no2":"1|0!68miOkMjCegHNaEcvcWmABahdKh2JdnJmL!28FdqbHjAEqbKDOajFljaEDUghtdFCJFdeU!26oiVrnAHECodCAQFcAsgdZcKepB","o3":"1|0!29GgCBbi2FEsQeHhAGdFeC2AFhDCacFEfDFEgKHnra!33mcEcaAhAaEbaFbEF3d2CbcHjdPpUA2kBFEAfIjCdhQaACAgGbaF","pm10":"1|0!34bAcbabFibYoCDehAKfHDeiBFf2FDkDACHGFBpJbGAhlHFdcAadbcAJ2EbjceEaILcaQjdDdfFfBcBE2fG2DchbaMdBCgB","pm25":"1!83fJpehCLua!55!-40KACocKkEJdhDLpHKHpfDHBJTO!-38LJVourUAcfBfeajbT2GJqhjBcZUrhYcieGqBcBcKajkLJGmjAhTdGfBe","so2":"1|0FbAC4AaA2BaABabCbABaBACAaBab2A2Ba2BABa2Bba2ABCaABAcbABAaB5ABaAB2A2BABCAaAbaCabBAbaA2CbA2a"},"dh":24,"time":{"span":["2016-07-03T00:00:00Z","2016-07-03T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"7ms"}},"status":"ok","cached":"13865h59m32.181830328s"}
+
+
+        event: debug
+
+        data: "Fetching 2016-Q1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:17+01:00","st":403296,"ps":{"co":"1|0F2BbCcBCAacBDaB2Ffb2c2Aa2B2Ca2BAbcCBCBCgaABEabCdbACE2AaABAaca5A2BAbABAB2aABABCcb2A2BADba","no2":"1|0!44HBkRrbMgJkD2FbZM!-28lAnI2bMkaAaGdCGrDGMk!28rigWOasUtkAGTCdzcQDceNreHUpaLgmCDcLdgcJIBTwgba!27iDJmi","o3":"1|0TAqVhOaeabAciJbnAL2CbIEBACAdEbiB2GCagehCAN2cBbHDAcgjHAGHfEBababCbBlCFHBLgDdGdede2HC2abcACGg","pm10":"1|0ZFIrNjeEAJmCSoL!27LqmdrKBnSlEgIGiAEfeNbg!26rBfFMehGmeBKUbAlqMbdAHbBDGqWRGumAcMphBNDKAvCbdHDcJbA","pm25":"1!54H!30!-40UojNdGnF!30xN!67V!-50!-27eqDboMhBAIFeEAerQCB!35zPwKHcbCzfMJ!40Bcl!-38LeiHDUlaMi!41!45I!-45!-30dg!28!-32tA!37BTh!-38dtFHFLQfJ","so2":"1|0LABaceBCaA2bCbCFDeA2aBa2BbB6A2BABaCbBadDaBAaABaC2A3a2C2AfaAEbaBAbaB2ABA2BA2Ba2BCbAbAbA"},"dh":24,"time":{"span":["2016-04-03T00:00:00Z","2016-04-03T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13865h59m24.922100087s"}
+
+
+        event: debug
+
+        data: "Fetching 2015-Q4"
+
+
+        event: data
+
+        data: {"msg":{"st":401016,"ps":{"co":"1|0E2B2A2aACcABA2B2aBACEcB2aAC2AaAFdcaCAa2ABa3AaCaAabACDacG4AaAba2AaAB2Aa2AB3Aa2AaAaAaDaBb$BaA","no2":"1|0!42VlEiGkIMsdQbCbAnhTLci!27eljfMBgiEcBMBkhCFCJACkpVhCOjqLVfoLcehNJceBjdEKDdBhgIbKcKsELmK2khQbRp$BjJ","o3":"1|0YfdToagHgHFbBAdFBdBefQjIiadGDcibaFCICAaHbBbFe2C2AbfHmCHefMFBcCEgBGAiAaHiIiciSiEaIa2B2aCAlKB$jCG","pm10":"1|0!28IOfncBGKrMake2HghGIDcFlAJModBUKkcfkcAbFaBHcicGAGabkHOlbKhbcAEGCecbIdEcaAeJEdPl2ebgLfdF!33smd$HlC","pm25":"1!66U!43s!-28efJW!-34!28dyoULodHKHpJfgMPthB!43!41!-36lksefAeGdKkagHcFJncP!37!-43GLgqcCJIFjhaQdACfcBQMtZpdrcQjflS!38wpi$Opf","so2":"1|0C3BAB2ABd3AaBAaA2BEbBba3BaAaCa2B2aAaB3ABbaCAaCbBaCAa2Aa2ABaABaABABaBa2AaB2AaB2AaBa2ABAB$aDB"},"dh":24,"time":{"span":["2015-10-01T00:00:00Z","2016-01-03T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"19313h0m58.263200408s"}
+
+
+        event: debug
+
+        data: "Fetching 2015-Q3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:23+01:00","st":398808,"ps":{"co":"1|0Iaca2AB2aCaC2AFfCaAB2A2aAD2AcbFbABb2BcBAa5ABaCBA2aBbBaBAaAaCAa3AaBA2BAaCAcD2aCBcaCaAa4A3B","no2":"1|0!86pycgOEnDXufHeBMJfibMBeF!-31XCdnGXpCeiNMflHkFfiPpDMICjCdDhJeGDgnDKBaBbhHAcNDhgEGfIZvaKfBClafIb2aVmF","o3":"1|0!69!-32ca2cBDFHmifaEPcFarG2DcCcaEcALgStCabDNenjKdGDdJiDjGQfpBCAECc2bCBcCHha2DIcgDBABjLEjfABEBCea2DgdU","pm10":"1|0!44.2kLiaCaJebgBaDLBhcIe2aFjEAdCKdGkEaCdDBeaBbLFkACFic2BCfEaDAdHkHACcaAcbFKInABDeFDiHdeGAHdj2EDcIOf","pm25":"1!104!-27x!28sbgGeJaeHfDKadiRjbfOpJghBAVdiJdIabda2cg!27T!-30bCMhfCBFkDBDdaKrQcCAiBiaGPQugEAhPbdVewEFGBoACEBU!43s","so2":"1|0FBbBAB2Aa2BaBbAaBAaB3AaA2B2aABAaBbaE2aB2Aa2B3ABaBaABCbAbAabACA2a2AaAC2BaACBbBAc2CbBAb2aBaAaCAB"},"dh":24,"time":{"span":["2015-10-04T00:00:00Z","2015-10-04T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"6ms"}},"status":"ok","cached":"13865h59m19.549035265s"}
+
+
+        event: debug
+
+        data: "Fetching 2015-Q2"
+
+
+        event: data
+
+        data: {"msg":{"st":396624,"ps":{"co":"1|0EBAaB2A$aAb$A2BabAOCdedC2bBABa4AaBCbBaCBa2A3BabAabBAaB3AaB2A2BcAB2AC2BbaC3aD2AaDA2aCaABacaA","no2":"1|0!35HgdbHE$YD!-30.2EICqBgCOBbMQxrEJQjifcAFLTCyHIfCberKLcn!27roFhJNoNfjJbA!27c!-28cJhMNKqoFWkrBNqLc!39fG!-29BMQJpybh","o3":"1|0!29cfBGAc$aJDBgHAlGFaBbcADbdhHCAabIEcabdLagF2eGIdbeBJqEDGcEAfBACBfHhHEjEFJanaBHpLajHfGHADfhLKY!-28kEd","pm10":"1|0UDaBbFd$!37B!-34bEDGjeBAMagDUxfIBUzDAfAIcBJjFcaFgEdBcbLABfdDcEdCbaHdEJEtBGCdFRmegJbJcgiECAKfcbBIK2kLi","pm25":"1!46JFGeJu$!100e!-79i2JPxm2BRbAH!49!-48pFeJgeHabKfDI!-27LDiEHdDhAgKNdibEeNsIAhJbCLS!-39EHkFO!29jsuScDEBr2BNGdkCDE!36!-27x!28s","so2":"1|0E2A2a2B$aCaA2BAbAa4A2C2aBAB2a2BAB2aAbABAbBa2ACBcEacBbA2BC2aB3AB2bBaACACbaCBcACaBbDB2aABAaBaAB"},"dh":24,"time":{"span":["2015-04-01T00:00:00Z","2015-07-05T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"19313h0m56.396705247s"}
+
+
+        event: debug
+
+        data: "Fetching 2015-Q1"
+
+
+        event: data
+
+        data: {"msg":{"st":394464,"ps":{"co":"1|0DBAD4ABbCACbBA$AcC2AEeEfDBcAabC2Aa2A2BCA2abCBdD2AaCBABcaba2CbC4AaCc2aADA2aCbADaCcBaABaABAaB","no2":"1|0TIKaGfDBanOAIdCjkCPKhDHwOh2DAbdhLKbjnTfFIkLbkCGmH2EmdPiGRlojQFaHegACLhCioBNbBFLqgQFElJoaEmOHgdb","o3":"1|0YEgmGKAEDadIeAFmiBcAEhCSkImP2bAGnFcDAaGhBEpTCkaHFDeDEa2fcDLEcabgK2ahaCaDEeibOIDfAlGgLBcHcD2cfBG","pm10":"1|0!28kaRdjDcBiIbBACFlDKRkKM!-31No2dcHcDKbImCAQaHaMnvXfoGa2deJbGFbkaBCFEeM2fJKb2hKHUfgaxFdFJtFdeEfHDaBb","pm25":"1!75!-33H!39puCcCtOaCcIBfIUZr!32S!-82TtatEMbeQIDpfVFSbN!29!-28!-46!47j!-37LbkaeHdHcKpbaDFOiVlab!38donPX!52m!-37E!-55k!27lX!-33FArFkQJFGe","so2":"1|0DAaCBa2ABc2BCaBbaABDbaFgDb2BCAabBaAbAa2BDaBa2ABdCB3AC2abDbaCBcDb3AaBAacBDabACaAC2A2Bb2AaB2A2a"},"dh":24,"time":{"span":["2015-01-01T00:00:00Z","2015-04-05T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"19313h0m55.240118506s"}
+
+
+        event: debug
+
+        data: "Fetching 2014-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:30+01:00","st":392256,"ps":{"co":"1|0FABcBACac2BaBAaDbaACdB|35GEbCbcAaAbAbABa2ADbACbaD2BaAaACbA","no2":"1|0!36ALtGCKfiDGmADCVkhaLrH|35.2Ek2AaPcfDLkBLDcbEnWeicEcDaBndKjB","o3":"1|0RgLbAcGcDhJADtBHE2CdDe|35lAcAICJ2bkaTiHJbEzTcqOFCdFAFbibGd","pm10":"1|0!34bElcBEaAcabcBNBAgaElKDB2eFIj!26gjgcDJLwDFfecHFDefEVCAfvVk2DCIeifABFCnBIAdcPjDGldaAbDbeFCeO","pm25":"1!69DLveCFAfdECoCXbe2fMuP2GhkLPm!51xylEFT!26!-50GSokCcNKbmI!46Ddt!-36!28kJFcTfrsiPIE!-31bNcdaZqEPwheDcFfhKLlL","so2":"1|0DABcBACAbABaBAaDabACbA|35DCbA2bAaCBAaADAaBAaDA2ab2ABAba2Bb"},"dh":24,"time":{"span":["2014-12-28T00:00:00Z","2014-12-28T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"3ms"}},"status":"ok","cached":"13865h59m12.116081083s"}
+
+
+        event: debug
+
+        data: "Fetching 2014-Q3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:34+01:00","st":390048,"ps":{"co":"1|0D2BAa2A2aAB4ABa4Aa2ABAa2AHeC2aB2AaBA$BabCcAEd2ACbA2Bb3A$DCc3ABa3BaAa2ABACBbaA$3AbBC2aABcB","no2":"1|0!48ELi!-46!31cEjFGfiKAMdNmtAiIkOfBdbGTFmAGDcAFk$KBpLdaZ!-27dCSneLfeImjcKXlHaN2gIHhcDmgSajIEiaDjDUbhbNCoALtG","o3":"1|0!29aIboFfbMgdVoFaCbScjfdMBhQlfMcfCbDcABadA$cHiBaKahDaB3CjMjCeADpMJiJdDAfdbIGCjDHAo2GibF2beHaJigLbA","pm10":"1|0QGAanLdCDbAFgACHcJgA2cD2ADfeAFGBedEBabId$bBfCA2bAbEFfaENlGhCgDKcLCNFmgAfMhfaEWACcfwRHmEdcHOfgbElc","pm25":"1!49LEb!-31YiMAfGIpdGLj!29nBeiEaEGmkbMNFklIHdbSl$fbnKbceAgGTtbP!32!-35LnBmK!26lZC!28W!-34wAm!27uiAD!54GElu!-44!39!27!-37oab2YtwDLve","so2":"1|0EB2AbB2Ab2A2BaBABaA2a2A2BABACBab2aC2AaBA$BABD2CjCdBCba2Bb2aABACb3A2BAbBbB$a2Ba2BbCRfj2AbACa2ABcB"},"dh":24,"time":{"span":["2014-10-05T00:00:00Z","2014-10-05T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13865h59m8.242912718s"}
+
+
+        event: debug
+
+        data: "Fetching 2014-Q2"
+
+
+        event: data
+
+        data: {"msg":{"st":387864,"ps":{"co":"1|0EB2Aba2ABABDcaCE2aACABaBaAaABA2cACABaBbaAB2aBA$BABbB2bA$DBAa2A2B2aB2ABAb3Aa3ACaABAaA2BabCaC2AaA","no2":"1|0!50bqHijKEKcLkoMaUeufAOKEahaeEHPflgNCDadeiCEDAbaqSKDkaBekJBjIgKhPeE!-31!32hBFbfEalhKcGaFcDIhAGEolXEFLj!-46!32","o3":"1|0RdbP2bBJgACAE2cIdDAdcCAeaLg2ALk2F2GmfACcCbgIAaEShckFAfDnGAcGLfahDaMCAbdbFDhbdHlfOIecD2AdhIDCaIaqG","pm10":"1|0!45SbwqfCALeDFkBaLFqA!30ghfcLmdPIbh2g2GecACeAaBcKB2ALjgcCacABWqAcFb2aiJDhFdCEC2gDFfJeBDaDjGHieHbGAanL","pm25":"1!105!39k!-34!-42hafWiGKsDgQO!-34F!68j!-29hdV!-30g!33Vcr2qPLmfBCfgDIcQHeBZuoeAahbCAThbMcChzWPnLgfGBhvHFfYpGEVk!-30MTvmRALEb!-31Y","so2":"1|0GabFdABaCabB2aACBdA2BDaAa2AaBCAe2BAD2A3aCabBAbC2BaBaA2aACAbABC2BdCAa2BbaBAbCAa4AB2aBCAbBAC2AbA"},"dh":24,"time":{"span":["2014-04-01T00:00:00Z","2014-07-06T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"3ms"}},"status":"ok","cached":"19313h0m53.453639373s"}
+
+
+        event: debug
+
+        data: "Fetching 2014-Q1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:45+01:00","st":385704,"ps":{"co":"1|0EB3AaC2ACBAbA3abBEBd2Aa2BaEHhcBaCABAbA2BdABCabC2bCBaABEfaBaBCBAB$abaC2AcABADbEAaBc2aBABaB2ABca","no2":"1|0XG2a2ABDAOSy2AdcHfa!29gnbKsCMaAEem2CHcHgmCTAiKegIBCikRGnMIDdajhXJbmbzINqOLI!-32CKaHjNsaSCBAcgGFBbqHij","o3":"1|0!29cFdcEAfCimKMiICDnEpOABdNaAcemNEAeJEaACAmHCAFAka2ACEaFbDqIfALdkDNiGE2aqICKCnIaIbDbcbebdQ2bjeaOba","pm10":"1|0QEHicIHfcGNfkDcB2bDRGqeFgbEcbJfiGACDacaBC2aDcBEBDAlHadGbGdgOlbSJke$NjcSQG!-44dLfHagiaHDBIUbgkLSbwqf","pm25":"1!37JDadbAfOL!45p!-37Fh2DcG!40K!-44bDjgGeD!26p!-37MKEBHfhaJCeBcDKCJDyI2fSiIeg!27!-27a!34Nvg$Zqp!48!42J!-95hVoHalsAUHDS!51es!-31X!39k!-34!-42h","so2":"1|0GFh3AaCaDbABAbCAcCDBcaAaAD2bCBbAaCABAbACACab2A2BbaC2aCACaABA2BacAdBAbDAEdBC2AbCbaBaAB4ACacFcA"},"dh":24,"time":{"span":["2014-04-06T00:00:00Z","2014-04-06T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13865h58m57.386673829s"}
+
+
+        event: done
+
+        data: "1.965496ms"
+
+
+        '
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Type:
+      - text/event-stream; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:10:42 GMT
+      Server:
+      - nginx
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/api/attsse/5724/yd.json
+  response:
+    body:
+      string: 'event: debug
+
+        data: "Fetching 2022-P4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2022-04-20T22:21:53+01:00","st":457992,"ps":{"co":"1|0B2CAabDaCbAba2BaCACa","no2":"1|0LEFEcDjDaHMghEFdbeAc","o3":"1|0!32BbcDAhEbFiFBAFaJfae","pm10":"1|0OFBdCdCBaCMCnALNenaJ","pm25":"1!32PGjhgANDCNCrHP!36g!-34iP","so2":"1|0.3ABa5AB3AaBaABa"},"dh":24,"time":{"span":["2022-04-20T00:00:00Z","2022-04-20T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"1ms"}},"status":"ok","cached":"3h50m12.397293219s"}
+
+
+        event: debug
+
+        data: "Fetching 2022-P3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2022-04-06T19:38:10+01:00","st":457248,"ps":{"co":"1|0.2BAaAa2BABa2AB2AIfdBCbBCb2a2ACEcaC","no2":"1|0XCInfaJc2FdeBJAgHak2DM2GjgiHhgeFCF","o3":"1|0ScEFBA2aEBbGbGkaBEaDcGFABCsbJ2ACBb","pm10":"1|0QPKrgCDOge2bcHBEb2DAT2FGcqtI2DueFC","pm25":"1!53!45C!-36bhb!31qadnDKbMqENK!28RPEA!-48!-34RKD!-48kRK","so2":"1|0.7AB2ABaABaB2a2ABA2B3A2aAa3A"},"dh":24,"time":{"span":["2022-04-03T00:00:00Z","2022-04-03T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"342h33m55.393539433s"}
+
+
+        event: debug
+
+        data: "Fetching 2022-P2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2022-03-06T19:26:40Z","st":456576,"ps":{"co":"1|0FaCFaBCdADAb2afbHabcC2ADaA2abCAbAB","no2":"1|0HENcBkOaAbGieHEiFfGgAKDcAFhHdJDpgb","o3":"1|0WDBDBaAaAkCFDbBGcCeE2aCBeDcagcFECB","pm10":"1|0TDFdFnKlFBEB2dHgPde2AEjiJAdIaPNvfB","pm25":"1!42FCiAjPqAOCDBgEfKcD2AEruTIiQH!44E!-38Il","so2":"1|0B2Aa2ABaBa2AB4AaBa3ABAaABa2Bb2A"},"dh":24,"time":{"span":["2022-03-06T00:00:00Z","2022-03-06T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"1ms"}},"status":"ok","cached":"1085h45m25.39306582s"}
+
+
+        event: debug
+
+        data: "Fetching 2022-P1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2022-02-06T19:39:29Z","st":455880,"ps":{"co":"1|0C2aFEcBAdFCBcabGeBdcBaA3BbDBAaCF2a","no2":"1|0.3ELEjFPrL2ElfGHkeHe2BbIdFrEbHDFfBk","o3":"1|0!28iaIc2adbibcGIe2CEiLCbhCEAHADeCBE2A","pm10":"1|0NdDFeDFLkPEIcmAMlkBfL2BcbBdFeAEFfGn","pm25":"1!33iGVsETOlWFZhzo!40!-38lcCw!47ImndmICbEDefj","so2":"1|0CbAB5ABABa2ABcB7ABbB2ABAb2A"},"dh":24,"time":{"span":["2022-02-06T00:00:00Z","2022-02-06T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"1ms"}},"status":"ok","cached":"1757h32m35.967772611s"}
+
+
+        event: debug
+
+        data: "Fetching 2021-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2022-01-06T17:48:21Z","st":453624,"ps":{"co":"1|0C4ABaAB3A2BbC2abBCBAaBabBABA2C2aGgDacbCABcCEFedBba2DeCbDEABC2AcAfAB2AdBAB2aA2BaACbaCcEcaABA","no2":"1|0!26ahMfADfKlaDFDaFfaiFaGCeEAdEAahIGgkSiaL2aDfjbMJhDfAmGQBoEoCXigEPkoVaecdTq2DbdABbHCKncjN2eDeBaD","o3":"1|0ZCeEaegDCabCeKBjKhEGbaDCeDEdDcCboJAmQaiIabEdbiEBEaIaboICGFblPAjCEAfKaeCeFagECacDCApJDaB2FgABcK","pm10":"1|0SAcCdGEaSdo2Bb2FfAEgcAcECab2BeCaFBgMBiGhbEBhaIFBbgBdCMJk2gCLBfdGIl!30AufgHecFaiFCfbHOBkbJfjEaFHi","pm25":"1!34aAFdHIB!51h!-43EjIEMhAJrh2cCGAhMaBjaOMr!31e!-27RrEFBsDVKg2edmNXWxudAWAD!-27RYv!78b!-72zdNoBLGoMGon!26PJwBVrmj2GS!-27","so2":"1|0AB6Aa3ABAaB11A2B2AcC2aBaABAB2AbBAa2B3AaCBabABa3ACbaEBA3aAbBAa2ACAb2Ba2AaAB2ABA"},"dh":24,"time":{"span":["2022-01-02T00:00:00Z","2022-01-02T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"3ms"}},"status":"ok","cached":"2503h23m44.469697216s"}
+
+
+        event: debug
+
+        data: "Fetching 2021-Q3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2021-12-31T15:17:19Z","st":451416,"ps":{"co":"1|0GE2AfcAFBbA2aBaB2ABa2A2aAaCACAaA2BAaB3ADbaCabABa2ABaABaBa2ABa4Ab2A2aBa2A2BE2AbACB2A2aABAbc2A","no2":"1|0YekdDaGOC2eGbacbdHE2DkeD2CAkLdDhaADfaKaCBGeABeCEaDAFhFda2DeAkdBAJaC!26ErtAaHcCDRBcjfGBAFgeFEfI2ah","o3":"1|0!30EicEeCADoCaLCgKCMADCndCgOgkDcEbDGbBhEceHCjEHAehHCebHBFcAb2BbadDBdTAOb!-28DFcBiHCAHtIjOhFlKIdeDACe","pm10":"1|0UFheEbCaCaBdEcdHcHDGCdnObGpdFafBABDcAaFaBAaDCfHfaCcDaAHfADgcdACIHIDIKe!-30g2BAFcGeGJsKEcAcDeEcGeAc","pm25":"1!57NunC2dAJICcFfiEbEIHTb!-27UDdvcdfBdBQIdmdCBKeBcadPpeJAIEhbkDCE2gaLGR2CBWAxqBDk!26PozQPzIFgAfCfcACBaA","so2":"1|0Eba2BA3a16AB5AaBa43ABAa4A2Ba5AaBA"},"dh":24,"time":{"span":["2021-10-03T00:00:00Z","2021-10-03T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"5ms"}},"status":"ok","cached":"2649h54m46.397339416s"}
+
+
+        event: debug
+
+        data: "Fetching 2021-Q2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2021-12-31T15:17:24Z","st":449232,"ps":{"co":"1|0FCA3B2A2aBCBdA2BAd3BA2aCBbd2aBaADBadaBABbB2ACbDcACbBAB2aAa2AB4Aa9AB13AFE2A","no2":"1|0RhbIBbJ2AebLMmeFeBLDefFgjDRiAFfdeDFCAkBGFAEfCgHBdBcAbHbAFGngDGIgGhdBFagadH2aLhC2dCAIA2bcDHbBekd","o3":"1|0!29ECBdcaACaD2bGcDcACfDaAKdAaFgDCaEheCD2gMHbkGAbcAF2AcHgdHGfIcHMbprWqEKbqDMHlhSq2AaFCImFCB2iKIEic","pm10":"1|0!35sBHcg2FebdHKdiCbCQIL!-28bAecNEla2BcdaBEcbBDBacDcAFcGai2BCaBIAbDAEAiacCACbdbGeDHce3aCAJhCDcEg2Fhe","pm25":"1!68!-31FNbuJBEacLPh!-27AbERY!61!-83bGkj!26asgBFqCgEAFdRDQeHvpPDfGFieAHaHNJdFBCcqJlA2dcDfGEfMFfAhiCNjEaMdAnVNun","so2":"1|0Ba5ACAbA2Bb4AB5AaBABAa3ABAFAgA2Ba5ABaA2BAaABABAa2ABca4ABAa3ABAa3ABaABAa4AEbaB"},"dh":24,"time":{"span":["2021-07-04T00:00:00Z","2021-07-04T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"3ms"}},"status":"ok","cached":"2649h54m41.437336103s"}
+
+
+        event: debug
+
+        data: "Fetching 2021-Q1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2021-12-31T15:17:30Z","st":447144,"ps":{"co":"1|0HBA2CAa2bEcE2aAcaAC2BAc3aB2ABDbBaCBABACAacAeAaBACb2ADAcBADaAbAbFcACaAdDBAB2Aaea2A%ACADCAB","no2":"1|0MBDGaDb2BFgCBEdidDIadFdCgFjABIEiAFjEa2IbgcICgCBAaJiD2Eck2BGbdFBNhjbEf2aHIDlKnJFbac2fOSG!-33hbI","o3":"1|0RBfdAFANagbdDHFABbiDEdAhLEjDgPcgDfNb2AeDCBcBGbaBcqWbAdFi2dm!30baDmNcBDAdFfbAGiKfEcFa2CaHqGECB","pm10":"1|0KBAJHBgcdHjMgBEjBAFabCaBbBbEDBbabCbdbEOBgCcbAbBRfFmCDHEgLGHrqALHBmcAdAFEDdhBaLBIqcFaEKPpsBH","pm25":"1!53sC!36bNmowRcVpcHvAlWKBbdLqdbHSkAEcPqnkG!37GpHiaidbZCKzbIdaiVUM!-60kRZ!33zjqhGfNBEDqVjPCE!-27iAGF2Z!-31!-31FN","so2":"1|0.3ABAaB2ACbaBACAa2CaAbaACD3AfaABa4AB2Aa2BaACDAdE2ABAaCabd3ACa5AaB2aB2AB2aBa3A2B2a2A"},"dh":24,"time":{"span":["2021-04-04T00:00:00Z","2021-04-04T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"3ms"}},"status":"ok","cached":"2649h54m35.163962874s"}
+
+
+        event: debug
+
+        data: "Fetching 2020-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2021-01-06T19:09:19Z","st":444864,"ps":{"co":"1|0Fc2ABABbECb2abABaDba3AaAB2ACaAaCDCGcdabAaBAbABa3BbBCcBDC2aBaCaBaABDcaAaAaB2A2cABA3CbACaCAbAB","no2":"1|0YcfdEbABHAkOkbAFbAdeEIChCJbaBabeFJDFcfgFAeECjcHbAGDkGEeCH2adaEGcacbDFbjCaC2FdbgcbCFBjGfaJaIeB2d","o3":"1|0VdGAdabDeDBeBEeDdfTdC2aGfdB2DBa2AckiDbAFJ2Ec2Db3AbBgaFdjgB2JanNADdgdHDEcdDaJd2DBcABCdHdmDfDACA","pm10":"1|0KBCfGaEdFdbF2cC2aF2AdBAeADBAaCGebCF!28AqApDaCE2dEADcBcALhGBHMfjkMidC2DGcgACkFBbHdcaCDcfAc2DEAE!33rg","pm25":"1!31CbfRcGjOlkJfD2FJLeagHhgjRfIfEHjCBG!51!49!-56I!-40pacGfhDCHeLoFZpLINTgp!-36ZrAgOCNwgHnuHbdDPFiPKgsKeAUDNFIym","so2":"1|0DB2AbBbABbAC2a3ABCDAcaDBa2AbA3BcAB3Aab3ABCca2ABaACDAaDab2ACEC2bC2aCDdgC2aCcAaB2Aa2AHBbcB2bA"},"dh":24,"time":{"span":["2021-01-03T00:00:00Z","2021-01-03T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"5ms"}},"status":"ok","cached":"11262h2m46.394303338s"}
+
+
+        event: debug
+
+        data: "Fetching 2020-Q3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-12-31T18:40:16Z","st":442656,"ps":{"co":"1|0Fa5ABAda2AB5AaAB6ABABa5A2BaABAa6Aa11ADeBAaBAaA2BaAB2Aa3ABAaBaBaD2aDc2A","no2":"1|0RdeaBFKjaCBCB2aeIgdHeJGefb2AJCOubCHeH!27qtNAKyaFafGdeDCDEg2CBfaIKGkGiCacbdChBPNoeBfdQJiBjDeIcAIcfd","o3":"1|0GCGaLaBmHDEMqCdcAHBGBFEqeaBbMDW!-32DECAbYEKACDxueBKlkPdFAbCAgHb2aDEgAbBeabKacDEM2eDEblUjsL2BjaKadGA","pm10":"1|0MabBDBAcCbBEaf2AHebEaBDdcCbBFBUubaEdBIEbINGujAFkacO2cfDbBDeBEcHBeDabBfaFDgASUmnadgGCicFEbEabdBCf","pm25":"1!33deDbKIDbeHNsa2fNEiIadc2adCfPBUxgBJqO!28LeB!32d!-27!-39TX!-35mAL2DgHAgKiaEBRdgbaFcfwNKld!30!39q!-33FdjUH!-27pODAOHshCbf","so2":"1|0BaAEBa2Bbd8ABa2A3B2A2a2B2AaBaAaAaBA2BCaKhCeB2a2ACa2AbaDb2ABaBAaB3AaCBbaBAbABaBa4ABCB2A"},"dh":24,"time":{"span":["2020-10-04T00:00:00Z","2020-10-04T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"5ms"}},"status":"ok","cached":"11406h31m49.220922336s"}
+
+
+        event: debug
+
+        data: "Fetching 2020-Q2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-12-31T18:40:35Z","st":440472,"ps":{"co":"1|0F2AaAaBa4AB2aABAa7ABa4ABa3ABAaB5AaAB2Aa2AB3ABa6AaBaB2AB3AaBAaAaB4ABaA2Ba3A","no2":"1|0WJ3fMADadDglKHBmBbCA2Eag2Dc2ADad2aELgAlaGcCFEbEAEbieDCFBgCedAKEdFebcHChDaDFAEcfAdHGE2aobFAadeaB","o3":"1|0!31BACFfCD2ABElBaAcdNbCE2CmJigCAbFBDc2GECnjEABCAbFfHLmAdICbhEJdDbhgCebFGeFcDCaBdFfdbHM!32bt!-27dEdnCGaL","pm10":"1|0SdGBdBMWC2hijaNU!-28EdIBAEanBHqFcBcDFbGFgQkgc2bFabB2AdHab3B2DA2cAFkABbHBacJiAd2BaC2aJBIBdqBDcAabBD","pm25":"1!52zR2eDNUlTbmob!26!45!-65JbfiFHeoDWpAgAaNFyZFJnmlBAGAbDFhMKEmNCnjfCDeENlicHACADMQuHecGbBjaKdNdH!-31bCaHdeDb","so2":"1|0EDCAB2cABaBCcA2BaB4AB2ABaeBAa2A2aB2AC2aABaABaAaABAa4A2B2ABACbCA2bA3B7AaBaACB3Aa2baAEB"},"dh":24,"time":{"span":["2020-07-05T00:00:00Z","2020-07-05T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"5ms"}},"status":"ok","cached":"11406h31m29.750723141s"}
+
+
+        event: debug
+
+        data: "Fetching 2020-Q1"
+
+
+        event: data
+
+        data: {"msg":{"st":438288,"ps":{"co":"1|0GcAB5ABbBAbCaBCBDBfb3A2D3aB3ACba2b2CAbBcACBAaBbABCB3aDbEbdCBbBb3BbaDb2aBCACaBabAB","no2":"1|0!30caEbsOFcDdAEmQsLHcLbedIsaJNAfbaACaKCgdnSdGBCoCHAHhBgc2HcaBgBDJBoHDhJgJdbljJfCGf2aQbCidge","o3":"1|0KRalHEdbBAKcE2eaDlAjaLCdGFIAbAcGbBbra2LDbBeGebIcbEABacdC2AdHafnLHbIAecJg2AdkGFBDAaeNdGFag","pm10":"1|0!41yaBebFHQyFeBdBGcHGSckcAIhnDHhbJACaQDaojCD2bLpbLcCgKaiaFAaCFhbNdbIBmBgEFaecEBEDeCBGa2Lele","pm25":"1!116!-60kBjgMLpImeaAMGhNBUJFo!-27!39qsoLkeZDbe!27LK!-38kbaAGIqbJeFkKIpb2BFDCkaUbHDbsbdeNCpfPgKQvGMGCTUj!-34u","so2":"1|0BABaAB2AB2aCBaAa2ABCAdACaC2Ba5AbBaBA2B2ACcFabaABbBdACaAaB2AB2Aa6A2a3A2B3ABa2BEda"},"dh":24,"time":{"span":["2020-03-29T00:00:00Z","2020-03-29T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"7ms"}},"status":"ok","cached":"18059h58m15.619634545s"}
+
+
+        event: debug
+
+        data: "Fetching 2019-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:09:47+01:00","st":436080,"ps":{"co":"1|0BADb2aC2BabBAaDa2ABbaFA2bACAa2CbADAdEBA2aCBAbc2DdGbabaCc2AaABbE2BaeBaBAC2aAaBAabCaBAaCaBAa","no2":"1|0!29eT2hjVBABlTnDPeMkcrAZAjfgASeA2BnKNwRElHceJGJ!-30XCyOaga2jEBAaKJlKJGkcfgBEJCgBeKAfcIebBcbacFd","o3":"1|0ZfCdcKeFcDabHkBEAFeEAkjFTAjACblQAgbFdBf2ED2cGehcIkPkJfDJAcEhgPmAdVcEBdBeaDHA2eaIfH2dFbBgDA","pm10":"1|0SeLCgeEIgDfaBFbEb2abcNMglbBUvHMFlDBmKkKDjcCacCEKqXnFhB2cfEaHFnOJKewBc2CDAdBdFcFcdaAE2aB2DA","pm25":"1!47dNDkcCFhBaCoKDKcbcJuJSmrPA2gORkmUpNO!-27YkcodRdEVK!-51!42iFyOqCo2LMC!-29!35pR2vPdAGAhDFdELaAajD2C2APHa","so2":"1|0CaDb2aDAaBcCAaDbaABaAB2A2aAEAB4ABa2ACbAaABbBA2aCaA2aABbBa3A2CABca3ACA2aA2CbA2CAbd3AaA"},"dh":24,"time":{"span":["2019-12-29T00:00:00Z","2019-12-29T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"4ms"}},"status":"ok","cached":"13866h2m18.278432716s"}
+
+
+        event: debug
+
+        data: "Fetching 2019-Q3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:04+01:00","st":433872,"ps":{"co":"1|0DaB2AaAB2Aa3Aa3BAaBaABAbBbB5A2Bb2ABaA2BaABaBAB2Aa2B2AbAa2ABaC2DcB2AaAc2AaAb3AbB5AaCaADb2a","no2":"1|0SFGHIxGMDFmrEaFL!26!-40CoIh!33MojdedbBFCICfBDFifBGFaeBhbHOcCENBAJ!-29cBdgMAk2GmCRfcbDMmgEFKAcecnASafjNbeT2hj","o3":"1|0ZEeIHtFIBDjaAcGIFtfIac!30!-30Vxb2JhgEKBHmabCa2BeHkGgFCBGBdE!26cAC!-30cEabBbcDeEBcbdaLdEiHCbDdDcbahBGCcJfCdcK","pm10":"1|0PBDBCfBFba2cCaDGCmdJeGKFBkiBCcbEHaAcCGh2CfbacBFaAGc2BFPFiCsdEbfIbcAFfDCKjACFdHlFBGIkgHhbCebFCeLCge","pm25":"1!40SnENka2ABgCHfeKGunGdMOSdjqnSU!-29ELHFfcAbDAcelD2ABCBQcFJ!37Psb!-43hHDnIcbCGfCJGnCBPhHvc2GagigIGcfBHFdNDkc","so2":"1|0B2AaBAFdGcdAaA2B2aBaABaB2AC2BdAa3AB3Aa4ABaBaABaBaBa3AB6AGEBdDdeABb3AaA2BAaBbBCbAaCAaDb2a"},"dh":24,"time":{"span":["2019-10-06T00:00:00Z","2019-10-06T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"7ms"}},"status":"ok","cached":"13866h2m0.552363742s"}
+
+
+        event: debug
+
+        data: "Fetching 2019-Q2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:12+01:00","st":431688,"ps":{"co":"1|0IDAaAdACbC2baCAaCDAaBAaBaBAb2B2ca4AECBd2CbBAcC2a2CBda2BaCbAabCaBbBCAcbCD3aDaB2AaBCbc2ABA2aB2AaA","no2":"1|0!32LpiBFjOaCFCicIDGFcelUcabfkdNLfhdmEGSbfJlbHeciMEdBbVevbABDLfDOAEigAedEb2aKB2fRAdAcblTjdFeTvdFGHIxG","o3":"1|0!33gmKBFCcIeEcaCfm2NLFEexHaAd2bCFnAFDhGfdMBAdCDAhCGAFEDuBhGDAecSadhEA2cCDbAEAabIkfJEFMs2BCg!33!-29bEeIHtF","pm10":"1|0ZFnd2FZCiqA2aESMCdkbAQkgtEBgLIegcdIhG2AdbABANcbDaAgEacdCbaFAbCABFgBDaCkEDaCadECAbdaPFdoEHGmeBDBCfB","pm25":"1!36!31myIS!74E!-32!-45iPefQKJvDfL!44!-28!-41uEaEZYyzKgPdRCafDodB!31jdOL!-40hIEDsCabKDjEcDEBhBbdUtEcFAeDObgBfY2AtBGVxbSnENka","so2":"1|0.2C2aAa2AaA2B5AaAaBHAe2a2AaABaBaBAaCB2a6ABaAa2BbABa2BAaBbBaDABbA2a2B2aAB2ABaAaCb2AB5AaBAF"},"dh":24,"time":{"span":["2019-07-07T00:00:00Z","2019-07-07T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"16ms"}},"status":"ok","cached":"13866h1m52.775983763s"}
+
+
+        event: debug
+
+        data: "Fetching 2019-Q1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:19+01:00","st":429528,"ps":{"co":"1|0H2ACBA2aDAdBbBDbBDcCDeBFebaEBaDeaEcAaCaAaCBbCBc2AB2aBACB2Ade2A2a2EA$aBa2AbADaBa4ABCaAcCa","no2":"1|0V2FAbBGiDaBAhDSdhPpEGgCQkfoLQhKqlMGaDhFgBIClZCkhFBbCAcBPGc!-30c2eLahNbsOAEbCGfBGEAfEibaNcSgcq","o3":"1|0XaAhFfLadjbOJfaDfbChGEemGRac2fGD2bDfaJEC2dcgAHFGhGAbfhdcACRgHImKcDcECcCAFgKd2gFfF2GbcabIBA","pm10":"1|0PHENhbdabMihACbfELAHKyGNhncLHeEkEDgDCceDgNEaTEjdjCbHKAEGFAzBlgDCAiFDgGdGcbCdJGfDaB2aKeIKIv","pm25":"1!49Kd!37khmjd!27mktLceEOM!36N!-70U!34j!-35jDFIbG!27!-30CHI!-30BblNfO!34!34wp!-28BIbMV!30FLC!-51h!-28hiDJuDCDbCJieDBIMeECBFtZiQI!31!-80","so2":"1|0.3ABA2BbC3AaAC2aBa2BaBEDCBheACa2ABAaEdAaACa2Bba2BaACabA2Caba4AFadaB2ABa3ABABA2aABaBABA"},"dh":24,"time":{"span":["2019-03-31T00:00:00Z","2019-03-31T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"6ms"}},"status":"ok","cached":"13866h1m46.389590771s"}
+
+
+        event: debug
+
+        data: "Fetching 2018-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:34+01:00","st":427320,"ps":{"co":"1|0F2ADAcAEAabA2aADAa2EebAaCABaABDdEcaCb3AbCABa2ABa2AEB2ba2BcACabAFca2AaCDbDBcaAbBAaBbDEeGbdA","no2":"1|0!37JHIO!-39F!28Dji2bqbQciJPxeFdDbiBDB!26iIanBEAFcFhMCfdnBc2CJdCjcDHEaNhkCOhCAdpMNmAImOFlOcjBhDCeLgeb","o3":"1|0VbdB2EcbIlHE2ad2abCcDCgACEaDdbajIMfqSEaCcDcAclaBPbdhfAKaEfQCgC2BnK2E2AofKkDNaAGdCABdgdAiFMc","pm10":"1|0SA2FJod2EWveCjGOgdIPscDdDicaDEKcIgBYpqFabd2FAKlHigFLTdnfdDgCEfdFIfEjEfFQiFMrdHg2AFdgOCgYjpe","pm25":"1!50aKOT!-28mJH!52!-53lEjIWclM!34!-35sHAC2laAMUFDhC!46!-31!-35aGBhECIUoQusO!26!45n!-29.2nOqd2ElPEhajAdK!26iCNmvHebABDg!27Jp!51r!-39A","so2":"1|0Ba7AB2Aa2AEAdCEcB2aBAa2A2B2AbAC2Aa3ABAa3Aa2ABCAda2BHCgaAaDbB3aBCcCB2ADeCA3aACbDAcA"},"dh":24,"time":{"span":["2018-12-30T00:00:00Z","2018-12-30T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13866h1m30.883474198s"}
+
+
+        event: debug
+
+        data: "Fetching 2018-Q3"
+
+
+        event: data
+
+        data: {"msg":{"st":425112,"ps":{"co":"1|0DCAaAa3AaA3BaB2ABabB6Ab3BabA2B2AaBA2a2BABabBABa4ABa2ABA2aA2BAaBaACBbaBAaACabDFeEfE2a2ADBdB","no2":"1|0!34IB2InAlGqDLOHfIiHGaofUafQj!-27bCKFBctI!31asiB2beFHaCfhIEAjGhHfMjAGNhCoCFADaG2gLHbfLfdIGf!-27N!26bM!-38!27rcJ2HO!-39G","o3":"1|0!64qfaOgCgco2FCLCetJEAVyF2DKhu2eMGcPjCQiqlBI2bD2dFeAEHoJbD2cGdECRCDqEfbaHcfAbBF2GhfBahGBDAEfaCbaebGEc","pm10":"1|0!26da2HcEjBhJaCBeDg2CBDeABEQmgiC2DB2bcJCj3AcDADB2acBF2caABcHCaBDAGecChFeCbECeCc2BGbc2dJKdFoQncA2FJod","pm25":"1!64kaPVhQ!-32blTfDBgDnCIAQpbEL!31!-28ydDFDCahDQLzLmabFAFBe2AaCJfiBDfKMDkF2GpfGkFdCDCIgceFbGcfBJlTAJ!-30UlgaKOT!-28m","so2":"1|0FAb6AB5AB3AB2AaAbBAbAB3Aa2A2Ba2AaBaA2BA2aBAa2BaBaBb2AC3aAC3ABAbDA2aBAba4ABa6AaABaA"},"dh":24,"time":{"span":["2018-07-01T00:00:00Z","2018-10-07T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"20328h11m24.233494961s"}
+
+
+        event: debug
+
+        data: "Fetching 2018-Q2"
+
+
+        event: data
+
+        data: {"msg":{"st":422928,"ps":{"co":"1|0GbABEBabA2aBDAbC2aCc2ACa2BbcACFcDbadCB2ABb2AaA2B2AabA2Ba2AaBABb2Aa2AB3AaCAB2AaAaBABaBba4A","no2":"1|0!32NIbeIElCAncWBgLbNM!-31HgHeDIe!-27lP!37qIbdjMNjsKaneEeIKCGAtAQHoPxfRCNqamHBGgcfPnWmJfaCBh2a2ASbefc2a","o3":"1|0!27aGAbCbgeFiFBOaDABQngLmcEDjDFCaAbA2KMguBahIBJkabIAaDAjAWja2fDcEFhBCeIdAbfJcBdbAkbREBKU!-30eKcEX","pm10":"1|0RAEAeJLhaJMfdKlhbIRjIknabEbfeIDfKDGFEBrfGabdA3CIaLjcTgNbE!-29EKilACeOfbCf2AH2beaCcCJfCaGbAb2aC","pm25":"1!58Ab2fTVfOF!34sw!28v!-38B!31TqW!-27!-37HgEFbiHBgRGTPRl!-47hELAtJbdFLJ!28!-27gUHW!-30V!-30E!30w!-32cMnGDbCakFEDFneFeBdDKBHgALkfI","so2":"1|0D3AaOm2Ab2AEbaCbCA2aAC2ABac2ADaCba2ACBcBAa2Aa2AB4A2Bb4AaDbAa3ABaB2AB5ABAbBaBAB4AB"},"dh":24,"time":{"span":["2018-04-01T00:00:00Z","2018-07-01T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"20328h11m17.317118562s"}
+
+
+        event: debug
+
+        data: "Fetching 2018-Q1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:40+01:00","st":420768,"ps":{"co":"1|0DBa2Bab2CBcAa2B2AaCbBADcAbAaBCabBAaABADaDbEb2ADa3bDA2BAbDAaAabaDAaAbBaC2aC2ACbDfBaAEb2BbaA","no2":"1|0!39FlNJphBOIrJjIJGdjWmdcMEFsJoDXiyBWuPca!31!-39Z!-30!30iKaLjfpmNKchdFKAp2BMGTmgDfehLaHF!-32AFJ!39xBrfOCHBmjd","o3":"1|0!27aEeadAdmMjRfdK2DClBcGEadjKGBgHgadGabdL2d3BAEhDEhGfDb3DcabaiOCceFjFaBaKABeAJaeEDoJCBeDfCF","pm10":"1|0SIDgDCjLKeB2bFpbFaMm2CdbLIkiCQoDFehHPIjmClOhEGIBfbi!28ncIqJFiPGQ!-33eBCgJbEkEeAJeHEcCc2FDjlaEi2A","pm25":"1!48JEgCV!-31!27ZySgCH!-38iEbGCMlfaKYqsDSqd2KsIXeiqCnQaKcEOgLy!65!-31iN!-37gGU2X!38!-75zFGxVaGbehDEAJlhQic!37I!-35iAda2D","so2":"1|0EBACaeaEBCdBbBDB2aEfBAFcadBaBEabaDdaCBFeCbEc2BCcaBcaB2A2a2BAB2ABD2a2Aa2Aa2BcaAaDaBAaA2BAaBb"},"dh":24,"time":{"span":["2018-04-01T00:00:00Z","2018-04-01T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13866h1m25.030555594s"}
+
+
+        event: debug
+
+        data: "Fetching 2017-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:45+01:00","st":418560,"ps":{"co":"1|0CABaAC2AC2aC2aBABa2A2aDaBAbCdED3AeADbaDba2AEAbBcACAaBABaA2aAaFcBCA2aCAbFabeACAEb3a4ABbAa","no2":"1|0!35MjOtHBfRfAIjcDAJlCRvARfIgkGqTYaqN!-29eVdlPiAoHWfbFiaFBeLjdbEhAfATmIMKyBMne!30fH!-32CFaShAghejNhVAf!-32","o3":"1|0VD2aB2bBhHBcAaNAeqTaBAiHArKDFkabhJCGiOcqTkMhgbGAcCEGEAqHCDjEIBpAcNDBfeEabOcjgLbmaKaJGCbBqQ2C","pm10":"1|0.2NfDhEcCHdBQkBHFbGgmahJbFD2chNGDOCseKpaLiDkHJBdFfdAFDfEbfdDdDaPcaecaeOdmTmIiDCIOk2difEdbPdIt","pm25":"1!48MbaiGBCOlhRAHMAr!34l!-36BgMFGRninTEJ!26N!-35fM!-34APrIlOcRjOmkACDl!34jzcIeaB!30obhaBg!28wb!33!-28DdALI!31ujiojHlCQaG!-36","so2":"1|0DBbDd2BaDaAB2aA2Ba2AbAC2ABbBaBCADBRsD2bCcdaBE3aBaDBcDbAaBba2ADcCDabaDcbJaE3ACF2gdAD2IaoaAd"},"dh":24,"time":{"span":["2017-12-31T00:00:00Z","2017-12-31T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"8ms"}},"status":"ok","cached":"13866h1m20.300750676s"}
+
+
+        event: debug
+
+        data: "Fetching 2017-Q3"
+
+
+        event: data
+
+        data: {"msg":{"st":416352,"ps":{"co":"1|0CA2BbCa2BbBbCBAb3BbBaA2aC2Bc2AaA2BaCA2a3AaB7ABAaB2ABaAa3ABa%Ba6ABAa6AB2Aa3A","no2":"1|0!33h!28KjOtp!28lKz!30!-34Jl2NceAafhFMedEjHDdbKqIEkCESwDZmHfClEAEbGKnhSgpQiId2C%!-31GNJFbjEjbKGNBAmcGbJGdeo","o3":"1|0!27EeAFZvAJnhEKi2fVHijFcbAGh3BEaCdC2BDg!47C!-45bAJaeJifFBkbSJOreOzdHDCBja%b2D2BJHbsFcfAGcDIsaPceFa","pm10":"1|0WdDAFJldFcabHdAfJKbhcdBcGECAebNjfNecbBdbKDnDHcBaBeBCPJwOgaSmX!-28dAeAa%lEIBaAcBAbICFeAdKOAGxDhg","pm25":"1!63lFEGSqiFfadIEejFOGoAiEbMbdeadG2aBFadEKh2EpEGabAbgCD!36C!-35U2B!38!-34lhKgnFe%!-28BVHcABGFiRIjeAd!29!32a!27!-81Iqh","so2":"1|0CaDBb2AaBABbDcC2aBABaABbACAaBa2BAaAbABA2aDbaCaBABbABAaCAbaBCbCb2ACA%bA2B2AbB2aABDaCcaBA2BA2a"},"dh":24,"time":{"span":["2017-07-01T00:00:00Z","2017-10-01T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"20225h1m35.724625024s"}
+
+
+        event: debug
+
+        data: "Fetching 2017-Q2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:53+01:00","st":414168,"ps":{"co":"1|0EbCbA2BDab2BaBbCaBb3a2BaAC4AaAa5A2BA2a2BABABaBAaBAa2ABbB2aAB3ABa3AaBaCABaBAbA2aBaAa2A","no2":"1|0!50rYsAIe!27.2rHCeDiAaGVbpd2DkDNdKrcHaCagdDHSCdcmN2cb2EcPmANehiBIhOatDIaDFbldLBDCpDKTcAkfkgJIlZyBi","o3":"1|0!37cCiFcDKBjBaAdKebDdBK!26ynbcEdLBfaDABdHeabeMCehaiKGCFEt!70!-37nafBgfOcBcacBbCBDdAPkbJZD!-28!45!-39reAIhabHCE","pm10":"1|0YaLgBHBLavBCafcABFCHEnDEiAIAbBkRCEjEcB2AQnbjD2CAfabKfDJebeBdFAFgeDb!70!-67FecCDFCfCBLGbgnbeIFgaACd","pm25":"1!60F!28wHKBWh!-40eIBodHebMSEubPrDEIfDvZHBu!32kpaG!45!-28luGDSfkhbVmMCcDkBeBEWzkFbCJBdfC2GEhLDPNioydhIPBjDCl","so2":"1|0DbCbaCaC2a2BbCbAaABDabBCbaCaCbAaAaB2AaADBA2a2BAa2AaABaBA2aBCaC2a2ABaBA2aC2aCb4AB2AaAaBACbaA"},"dh":24,"time":{"span":["2017-07-02T00:00:00Z","2017-07-02T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"20ms"}},"status":"ok","cached":"13866h1m11.874440779s"}
+
+
+        event: debug
+
+        data: "Fetching 2017-Q1"
+
+
+        event: data
+
+        data: {"msg":{"st":412032,"ps":{"co":"1|0.2CbFAcBaAaBbB2ABDbaBICcbeA2aA2BbBCbDbcA3BaAa2BaBaBcA2BACac8ACAaA3Ba2A2BAda2ACBa3Aa","no2":"1|0!32RdMP!-34.2HbhJpBDNHNkcdJLcgqAbdAaEeLOuLBkI2iBALEHcefcHDpKcgRbGgAcfbKEeKflEBJbcjeOEBjdCfIJAJBjq","o3":"1|0XjGhCAbIfOcB2fbBfAEac2ABFfTaheHIFlbDEnHeFd2bKCaHcfFHCbBCDcABeJ2bcHglBcMgcBIbDaCAdALehKBGcAd","pm10":"1|0!27BFMBtDeKW!-32.3AGPQakBXKqsMDwpICiCFCeOgGAJgGKio2BAge2cCEDmCIEDAfiJBAcEJCjaIBkecFDb2Iqd!27EwBaca","pm25":"1!72hJZDoDrLhfCbdQT!26H!-35H!60Nv!-36YA!-74s!29SxneOKZxMN!29jKL!-36zmLMokiCkNBoGCFALknLEQiBVM!-37HJL!-36ceF2B!31K!-37f!65D!-56aBeF","so2":"1|0CEcBDc2BAaCBd2ABCbaBDFb2c2AaBABaABbCabaB3ABACAbAB2AbaBaDB3aBa2ACbBA2aC2BbAaCAb2a2ABCaABAb"},"dh":24,"time":{"span":["2017-01-02T00:00:00Z","2017-04-02T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"20225h1m33.324809918s"}
+
+
+        event: debug
+
+        data: "Fetching 2016-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:10:58+01:00","st":409800,"ps":{"co":"1|0DaDb2aBa2AC2BABaD2ba4ABC2aCB2AcCabaA3B2AaBAcAD2aAE2acEaBDIfedAECdaAaCABAaACb2A2BcAaBICdbcb","no2":"1|0!47oUlbHAncIGfAFJjTqfaGgbL2IbjIg2CLPm!-28lMNhJB2gVmKCImpIFgbEhaMPXlsgbFIafAjGBCEhCFBajIPpew!49Ua2uh!-28","o3":"1|0SFebDGjKBcfBgAPCaAg2cEahcNFbodaPb2cMcCm2Ed2DdBGFBiHCagIagECsbACMfjDGCbQoHgce2aBAIKkQEabwbDADU","pm10":"1|0XbIAafEdeG2ADHbjHgBDabCJLchCLJDkmKhCmcLlJGiDJ2fD2biIA!30!-32AGfDR!40whwC!27BmfA2fECJBJgjLgeDoJpE!27Nhfnp","pm25":"1!63AIambRenKCaHMftIkMaJhEQXnoGU!34B!-33sNrCloVvHShgRmjAcbFX!-32RvEYij!40!54lo!-66J!63R!-43hcklFMLEXgrMj!-30EtCsI!53!41og!-36!-35","so2":"1|0GdEDbdB2A4BDBeDcaBA2B2A2a2BGcfdF2aBaCbBb2aFa2ABa2BbBcAC2aCHbAaB2Ededa2ABab2BbA3BcaABCB2Aba"},"dh":24,"time":{"span":["2017-01-01T00:00:00Z","2017-01-01T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13866h1m6.914738422s"}
+
+
+        event: debug
+
+        data: "Fetching 2016-Q3"
+
+
+        event: data
+
+        data: {"msg":{"st":407592,"ps":{"co":"1|0F3AacFDaABadbDaBC2BcBAaDC2baBaDBabAaBbaDBbcbB3ABa3A2BaADcCaADaACA2acaABAaCaD2AaDAbdC4ABab","no2":"1|0!54oBGtJ!29wdfJblFQrdXNbyLFpaHaKBtcUeCdAbfc2ADRkhNBJeGscNUCpfdfd!35.2idemQaPA2h2FRCi!-31g2GEZdGkmMeAbKio","o3":"1|0XaFeGDb2fHdcCGfbDWbItgVobcdFfIBiaFBHFhcBaeLeDbGFBgcAaONojGgDJpDkHAjc!28iceJeUbFuhNkcTmFIfkaBDAcE","pm10":"1|0!26gBCcCGcbd2EeaDfaIGHoNghBDA2CehIBC2bDdAEcAEga2DI2BhjMBJClDfbH3acdIEBAgbADRdBdrCNfHaefBNjIiFhb","pm25":"1!59BeIqHRBAgFEfBeiB2KMpXsuBHFebJsIDcADElJCeCFkaCEOaN!-28jQFWKqgjFacdDejNPeCobcF!31BGsuKWiCgobgHBHjGbA","so2":"1|0Fa2AaAD2aC3AaBaA3Bac3ABaACcACAa3AaAa3BabC3AB2a3BbBaAaCBAaABaAbCAa3AaAaAB2A4B3ABCB2d"},"dh":24,"time":{"span":["2016-07-01T00:00:00Z","2016-10-02T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"3ms"}},"status":"ok","cached":"19313h2m24.396385214s"}
+
+
+        event: debug
+
+        data: "Fetching 2016-Q2"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:10+01:00","st":405408,"ps":{"co":"1|0HbaAb3BbADb2A2aBDcAa3ABaACBbEcbCAB2aBCDe2aBABAaBA2aABCab6Aa3BAcCABAEda2ADCBbCdc2AGbcB2A","no2":"1|0!68miOkMjCegHNaEcvcWmABahdKh2JdnJmL!28FdqbHjAEqbKDOajFljaEDUghtdFCJFdeU!26oiVrnAHECodCAQFcAsgdZcKepB","o3":"1|0!29GgCBbi2FEsQeHhAGdFeC2AFhDCacFEfDFEgKHnra!33mcEcaAhAaEbaFbEF3d2CbcHjdPpUA2kBFEAfIjCdhQaACAgGbaF","pm10":"1|0!34bAcbabFibYoCDehAKfHDeiBFf2FDkDACHGFBpJbGAhlHFdcAadbcAJ2EbjceEaILcaQjdDdfFfBcBE2fG2DchbaMdBCgB","pm25":"1!83fJpehCLua!55!-40KACocKkEJdhDLpHKHpfDHBJTO!-38LJVourUAcfBfeajbT2GJqhjBcZUrhYcieGqBcBcKajkLJGmjAhTdGfBe","so2":"1|0FbAC4AaA2BaABabCbABaBACAaBab2A2Ba2BABa2Bba2ABCaABAcbABAaB5ABaAB2A2BABCAaAbaCabBAbaA2CbA2a"},"dh":24,"time":{"span":["2016-07-03T00:00:00Z","2016-07-03T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"7ms"}},"status":"ok","cached":"13866h0m55.175312122s"}
+
+
+        event: debug
+
+        data: "Fetching 2016-Q1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:17+01:00","st":403296,"ps":{"co":"1|0F2BbCcBCAacBDaB2Ffb2c2Aa2B2Ca2BAbcCBCBCgaABEabCdbACE2AaABAaca5A2BAbABAB2aABABCcb2A2BADba","no2":"1|0!44HBkRrbMgJkD2FbZM!-28lAnI2bMkaAaGdCGrDGMk!28rigWOasUtkAGTCdzcQDceNreHUpaLgmCDcLdgcJIBTwgba!27iDJmi","o3":"1|0TAqVhOaeabAciJbnAL2CbIEBACAdEbiB2GCagehCAN2cBbHDAcgjHAGHfEBababCbBlCFHBLgDdGdede2HC2abcACGg","pm10":"1|0ZFIrNjeEAJmCSoL!27LqmdrKBnSlEgIGiAEfeNbg!26rBfFMehGmeBKUbAlqMbdAHbBDGqWRGumAcMphBNDKAvCbdHDcJbA","pm25":"1!54H!30!-40UojNdGnF!30xN!67V!-50!-27eqDboMhBAIFeEAerQCB!35zPwKHcbCzfMJ!40Bcl!-38LeiHDUlaMi!41!45I!-45!-30dg!28!-32tA!37BTh!-38dtFHFLQfJ","so2":"1|0LABaceBCaA2bCbCFDeA2aBa2BbB6A2BABaCbBadDaBAaABaC2A3a2C2AfaAEbaBAbaB2ABA2BA2Ba2BCbAbAbA"},"dh":24,"time":{"span":["2016-04-03T00:00:00Z","2016-04-03T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13866h0m47.915680282s"}
+
+
+        event: debug
+
+        data: "Fetching 2015-Q4"
+
+
+        event: data
+
+        data: {"msg":{"st":401016,"ps":{"co":"1|0E2B2A2aACcABA2B2aBACEcB2aAC2AaAFdcaCAa2ABa3AaCaAabACDacG4AaAba2AaAB2Aa2AB3Aa2AaAaAaDaBb$BaA","no2":"1|0!42VlEiGkIMsdQbCbAnhTLci!27eljfMBgiEcBMBkhCFCJACkpVhCOjqLVfoLcehNJceBjdEKDdBhgIbKcKsELmK2khQbRp$BjJ","o3":"1|0YfdToagHgHFbBAdFBdBefQjIiadGDcibaFCICAaHbBbFe2C2AbfHmCHefMFBcCEgBGAiAaHiIiciSiEaIa2B2aCAlKB$jCG","pm10":"1|0!28IOfncBGKrMake2HghGIDcFlAJModBUKkcfkcAbFaBHcicGAGabkHOlbKhbcAEGCecbIdEcaAeJEdPl2ebgLfdF!33smd$HlC","pm25":"1!66U!43s!-28efJW!-34!28dyoULodHKHpJfgMPthB!43!41!-36lksefAeGdKkagHcFJncP!37!-43GLgqcCJIFjhaQdACfcBQMtZpdrcQjflS!38wpi$Opf","so2":"1|0C3BAB2ABd3AaBAaA2BEbBba3BaAaCa2B2aAaB3ABbaCAaCbBaCAa2Aa2ABaABaABABaBa2AaB2AaB2AaBa2ABAB$aDB"},"dh":24,"time":{"span":["2015-10-01T00:00:00Z","2016-01-03T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"19313h2m21.256849214s"}
+
+
+        event: debug
+
+        data: "Fetching 2015-Q3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:23+01:00","st":398808,"ps":{"co":"1|0Iaca2AB2aCaC2AFfCaAB2A2aAD2AcbFbABb2BcBAa5ABaCBA2aBbBaBAaAaCAa3AaBA2BAaCAcD2aCBcaCaAa4A3B","no2":"1|0!86pycgOEnDXufHeBMJfibMBeF!-31XCdnGXpCeiNMflHkFfiPpDMICjCdDhJeGDgnDKBaBbhHAcNDhgEGfIZvaKfBClafIb2aVmF","o3":"1|0!69!-32ca2cBDFHmifaEPcFarG2DcCcaEcALgStCabDNenjKdGDdJiDjGQfpBCAECc2bCBcCHha2DIcgDBABjLEjfABEBCea2DgdU","pm10":"1|0!44.2kLiaCaJebgBaDLBhcIe2aFjEAdCKdGkEaCdDBeaBbLFkACFic2BCfEaDAdHkHACcaAcbFKInABDeFDiHdeGAHdj2EDcIOf","pm25":"1!104!-27x!28sbgGeJaeHfDKadiRjbfOpJghBAVdiJdIabda2cg!27T!-30bCMhfCBFkDBDdaKrQcCAiBiaGPQugEAhPbdVewEFGBoACEBU!43s","so2":"1|0FBbBAB2Aa2BaBbAaBAaB3AaA2B2aABAaBbaE2aB2Aa2B3ABaBaABCbAbAabACA2a2AaAC2BaACBbBAc2CbBAb2aBaAaCAB"},"dh":24,"time":{"span":["2015-10-04T00:00:00Z","2015-10-04T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"6ms"}},"status":"ok","cached":"13866h0m42.54271268s"}
+
+
+        event: debug
+
+        data: "Fetching 2015-Q2"
+
+
+        event: data
+
+        data: {"msg":{"st":396624,"ps":{"co":"1|0EBAaB2A$aAb$A2BabAOCdedC2bBABa4AaBCbBaCBa2A3BabAabBAaB3AaB2A2BcAB2AC2BbaC3aD2AaDA2aCaABacaA","no2":"1|0!35HgdbHE$YD!-30.2EICqBgCOBbMQxrEJQjifcAFLTCyHIfCberKLcn!27roFhJNoNfjJbA!27c!-28cJhMNKqoFWkrBNqLc!39fG!-29BMQJpybh","o3":"1|0!29cfBGAc$aJDBgHAlGFaBbcADbdhHCAabIEcabdLagF2eGIdbeBJqEDGcEAfBACBfHhHEjEFJanaBHpLajHfGHADfhLKY!-28kEd","pm10":"1|0UDaBbFd$!37B!-34bEDGjeBAMagDUxfIBUzDAfAIcBJjFcaFgEdBcbLABfdDcEdCbaHdEJEtBGCdFRmegJbJcgiECAKfcbBIK2kLi","pm25":"1!46JFGeJu$!100e!-79i2JPxm2BRbAH!49!-48pFeJgeHabKfDI!-27LDiEHdDhAgKNdibEeNsIAhJbCLS!-39EHkFO!29jsuScDEBr2BNGdkCDE!36!-27x!28s","so2":"1|0E2A2a2B$aCaA2BAbAa4A2C2aBAB2a2BAB2aAbABAbBa2ACBcEacBbA2BC2aB3AB2bBaACACbaCBcACaBbDB2aABAaBaAB"},"dh":24,"time":{"span":["2015-04-01T00:00:00Z","2015-07-05T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"19313h2m19.390412294s"}
+
+
+        event: debug
+
+        data: "Fetching 2015-Q1"
+
+
+        event: data
+
+        data: {"msg":{"st":394464,"ps":{"co":"1|0DBAD4ABbCACbBA$AcC2AEeEfDBcAabC2Aa2A2BCA2abCBdD2AaCBABcaba2CbC4AaCc2aADA2aCbADaCcBaABaABAaB","no2":"1|0TIKaGfDBanOAIdCjkCPKhDHwOh2DAbdhLKbjnTfFIkLbkCGmH2EmdPiGRlojQFaHegACLhCioBNbBFLqgQFElJoaEmOHgdb","o3":"1|0YEgmGKAEDadIeAFmiBcAEhCSkImP2bAGnFcDAaGhBEpTCkaHFDeDEa2fcDLEcabgK2ahaCaDEeibOIDfAlGgLBcHcD2cfBG","pm10":"1|0!28kaRdjDcBiIbBACFlDKRkKM!-31No2dcHcDKbImCAQaHaMnvXfoGa2deJbGFbkaBCFEeM2fJKb2hKHUfgaxFdFJtFdeEfHDaBb","pm25":"1!75!-33H!39puCcCtOaCcIBfIUZr!32S!-82TtatEMbeQIDpfVFSbN!29!-28!-46!47j!-37LbkaeHdHcKpbaDFOiVlab!38donPX!52m!-37E!-55k!27lX!-33FArFkQJFGe","so2":"1|0DAaCBa2ABc2BCaBbaABDbaFgDb2BCAabBaAbAa2BDaBa2ABdCB3AC2abDbaCBcDb3AaBAacBDabACaAC2A2Bb2AaB2A2a"},"dh":24,"time":{"span":["2015-01-01T00:00:00Z","2015-04-05T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"2ms"}},"status":"ok","cached":"19313h2m18.233867345s"}
+
+
+        event: debug
+
+        data: "Fetching 2014-Q4"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:30+01:00","st":392256,"ps":{"co":"1|0FABcBACac2BaBAaDbaACdB|35GEbCbcAaAbAbABa2ADbACbaD2BaAaACbA","no2":"1|0!36ALtGCKfiDGmADCVkhaLrH|35.2Ek2AaPcfDLkBLDcbEnWeicEcDaBndKjB","o3":"1|0RgLbAcGcDhJADtBHE2CdDe|35lAcAICJ2bkaTiHJbEzTcqOFCdFAFbibGd","pm10":"1|0!34bElcBEaAcabcBNBAgaElKDB2eFIj!26gjgcDJLwDFfecHFDefEVCAfvVk2DCIeifABFCnBIAdcPjDGldaAbDbeFCeO","pm25":"1!69DLveCFAfdECoCXbe2fMuP2GhkLPm!51xylEFT!26!-50GSokCcNKbmI!46Ddt!-36!28kJFcTfrsiPIE!-31bNcdaZqEPwheDcFfhKLlL","so2":"1|0DABcBACAbABaBAaDabACbA|35DCbA2bAaCBAaADAaBAaDA2ab2ABAba2Bb"},"dh":24,"time":{"span":["2014-12-28T00:00:00Z","2014-12-28T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"3ms"}},"status":"ok","cached":"13866h0m35.109868611s"}
+
+
+        event: debug
+
+        data: "Fetching 2014-Q3"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:34+01:00","st":390048,"ps":{"co":"1|0D2BAa2A2aAB4ABa4Aa2ABAa2AHeC2aB2AaBA$BabCcAEd2ACbA2Bb3A$DCc3ABa3BaAa2ABACBbaA$3AbBC2aABcB","no2":"1|0!48ELi!-46!31cEjFGfiKAMdNmtAiIkOfBdbGTFmAGDcAFk$KBpLdaZ!-27dCSneLfeImjcKXlHaN2gIHhcDmgSajIEiaDjDUbhbNCoALtG","o3":"1|0!29aIboFfbMgdVoFaCbScjfdMBhQlfMcfCbDcABadA$cHiBaKahDaB3CjMjCeADpMJiJdDAfdbIGCjDHAo2GibF2beHaJigLbA","pm10":"1|0QGAanLdCDbAFgACHcJgA2cD2ADfeAFGBedEBabId$bBfCA2bAbEFfaENlGhCgDKcLCNFmgAfMhfaEWACcfwRHmEdcHOfgbElc","pm25":"1!49LEb!-31YiMAfGIpdGLj!29nBeiEaEGmkbMNFklIHdbSl$fbnKbceAgGTtbP!32!-35LnBmK!26lZC!28W!-34wAm!27uiAD!54GElu!-44!39!27!-37oab2YtwDLve","so2":"1|0EB2AbB2Ab2A2BaBABaA2a2A2BABACBab2aC2AaBA$BABD2CjCdBCba2Bb2aABACb3A2BAbBbB$a2Ba2BbCRfj2AbACa2ABcB"},"dh":24,"time":{"span":["2014-10-05T00:00:00Z","2014-10-05T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13866h0m31.236732747s"}
+
+
+        event: debug
+
+        data: "Fetching 2014-Q2"
+
+
+        event: data
+
+        data: {"msg":{"st":387864,"ps":{"co":"1|0EB2Aba2ABABDcaCE2aACABaBaAaABA2cACABaBbaAB2aBA$BABbB2bA$DBAa2A2B2aB2ABAb3Aa3ACaABAaA2BabCaC2AaA","no2":"1|0!50bqHijKEKcLkoMaUeufAOKEahaeEHPflgNCDadeiCEDAbaqSKDkaBekJBjIgKhPeE!-31!32hBFbfEalhKcGaFcDIhAGEolXEFLj!-46!32","o3":"1|0RdbP2bBJgACAE2cIdDAdcCAeaLg2ALk2F2GmfACcCbgIAaEShckFAfDnGAcGLfahDaMCAbdbFDhbdHlfOIecD2AdhIDCaIaqG","pm10":"1|0!45SbwqfCALeDFkBaLFqA!30ghfcLmdPIbh2g2GecACeAaBcKB2ALjgcCacABWqAcFb2aiJDhFdCEC2gDFfJeBDaDjGHieHbGAanL","pm25":"1!105!39k!-34!-42hafWiGKsDgQO!-34F!68j!-29hdV!-30g!33Vcr2qPLmfBCfgDIcQHeBZuoeAahbCAThbMcChzWPnLgfGBhvHFfYpGEVk!-30MTvmRALEb!-31Y","so2":"1|0GabFdABaCabB2aACBdA2BDaAa2AaBCAe2BAD2A3aCabBAbC2BaBaA2aACAbABC2BdCAa2BbaBAbCAa4AB2aBCAbBAC2AbA"},"dh":24,"time":{"span":["2014-04-01T00:00:00Z","2014-07-06T23:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"}],"city":{"name":"London","idx":5724},"timezone":"0.00"},"dt":"3ms"}},"status":"ok","cached":"19313h2m16.447497594s"}
+
+
+        event: debug
+
+        data: "Fetching 2014-Q1"
+
+
+        event: data
+
+        data: {"msg":{"now":"2020-09-20T08:11:45+01:00","st":385704,"ps":{"co":"1|0EB3AaC2ACBAbA3abBEBd2Aa2BaEHhcBaCABAbA2BdABCabC2bCBaABEfaBaBCBAB$abaC2AcABADbEAaBc2aBABaB2ABca","no2":"1|0XG2a2ABDAOSy2AdcHfa!29gnbKsCMaAEem2CHcHgmCTAiKegIBCikRGnMIDdajhXJbmbzINqOLI!-32CKaHjNsaSCBAcgGFBbqHij","o3":"1|0!29cFdcEAfCimKMiICDnEpOABdNaAcemNEAeJEaACAmHCAFAka2ACEaFbDqIfALdkDNiGE2aqICKCnIaIbDbcbebdQ2bjeaOba","pm10":"1|0QEHicIHfcGNfkDcB2bDRGqeFgbEcbJfiGACDacaBC2aDcBEBDAlHadGbGdgOlbSJke$NjcSQG!-44dLfHagiaHDBIUbgkLSbwqf","pm25":"1!37JDadbAfOL!45p!-37Fh2DcG!40K!-44bDjgGeD!26p!-37MKEBHfhaJCeBcDKCJDyI2fSiIeg!27!-27a!34Nvg$Zqp!48!42J!-95hVoHalsAUHDS!51es!-31X!39k!-34!-42h","so2":"1|0GFh3AaCaDbABAbCAcCDBcaAaAD2bCBbAaCABAbACACab2A2BbaC2aCACaABA2BacAdBAbDAEdBC2AbCbaBaAB4ACacFcA"},"dh":24,"time":{"span":["2014-04-06T00:00:00Z","2014-04-06T00:00:00Z"]},"meta":{"si":{"sources":[{"name":"Citizen
+        Weather Observer Program (CWOP/APRS)","url":"http://wxqa.com/","pols":["weather"],"logo":""},{"name":"UK-AIR,
+        air quality information resource - Defra, UK","url":"http://uk-air.defra.gov.uk/","pols":null,"logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","url":"https://londonair.org.uk/","pols":null,"logo":"UK-London-Kings-College.png"}],"city":{"name":"London","idx":5724},"timezone":"1.00"},"dt":"5ms"}},"status":"ok","cached":"13866h0m20.38057462s"}
+
+
+        event: done
+
+        data: "2.912103ms"
+
+
+        '
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Type:
+      - text/event-stream; charset=UTF-8
+      Date:
+      - Thu, 21 Apr 2022 01:12:05 GMT
+      Server:
+      - nginx
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_multiple_city_air/test_bad_city.yaml
+++ b/tests/cassettes/test_get_multiple_city_air/test_bad_city.yaml
@@ -1,0 +1,150 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:13 GMT
+      Location:
+      - /feed/london/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":52,"idx":5724,"attributions":[{"url":"http://uk-air.defra.gov.uk/","name":"UK-AIR,
+        air quality information resource - Defra, UK","logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"url":"https://londonair.org.uk/","name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","logo":"UK-London-Kings-College.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[51.5073509,-0.1277583],"name":"London","url":"https://aqicn.org/city/london","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":1.7},"h":{"v":80.3},"no2":{"v":6.5},"o3":{"v":32.1},"p":{"v":1010.8},"pm10":{"v":18},"pm25":{"v":52},"so2":{"v":0.6},"t":{"v":8.8},"w":{"v":3.3}},"time":{"s":"2022-04-22
+        01:00:00","tz":"+01:00","v":1650589200,"iso":"2022-04-22T01:00:00+01:00"},"forecast":{"daily":{"o3":[{"avg":17,"day":"2022-04-19","max":34,"min":2},{"avg":25,"day":"2022-04-20","max":39,"min":14},{"avg":25,"day":"2022-04-21","max":37,"min":13},{"avg":24,"day":"2022-04-22","max":33,"min":17},{"avg":28,"day":"2022-04-23","max":38,"min":19},{"avg":30,"day":"2022-04-24","max":38,"min":24},{"avg":29,"day":"2022-04-25","max":29,"min":29}],"pm10":[{"avg":23,"day":"2022-04-19","max":31,"min":13},{"avg":19,"day":"2022-04-20","max":36,"min":10},{"avg":20,"day":"2022-04-21","max":29,"min":11},{"avg":18,"day":"2022-04-22","max":23,"min":12},{"avg":19,"day":"2022-04-23","max":22,"min":17},{"avg":16,"day":"2022-04-24","max":19,"min":13},{"avg":17,"day":"2022-04-25","max":18,"min":17}],"pm25":[{"avg":64,"day":"2022-04-19","max":81,"min":45},{"avg":59,"day":"2022-04-20","max":94,"min":33},{"avg":59,"day":"2022-04-21","max":78,"min":40},{"avg":55,"day":"2022-04-22","max":63,"min":41},{"avg":58,"day":"2022-04-23","max":68,"min":53},{"avg":49,"day":"2022-04-24","max":60,"min":40},{"avg":43,"day":"2022-04-25","max":43,"min":42}],"uvi":[{"avg":1,"day":"2022-04-20","max":4,"min":0},{"avg":1,"day":"2022-04-21","max":4,"min":0},{"avg":0,"day":"2022-04-22","max":3,"min":0},{"avg":0,"day":"2022-04-23","max":3,"min":0},{"avg":1,"day":"2022-04-24","max":3,"min":0},{"avg":0,"day":"2022-04-25","max":2,"min":0},{"avg":0,"day":"2022-04-26","max":2,"min":0}]}},"debug":{"sync":"2022-04-22T10:26:00+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:13 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "93.352\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2273'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//paris/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:14 GMT
+      Location:
+      - /feed/paris/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/paris/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: "{\"status\":\"ok\",\"data\":{\"aqi\":\"-\",\"idx\":5722,\"attributions\":[{\"url\":\"https://www.airparif.asso.fr/\",\"name\":\"AirParif
+        - Association de surveillance de la qualit\xE9 de l'air en \xCEle-de-France\",\"logo\":\"Paris-Air-Parif.png\"},{\"url\":\"http://www.eea.europa.eu/themes/air/\",\"name\":\"European
+        Environment Agency\",\"logo\":\"Europe-EEA.png\"},{\"url\":\"https://waqi.info/\",\"name\":\"World
+        Air Quality Index Project\"}],\"city\":{\"geo\":[48.856614,2.3522219],\"name\":\"Paris\",\"url\":\"https://aqicn.org/city/paris\",\"location\":\"\"},\"dominentpol\":\"\",\"iaqi\":{\"co\":{\"v\":0.1},\"h\":{\"v\":66.5},\"no2\":{\"v\":44.6},\"o3\":{\"v\":35},\"p\":{\"v\":1004.1},\"pm10\":{\"v\":21},\"pm25\":{\"v\":40},\"so2\":{\"v\":0.6},\"t\":{\"v\":13.3},\"w\":{\"v\":3}},\"time\":{\"s\":\"2022-04-22
+        00:00:00\",\"tz\":\"+02:00\",\"v\":1650585600,\"iso\":\"2022-04-22T00:00:00+02:00\"},\"forecast\":{\"daily\":{\"o3\":[{\"avg\":27,\"day\":\"2022-04-21\",\"max\":41,\"min\":16},{\"avg\":23,\"day\":\"2022-04-22\",\"max\":36,\"min\":13},{\"avg\":28,\"day\":\"2022-04-23\",\"max\":37,\"min\":20},{\"avg\":22,\"day\":\"2022-04-24\",\"max\":33,\"min\":12},{\"avg\":9,\"day\":\"2022-04-25\",\"max\":9,\"min\":6}],\"pm10\":[{\"avg\":14,\"day\":\"2022-04-21\",\"max\":19,\"min\":10},{\"avg\":16,\"day\":\"2022-04-22\",\"max\":19,\"min\":12},{\"avg\":13,\"day\":\"2022-04-23\",\"max\":19,\"min\":6},{\"avg\":14,\"day\":\"2022-04-24\",\"max\":20,\"min\":9},{\"avg\":22,\"day\":\"2022-04-25\",\"max\":24,\"min\":22}],\"pm25\":[{\"avg\":50,\"day\":\"2022-04-21\",\"max\":63,\"min\":40},{\"avg\":57,\"day\":\"2022-04-22\",\"max\":64,\"min\":45},{\"avg\":46,\"day\":\"2022-04-23\",\"max\":63,\"min\":23},{\"avg\":49,\"day\":\"2022-04-24\",\"max\":66,\"min\":28},{\"avg\":68,\"day\":\"2022-04-25\",\"max\":71,\"min\":68}],\"uvi\":[{\"avg\":0,\"day\":\"2022-04-21\",\"max\":4,\"min\":0},{\"avg\":1,\"day\":\"2022-04-22\",\"max\":4,\"min\":0},{\"avg\":0,\"day\":\"2022-04-23\",\"max\":3,\"min\":0},{\"avg\":0,\"day\":\"2022-04-24\",\"max\":3,\"min\":0},{\"avg\":0,\"day\":\"2022-04-25\",\"max\":4,\"min\":0},{\"avg\":1,\"day\":\"2022-04-26\",\"max\":4,\"min\":0}]}},\"debug\":{\"sync\":\"2022-04-22T10:22:51+09:00\"}}}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:15 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "74.982\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '1865'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_multiple_city_air/test_bad_data_format.yaml
+++ b/tests/cassettes/test_get_multiple_city_air/test_bad_data_format.yaml
@@ -1,0 +1,226 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:15 GMT
+      Location:
+      - /feed/london/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":52,"idx":5724,"attributions":[{"url":"http://uk-air.defra.gov.uk/","name":"UK-AIR,
+        air quality information resource - Defra, UK","logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"url":"https://londonair.org.uk/","name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","logo":"UK-London-Kings-College.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[51.5073509,-0.1277583],"name":"London","url":"https://aqicn.org/city/london","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":1.7},"h":{"v":80.3},"no2":{"v":6.5},"o3":{"v":32.1},"p":{"v":1010.8},"pm10":{"v":18},"pm25":{"v":52},"so2":{"v":0.6},"t":{"v":8.8},"w":{"v":3.3}},"time":{"s":"2022-04-22
+        01:00:00","tz":"+01:00","v":1650589200,"iso":"2022-04-22T01:00:00+01:00"},"forecast":{"daily":{"o3":[{"avg":17,"day":"2022-04-19","max":34,"min":2},{"avg":25,"day":"2022-04-20","max":39,"min":14},{"avg":25,"day":"2022-04-21","max":37,"min":13},{"avg":24,"day":"2022-04-22","max":33,"min":17},{"avg":28,"day":"2022-04-23","max":38,"min":19},{"avg":30,"day":"2022-04-24","max":38,"min":24},{"avg":29,"day":"2022-04-25","max":29,"min":29}],"pm10":[{"avg":23,"day":"2022-04-19","max":31,"min":13},{"avg":19,"day":"2022-04-20","max":36,"min":10},{"avg":20,"day":"2022-04-21","max":29,"min":11},{"avg":18,"day":"2022-04-22","max":23,"min":12},{"avg":19,"day":"2022-04-23","max":22,"min":17},{"avg":16,"day":"2022-04-24","max":19,"min":13},{"avg":17,"day":"2022-04-25","max":18,"min":17}],"pm25":[{"avg":64,"day":"2022-04-19","max":81,"min":45},{"avg":59,"day":"2022-04-20","max":94,"min":33},{"avg":59,"day":"2022-04-21","max":78,"min":40},{"avg":55,"day":"2022-04-22","max":63,"min":41},{"avg":58,"day":"2022-04-23","max":68,"min":53},{"avg":49,"day":"2022-04-24","max":60,"min":40},{"avg":43,"day":"2022-04-25","max":43,"min":42}],"uvi":[{"avg":1,"day":"2022-04-20","max":4,"min":0},{"avg":1,"day":"2022-04-21","max":4,"min":0},{"avg":0,"day":"2022-04-22","max":3,"min":0},{"avg":0,"day":"2022-04-23","max":3,"min":0},{"avg":1,"day":"2022-04-24","max":3,"min":0},{"avg":0,"day":"2022-04-25","max":2,"min":0},{"avg":0,"day":"2022-04-26","max":2,"min":0}]}},"debug":{"sync":"2022-04-22T10:26:00+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:16 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "174.314\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2273'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//new%20delhi/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:17 GMT
+      Location:
+      - /feed/new%20delhi/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/new%20delhi/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: "{\"status\":\"ok\",\"data\":{\"aqi\":99,\"idx\":7024,\"attributions\":[{\"url\":\"http://worldweather.wmo.int\",\"name\":\"World
+        Meteorological Organization - surface synoptic observations (WMO-SYNOP)\"},{\"url\":\"https://in.usembassy.gov/embassy-consulates/new-delhi/air-quality-data/\",\"name\":\"U.S.
+        Embassy and Consulates' Air Quality Monitor in India\",\"logo\":\"US-StateDepartment.png\"},{\"url\":\"https://waqi.info/\",\"name\":\"World
+        Air Quality Index Project\"}],\"city\":{\"geo\":[28.63576,77.22445],\"name\":\"New
+        Delhi US Embassy, India (\u0928\u0908 \u0926\u093F\u0932\u094D\u0932\u0940
+        \u0905\u092E\u0947\u0930\u093F\u0915\u0940 \u0926\u0942\u0924\u093E\u0935\u093E\u0938)\",\"url\":\"https://aqicn.org/city/india/new-delhi/us-embassy\",\"location\":\"\"},\"dominentpol\":\"pm25\",\"iaqi\":{\"dew\":{\"v\":11},\"h\":{\"v\":41},\"p\":{\"v\":1008},\"pm25\":{\"v\":99},\"t\":{\"v\":25},\"w\":{\"v\":1},\"wg\":{\"v\":9.2}},\"time\":{\"s\":\"2022-04-22
+        06:00:00\",\"tz\":\"+05:30\",\"v\":1650607200,\"iso\":\"2022-04-22T06:00:00+05:30\"},\"forecast\":{\"daily\":{\"o3\":[{\"avg\":18,\"day\":\"2022-04-20\",\"max\":53,\"min\":1},{\"avg\":7,\"day\":\"2022-04-21\",\"max\":30,\"min\":1},{\"avg\":20,\"day\":\"2022-04-22\",\"max\":70,\"min\":1},{\"avg\":23,\"day\":\"2022-04-23\",\"max\":83,\"min\":1},{\"avg\":23,\"day\":\"2022-04-24\",\"max\":47,\"min\":6},{\"avg\":15,\"day\":\"2022-04-25\",\"max\":65,\"min\":1},{\"avg\":1,\"day\":\"2022-04-26\",\"max\":1,\"min\":1},{\"avg\":1,\"day\":\"2022-04-27\",\"max\":1,\"min\":1}],\"pm10\":[{\"avg\":123,\"day\":\"2022-04-20\",\"max\":123,\"min\":123},{\"avg\":123,\"day\":\"2022-04-21\",\"max\":123,\"min\":123},{\"avg\":123,\"day\":\"2022-04-22\",\"max\":123,\"min\":123},{\"avg\":102,\"day\":\"2022-04-23\",\"max\":123,\"min\":73},{\"avg\":76,\"day\":\"2022-04-24\",\"max\":85,\"min\":73},{\"avg\":73,\"day\":\"2022-04-25\",\"max\":73,\"min\":73},{\"avg\":119,\"day\":\"2022-04-26\",\"max\":123,\"min\":73},{\"avg\":84,\"day\":\"2022-04-27\",\"max\":123,\"min\":46},{\"avg\":67,\"day\":\"2022-04-28\",\"max\":113,\"min\":51}],\"pm25\":[{\"avg\":160,\"day\":\"2022-04-20\",\"max\":161,\"min\":159},{\"avg\":184,\"day\":\"2022-04-21\",\"max\":252,\"min\":159},{\"avg\":164,\"day\":\"2022-04-22\",\"max\":174,\"min\":159},{\"avg\":156,\"day\":\"2022-04-23\",\"max\":174,\"min\":138},{\"avg\":152,\"day\":\"2022-04-24\",\"max\":174,\"min\":138},{\"avg\":146,\"day\":\"2022-04-25\",\"max\":159,\"min\":138},{\"avg\":153,\"day\":\"2022-04-26\",\"max\":165,\"min\":138},{\"avg\":143,\"day\":\"2022-04-27\",\"max\":174,\"min\":89},{\"avg\":151,\"day\":\"2022-04-28\",\"max\":159,\"min\":138}],\"uvi\":[{\"avg\":0,\"day\":\"2022-04-21\",\"max\":0,\"min\":0},{\"avg\":2,\"day\":\"2022-04-22\",\"max\":7,\"min\":0},{\"avg\":2,\"day\":\"2022-04-23\",\"max\":8,\"min\":0},{\"avg\":2,\"day\":\"2022-04-24\",\"max\":8,\"min\":0},{\"avg\":2,\"day\":\"2022-04-25\",\"max\":8,\"min\":0},{\"avg\":3,\"day\":\"2022-04-26\",\"max\":8,\"min\":0}]}},\"debug\":{\"sync\":\"2022-04-22T10:17:59+09:00\"}}}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:17 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "338.725\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2527'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//paris/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:18 GMT
+      Location:
+      - /feed/paris/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/paris/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: "{\"status\":\"ok\",\"data\":{\"aqi\":\"-\",\"idx\":5722,\"attributions\":[{\"url\":\"https://www.airparif.asso.fr/\",\"name\":\"AirParif
+        - Association de surveillance de la qualit\xE9 de l'air en \xCEle-de-France\",\"logo\":\"Paris-Air-Parif.png\"},{\"url\":\"http://www.eea.europa.eu/themes/air/\",\"name\":\"European
+        Environment Agency\",\"logo\":\"Europe-EEA.png\"},{\"url\":\"https://waqi.info/\",\"name\":\"World
+        Air Quality Index Project\"}],\"city\":{\"geo\":[48.856614,2.3522219],\"name\":\"Paris\",\"url\":\"https://aqicn.org/city/paris\",\"location\":\"\"},\"dominentpol\":\"\",\"iaqi\":{\"co\":{\"v\":0.1},\"h\":{\"v\":66.5},\"no2\":{\"v\":44.6},\"o3\":{\"v\":35},\"p\":{\"v\":1004.1},\"pm10\":{\"v\":21},\"pm25\":{\"v\":40},\"so2\":{\"v\":0.6},\"t\":{\"v\":13.3},\"w\":{\"v\":3}},\"time\":{\"s\":\"2022-04-22
+        00:00:00\",\"tz\":\"+02:00\",\"v\":1650585600,\"iso\":\"2022-04-22T00:00:00+02:00\"},\"forecast\":{\"daily\":{\"o3\":[{\"avg\":27,\"day\":\"2022-04-21\",\"max\":41,\"min\":16},{\"avg\":23,\"day\":\"2022-04-22\",\"max\":36,\"min\":13},{\"avg\":28,\"day\":\"2022-04-23\",\"max\":37,\"min\":20},{\"avg\":22,\"day\":\"2022-04-24\",\"max\":33,\"min\":12},{\"avg\":9,\"day\":\"2022-04-25\",\"max\":9,\"min\":6}],\"pm10\":[{\"avg\":14,\"day\":\"2022-04-21\",\"max\":19,\"min\":10},{\"avg\":16,\"day\":\"2022-04-22\",\"max\":19,\"min\":12},{\"avg\":13,\"day\":\"2022-04-23\",\"max\":19,\"min\":6},{\"avg\":14,\"day\":\"2022-04-24\",\"max\":20,\"min\":9},{\"avg\":22,\"day\":\"2022-04-25\",\"max\":24,\"min\":22}],\"pm25\":[{\"avg\":50,\"day\":\"2022-04-21\",\"max\":63,\"min\":40},{\"avg\":57,\"day\":\"2022-04-22\",\"max\":64,\"min\":45},{\"avg\":46,\"day\":\"2022-04-23\",\"max\":63,\"min\":23},{\"avg\":49,\"day\":\"2022-04-24\",\"max\":66,\"min\":28},{\"avg\":68,\"day\":\"2022-04-25\",\"max\":71,\"min\":68}],\"uvi\":[{\"avg\":0,\"day\":\"2022-04-21\",\"max\":4,\"min\":0},{\"avg\":1,\"day\":\"2022-04-22\",\"max\":4,\"min\":0},{\"avg\":0,\"day\":\"2022-04-23\",\"max\":3,\"min\":0},{\"avg\":0,\"day\":\"2022-04-24\",\"max\":3,\"min\":0},{\"avg\":0,\"day\":\"2022-04-25\",\"max\":4,\"min\":0},{\"avg\":1,\"day\":\"2022-04-26\",\"max\":4,\"min\":0}]}},\"debug\":{\"sync\":\"2022-04-22T10:22:51+09:00\"}}}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:18 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "99.131\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '1865'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_multiple_city_air/test_column_expected_contents.yaml
+++ b/tests/cassettes/test_get_multiple_city_air/test_column_expected_contents.yaml
@@ -1,0 +1,226 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:25:59 GMT
+      Location:
+      - /feed/london/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":39,"idx":5724,"attributions":[{"url":"http://uk-air.defra.gov.uk/","name":"UK-AIR,
+        air quality information resource - Defra, UK","logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"url":"https://londonair.org.uk/","name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","logo":"UK-London-Kings-College.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[51.5073509,-0.1277583],"name":"London","url":"https://aqicn.org/city/london","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":1.7},"h":{"v":78},"no2":{"v":8.8},"o3":{"v":32.5},"p":{"v":1011.3},"pm10":{"v":17},"pm25":{"v":39},"so2":{"v":0.5},"t":{"v":8.8},"w":{"v":4}},"time":{"s":"2022-04-22
+        00:00:00","tz":"+01:00","v":1650585600,"iso":"2022-04-22T00:00:00+01:00"},"forecast":{"daily":{"o3":[{"avg":17,"day":"2022-04-19","max":34,"min":2},{"avg":25,"day":"2022-04-20","max":39,"min":14},{"avg":25,"day":"2022-04-21","max":37,"min":13},{"avg":24,"day":"2022-04-22","max":33,"min":17},{"avg":28,"day":"2022-04-23","max":38,"min":19},{"avg":30,"day":"2022-04-24","max":38,"min":24},{"avg":29,"day":"2022-04-25","max":29,"min":29}],"pm10":[{"avg":23,"day":"2022-04-19","max":31,"min":13},{"avg":19,"day":"2022-04-20","max":36,"min":10},{"avg":20,"day":"2022-04-21","max":29,"min":11},{"avg":18,"day":"2022-04-22","max":23,"min":12},{"avg":19,"day":"2022-04-23","max":22,"min":17},{"avg":16,"day":"2022-04-24","max":19,"min":13},{"avg":17,"day":"2022-04-25","max":18,"min":17}],"pm25":[{"avg":64,"day":"2022-04-19","max":81,"min":45},{"avg":59,"day":"2022-04-20","max":94,"min":33},{"avg":59,"day":"2022-04-21","max":78,"min":40},{"avg":55,"day":"2022-04-22","max":63,"min":41},{"avg":58,"day":"2022-04-23","max":68,"min":53},{"avg":49,"day":"2022-04-24","max":60,"min":40},{"avg":43,"day":"2022-04-25","max":43,"min":42}],"uvi":[{"avg":1,"day":"2022-04-20","max":4,"min":0},{"avg":1,"day":"2022-04-21","max":4,"min":0},{"avg":0,"day":"2022-04-22","max":3,"min":0},{"avg":0,"day":"2022-04-23","max":3,"min":0},{"avg":1,"day":"2022-04-24","max":3,"min":0},{"avg":0,"day":"2022-04-25","max":2,"min":0},{"avg":0,"day":"2022-04-26","max":2,"min":0}]}},"debug":{"sync":"2022-04-22T09:24:17+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:25:59 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "78.733\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2269'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//new%20delhi/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:00 GMT
+      Location:
+      - /feed/new%20delhi/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/new%20delhi/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: "{\"status\":\"ok\",\"data\":{\"aqi\":99,\"idx\":7024,\"attributions\":[{\"url\":\"http://worldweather.wmo.int\",\"name\":\"World
+        Meteorological Organization - surface synoptic observations (WMO-SYNOP)\"},{\"url\":\"https://in.usembassy.gov/embassy-consulates/new-delhi/air-quality-data/\",\"name\":\"U.S.
+        Embassy and Consulates' Air Quality Monitor in India\",\"logo\":\"US-StateDepartment.png\"},{\"url\":\"https://waqi.info/\",\"name\":\"World
+        Air Quality Index Project\"}],\"city\":{\"geo\":[28.63576,77.22445],\"name\":\"New
+        Delhi US Embassy, India (\u0928\u0908 \u0926\u093F\u0932\u094D\u0932\u0940
+        \u0905\u092E\u0947\u0930\u093F\u0915\u0940 \u0926\u0942\u0924\u093E\u0935\u093E\u0938)\",\"url\":\"https://aqicn.org/city/india/new-delhi/us-embassy\",\"location\":\"\"},\"dominentpol\":\"pm25\",\"iaqi\":{\"dew\":{\"v\":11},\"h\":{\"v\":41},\"p\":{\"v\":1008},\"pm25\":{\"v\":99},\"t\":{\"v\":25},\"w\":{\"v\":1},\"wg\":{\"v\":9.2}},\"time\":{\"s\":\"2022-04-22
+        06:00:00\",\"tz\":\"+05:30\",\"v\":1650607200,\"iso\":\"2022-04-22T06:00:00+05:30\"},\"forecast\":{\"daily\":{\"o3\":[{\"avg\":18,\"day\":\"2022-04-20\",\"max\":53,\"min\":1},{\"avg\":7,\"day\":\"2022-04-21\",\"max\":30,\"min\":1},{\"avg\":20,\"day\":\"2022-04-22\",\"max\":70,\"min\":1},{\"avg\":23,\"day\":\"2022-04-23\",\"max\":83,\"min\":1},{\"avg\":23,\"day\":\"2022-04-24\",\"max\":47,\"min\":6},{\"avg\":15,\"day\":\"2022-04-25\",\"max\":65,\"min\":1},{\"avg\":1,\"day\":\"2022-04-26\",\"max\":1,\"min\":1},{\"avg\":1,\"day\":\"2022-04-27\",\"max\":1,\"min\":1}],\"pm10\":[{\"avg\":123,\"day\":\"2022-04-20\",\"max\":123,\"min\":123},{\"avg\":123,\"day\":\"2022-04-21\",\"max\":123,\"min\":123},{\"avg\":123,\"day\":\"2022-04-22\",\"max\":123,\"min\":123},{\"avg\":102,\"day\":\"2022-04-23\",\"max\":123,\"min\":73},{\"avg\":76,\"day\":\"2022-04-24\",\"max\":85,\"min\":73},{\"avg\":73,\"day\":\"2022-04-25\",\"max\":73,\"min\":73},{\"avg\":119,\"day\":\"2022-04-26\",\"max\":123,\"min\":73},{\"avg\":84,\"day\":\"2022-04-27\",\"max\":123,\"min\":46},{\"avg\":67,\"day\":\"2022-04-28\",\"max\":113,\"min\":51}],\"pm25\":[{\"avg\":160,\"day\":\"2022-04-20\",\"max\":161,\"min\":159},{\"avg\":184,\"day\":\"2022-04-21\",\"max\":252,\"min\":159},{\"avg\":164,\"day\":\"2022-04-22\",\"max\":174,\"min\":159},{\"avg\":156,\"day\":\"2022-04-23\",\"max\":174,\"min\":138},{\"avg\":152,\"day\":\"2022-04-24\",\"max\":174,\"min\":138},{\"avg\":146,\"day\":\"2022-04-25\",\"max\":159,\"min\":138},{\"avg\":153,\"day\":\"2022-04-26\",\"max\":165,\"min\":138},{\"avg\":143,\"day\":\"2022-04-27\",\"max\":174,\"min\":89},{\"avg\":151,\"day\":\"2022-04-28\",\"max\":159,\"min\":138}],\"uvi\":[{\"avg\":0,\"day\":\"2022-04-21\",\"max\":0,\"min\":0},{\"avg\":2,\"day\":\"2022-04-22\",\"max\":7,\"min\":0},{\"avg\":2,\"day\":\"2022-04-23\",\"max\":8,\"min\":0},{\"avg\":2,\"day\":\"2022-04-24\",\"max\":8,\"min\":0},{\"avg\":2,\"day\":\"2022-04-25\",\"max\":8,\"min\":0},{\"avg\":3,\"day\":\"2022-04-26\",\"max\":8,\"min\":0}]}},\"debug\":{\"sync\":\"2022-04-22T10:17:59+09:00\"}}}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:00 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "280.756\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2527'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//paris/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:01 GMT
+      Location:
+      - /feed/paris/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/paris/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: "{\"status\":\"ok\",\"data\":{\"aqi\":\"-\",\"idx\":5722,\"attributions\":[{\"url\":\"https://www.airparif.asso.fr/\",\"name\":\"AirParif
+        - Association de surveillance de la qualit\xE9 de l'air en \xCEle-de-France\",\"logo\":\"Paris-Air-Parif.png\"},{\"url\":\"http://www.eea.europa.eu/themes/air/\",\"name\":\"European
+        Environment Agency\",\"logo\":\"Europe-EEA.png\"},{\"url\":\"https://waqi.info/\",\"name\":\"World
+        Air Quality Index Project\"}],\"city\":{\"geo\":[48.856614,2.3522219],\"name\":\"Paris\",\"url\":\"https://aqicn.org/city/paris\",\"location\":\"\"},\"dominentpol\":\"\",\"iaqi\":{\"co\":{\"v\":0.1},\"h\":{\"v\":66.5},\"no2\":{\"v\":44.6},\"o3\":{\"v\":35},\"p\":{\"v\":1004.1},\"pm10\":{\"v\":21},\"pm25\":{\"v\":40},\"so2\":{\"v\":0.6},\"t\":{\"v\":13.3},\"w\":{\"v\":3}},\"time\":{\"s\":\"2022-04-22
+        00:00:00\",\"tz\":\"+02:00\",\"v\":1650585600,\"iso\":\"2022-04-22T00:00:00+02:00\"},\"forecast\":{\"daily\":{\"o3\":[{\"avg\":27,\"day\":\"2022-04-21\",\"max\":41,\"min\":16},{\"avg\":23,\"day\":\"2022-04-22\",\"max\":36,\"min\":13},{\"avg\":28,\"day\":\"2022-04-23\",\"max\":37,\"min\":20},{\"avg\":22,\"day\":\"2022-04-24\",\"max\":33,\"min\":12},{\"avg\":9,\"day\":\"2022-04-25\",\"max\":9,\"min\":6}],\"pm10\":[{\"avg\":14,\"day\":\"2022-04-21\",\"max\":19,\"min\":10},{\"avg\":16,\"day\":\"2022-04-22\",\"max\":19,\"min\":12},{\"avg\":13,\"day\":\"2022-04-23\",\"max\":19,\"min\":6},{\"avg\":14,\"day\":\"2022-04-24\",\"max\":20,\"min\":9},{\"avg\":22,\"day\":\"2022-04-25\",\"max\":24,\"min\":22}],\"pm25\":[{\"avg\":50,\"day\":\"2022-04-21\",\"max\":63,\"min\":40},{\"avg\":57,\"day\":\"2022-04-22\",\"max\":64,\"min\":45},{\"avg\":46,\"day\":\"2022-04-23\",\"max\":63,\"min\":23},{\"avg\":49,\"day\":\"2022-04-24\",\"max\":66,\"min\":28},{\"avg\":68,\"day\":\"2022-04-25\",\"max\":71,\"min\":68}],\"uvi\":[{\"avg\":0,\"day\":\"2022-04-21\",\"max\":4,\"min\":0},{\"avg\":1,\"day\":\"2022-04-22\",\"max\":4,\"min\":0},{\"avg\":0,\"day\":\"2022-04-23\",\"max\":3,\"min\":0},{\"avg\":0,\"day\":\"2022-04-24\",\"max\":3,\"min\":0},{\"avg\":0,\"day\":\"2022-04-25\",\"max\":4,\"min\":0},{\"avg\":1,\"day\":\"2022-04-26\",\"max\":4,\"min\":0}]}},\"debug\":{\"sync\":\"2022-04-22T10:22:51+09:00\"}}}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:01 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "383.667\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '1865'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_multiple_city_air/test_column_types.yaml
+++ b/tests/cassettes/test_get_multiple_city_air/test_column_types.yaml
@@ -1,0 +1,226 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:02 GMT
+      Location:
+      - /feed/london/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":52,"idx":5724,"attributions":[{"url":"http://uk-air.defra.gov.uk/","name":"UK-AIR,
+        air quality information resource - Defra, UK","logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"url":"https://londonair.org.uk/","name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","logo":"UK-London-Kings-College.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[51.5073509,-0.1277583],"name":"London","url":"https://aqicn.org/city/london","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":1.7},"h":{"v":80.3},"no2":{"v":6.5},"o3":{"v":32.1},"p":{"v":1010.8},"pm10":{"v":18},"pm25":{"v":52},"so2":{"v":0.6},"t":{"v":8.8},"w":{"v":3.3}},"time":{"s":"2022-04-22
+        01:00:00","tz":"+01:00","v":1650589200,"iso":"2022-04-22T01:00:00+01:00"},"forecast":{"daily":{"o3":[{"avg":17,"day":"2022-04-19","max":34,"min":2},{"avg":25,"day":"2022-04-20","max":39,"min":14},{"avg":25,"day":"2022-04-21","max":37,"min":13},{"avg":24,"day":"2022-04-22","max":33,"min":17},{"avg":28,"day":"2022-04-23","max":38,"min":19},{"avg":30,"day":"2022-04-24","max":38,"min":24},{"avg":29,"day":"2022-04-25","max":29,"min":29}],"pm10":[{"avg":23,"day":"2022-04-19","max":31,"min":13},{"avg":19,"day":"2022-04-20","max":36,"min":10},{"avg":20,"day":"2022-04-21","max":29,"min":11},{"avg":18,"day":"2022-04-22","max":23,"min":12},{"avg":19,"day":"2022-04-23","max":22,"min":17},{"avg":16,"day":"2022-04-24","max":19,"min":13},{"avg":17,"day":"2022-04-25","max":18,"min":17}],"pm25":[{"avg":64,"day":"2022-04-19","max":81,"min":45},{"avg":59,"day":"2022-04-20","max":94,"min":33},{"avg":59,"day":"2022-04-21","max":78,"min":40},{"avg":55,"day":"2022-04-22","max":63,"min":41},{"avg":58,"day":"2022-04-23","max":68,"min":53},{"avg":49,"day":"2022-04-24","max":60,"min":40},{"avg":43,"day":"2022-04-25","max":43,"min":42}],"uvi":[{"avg":1,"day":"2022-04-20","max":4,"min":0},{"avg":1,"day":"2022-04-21","max":4,"min":0},{"avg":0,"day":"2022-04-22","max":3,"min":0},{"avg":0,"day":"2022-04-23","max":3,"min":0},{"avg":1,"day":"2022-04-24","max":3,"min":0},{"avg":0,"day":"2022-04-25","max":2,"min":0},{"avg":0,"day":"2022-04-26","max":2,"min":0}]}},"debug":{"sync":"2022-04-22T10:26:00+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:02 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "100.063\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2273'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//new%20delhi/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:03 GMT
+      Location:
+      - /feed/new%20delhi/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/new%20delhi/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: "{\"status\":\"ok\",\"data\":{\"aqi\":99,\"idx\":7024,\"attributions\":[{\"url\":\"http://worldweather.wmo.int\",\"name\":\"World
+        Meteorological Organization - surface synoptic observations (WMO-SYNOP)\"},{\"url\":\"https://in.usembassy.gov/embassy-consulates/new-delhi/air-quality-data/\",\"name\":\"U.S.
+        Embassy and Consulates' Air Quality Monitor in India\",\"logo\":\"US-StateDepartment.png\"},{\"url\":\"https://waqi.info/\",\"name\":\"World
+        Air Quality Index Project\"}],\"city\":{\"geo\":[28.63576,77.22445],\"name\":\"New
+        Delhi US Embassy, India (\u0928\u0908 \u0926\u093F\u0932\u094D\u0932\u0940
+        \u0905\u092E\u0947\u0930\u093F\u0915\u0940 \u0926\u0942\u0924\u093E\u0935\u093E\u0938)\",\"url\":\"https://aqicn.org/city/india/new-delhi/us-embassy\",\"location\":\"\"},\"dominentpol\":\"pm25\",\"iaqi\":{\"dew\":{\"v\":11},\"h\":{\"v\":41},\"p\":{\"v\":1008},\"pm25\":{\"v\":99},\"t\":{\"v\":25},\"w\":{\"v\":1},\"wg\":{\"v\":9.2}},\"time\":{\"s\":\"2022-04-22
+        06:00:00\",\"tz\":\"+05:30\",\"v\":1650607200,\"iso\":\"2022-04-22T06:00:00+05:30\"},\"forecast\":{\"daily\":{\"o3\":[{\"avg\":18,\"day\":\"2022-04-20\",\"max\":53,\"min\":1},{\"avg\":7,\"day\":\"2022-04-21\",\"max\":30,\"min\":1},{\"avg\":20,\"day\":\"2022-04-22\",\"max\":70,\"min\":1},{\"avg\":23,\"day\":\"2022-04-23\",\"max\":83,\"min\":1},{\"avg\":23,\"day\":\"2022-04-24\",\"max\":47,\"min\":6},{\"avg\":15,\"day\":\"2022-04-25\",\"max\":65,\"min\":1},{\"avg\":1,\"day\":\"2022-04-26\",\"max\":1,\"min\":1},{\"avg\":1,\"day\":\"2022-04-27\",\"max\":1,\"min\":1}],\"pm10\":[{\"avg\":123,\"day\":\"2022-04-20\",\"max\":123,\"min\":123},{\"avg\":123,\"day\":\"2022-04-21\",\"max\":123,\"min\":123},{\"avg\":123,\"day\":\"2022-04-22\",\"max\":123,\"min\":123},{\"avg\":102,\"day\":\"2022-04-23\",\"max\":123,\"min\":73},{\"avg\":76,\"day\":\"2022-04-24\",\"max\":85,\"min\":73},{\"avg\":73,\"day\":\"2022-04-25\",\"max\":73,\"min\":73},{\"avg\":119,\"day\":\"2022-04-26\",\"max\":123,\"min\":73},{\"avg\":84,\"day\":\"2022-04-27\",\"max\":123,\"min\":46},{\"avg\":67,\"day\":\"2022-04-28\",\"max\":113,\"min\":51}],\"pm25\":[{\"avg\":160,\"day\":\"2022-04-20\",\"max\":161,\"min\":159},{\"avg\":184,\"day\":\"2022-04-21\",\"max\":252,\"min\":159},{\"avg\":164,\"day\":\"2022-04-22\",\"max\":174,\"min\":159},{\"avg\":156,\"day\":\"2022-04-23\",\"max\":174,\"min\":138},{\"avg\":152,\"day\":\"2022-04-24\",\"max\":174,\"min\":138},{\"avg\":146,\"day\":\"2022-04-25\",\"max\":159,\"min\":138},{\"avg\":153,\"day\":\"2022-04-26\",\"max\":165,\"min\":138},{\"avg\":143,\"day\":\"2022-04-27\",\"max\":174,\"min\":89},{\"avg\":151,\"day\":\"2022-04-28\",\"max\":159,\"min\":138}],\"uvi\":[{\"avg\":0,\"day\":\"2022-04-21\",\"max\":0,\"min\":0},{\"avg\":2,\"day\":\"2022-04-22\",\"max\":7,\"min\":0},{\"avg\":2,\"day\":\"2022-04-23\",\"max\":8,\"min\":0},{\"avg\":2,\"day\":\"2022-04-24\",\"max\":8,\"min\":0},{\"avg\":2,\"day\":\"2022-04-25\",\"max\":8,\"min\":0},{\"avg\":3,\"day\":\"2022-04-26\",\"max\":8,\"min\":0}]}},\"debug\":{\"sync\":\"2022-04-22T10:17:59+09:00\"}}}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:03 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "275.145\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2527'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//paris/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:04 GMT
+      Location:
+      - /feed/paris/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/paris/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: "{\"status\":\"ok\",\"data\":{\"aqi\":\"-\",\"idx\":5722,\"attributions\":[{\"url\":\"https://www.airparif.asso.fr/\",\"name\":\"AirParif
+        - Association de surveillance de la qualit\xE9 de l'air en \xCEle-de-France\",\"logo\":\"Paris-Air-Parif.png\"},{\"url\":\"http://www.eea.europa.eu/themes/air/\",\"name\":\"European
+        Environment Agency\",\"logo\":\"Europe-EEA.png\"},{\"url\":\"https://waqi.info/\",\"name\":\"World
+        Air Quality Index Project\"}],\"city\":{\"geo\":[48.856614,2.3522219],\"name\":\"Paris\",\"url\":\"https://aqicn.org/city/paris\",\"location\":\"\"},\"dominentpol\":\"\",\"iaqi\":{\"co\":{\"v\":0.1},\"h\":{\"v\":66.5},\"no2\":{\"v\":44.6},\"o3\":{\"v\":35},\"p\":{\"v\":1004.1},\"pm10\":{\"v\":21},\"pm25\":{\"v\":40},\"so2\":{\"v\":0.6},\"t\":{\"v\":13.3},\"w\":{\"v\":3}},\"time\":{\"s\":\"2022-04-22
+        00:00:00\",\"tz\":\"+02:00\",\"v\":1650585600,\"iso\":\"2022-04-22T00:00:00+02:00\"},\"forecast\":{\"daily\":{\"o3\":[{\"avg\":27,\"day\":\"2022-04-21\",\"max\":41,\"min\":16},{\"avg\":23,\"day\":\"2022-04-22\",\"max\":36,\"min\":13},{\"avg\":28,\"day\":\"2022-04-23\",\"max\":37,\"min\":20},{\"avg\":22,\"day\":\"2022-04-24\",\"max\":33,\"min\":12},{\"avg\":9,\"day\":\"2022-04-25\",\"max\":9,\"min\":6}],\"pm10\":[{\"avg\":14,\"day\":\"2022-04-21\",\"max\":19,\"min\":10},{\"avg\":16,\"day\":\"2022-04-22\",\"max\":19,\"min\":12},{\"avg\":13,\"day\":\"2022-04-23\",\"max\":19,\"min\":6},{\"avg\":14,\"day\":\"2022-04-24\",\"max\":20,\"min\":9},{\"avg\":22,\"day\":\"2022-04-25\",\"max\":24,\"min\":22}],\"pm25\":[{\"avg\":50,\"day\":\"2022-04-21\",\"max\":63,\"min\":40},{\"avg\":57,\"day\":\"2022-04-22\",\"max\":64,\"min\":45},{\"avg\":46,\"day\":\"2022-04-23\",\"max\":63,\"min\":23},{\"avg\":49,\"day\":\"2022-04-24\",\"max\":66,\"min\":28},{\"avg\":68,\"day\":\"2022-04-25\",\"max\":71,\"min\":68}],\"uvi\":[{\"avg\":0,\"day\":\"2022-04-21\",\"max\":4,\"min\":0},{\"avg\":1,\"day\":\"2022-04-22\",\"max\":4,\"min\":0},{\"avg\":0,\"day\":\"2022-04-23\",\"max\":3,\"min\":0},{\"avg\":0,\"day\":\"2022-04-24\",\"max\":3,\"min\":0},{\"avg\":0,\"day\":\"2022-04-25\",\"max\":4,\"min\":0},{\"avg\":1,\"day\":\"2022-04-26\",\"max\":4,\"min\":0}]}},\"debug\":{\"sync\":\"2022-04-22T10:22:51+09:00\"}}}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:05 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "80.061\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '1865'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_multiple_city_air/test_correct_data_format.yaml
+++ b/tests/cassettes/test_get_multiple_city_air/test_correct_data_format.yaml
@@ -1,0 +1,226 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:20 GMT
+      Location:
+      - /feed/london/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":52,"idx":5724,"attributions":[{"url":"http://uk-air.defra.gov.uk/","name":"UK-AIR,
+        air quality information resource - Defra, UK","logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"url":"https://londonair.org.uk/","name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","logo":"UK-London-Kings-College.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[51.5073509,-0.1277583],"name":"London","url":"https://aqicn.org/city/london","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":1.7},"h":{"v":80.3},"no2":{"v":6.5},"o3":{"v":32.1},"p":{"v":1010.8},"pm10":{"v":18},"pm25":{"v":52},"so2":{"v":0.6},"t":{"v":8.8},"w":{"v":3.3}},"time":{"s":"2022-04-22
+        01:00:00","tz":"+01:00","v":1650589200,"iso":"2022-04-22T01:00:00+01:00"},"forecast":{"daily":{"o3":[{"avg":17,"day":"2022-04-19","max":34,"min":2},{"avg":25,"day":"2022-04-20","max":39,"min":14},{"avg":25,"day":"2022-04-21","max":37,"min":13},{"avg":24,"day":"2022-04-22","max":33,"min":17},{"avg":28,"day":"2022-04-23","max":38,"min":19},{"avg":30,"day":"2022-04-24","max":38,"min":24},{"avg":29,"day":"2022-04-25","max":29,"min":29}],"pm10":[{"avg":23,"day":"2022-04-19","max":31,"min":13},{"avg":19,"day":"2022-04-20","max":36,"min":10},{"avg":20,"day":"2022-04-21","max":29,"min":11},{"avg":18,"day":"2022-04-22","max":23,"min":12},{"avg":19,"day":"2022-04-23","max":22,"min":17},{"avg":16,"day":"2022-04-24","max":19,"min":13},{"avg":17,"day":"2022-04-25","max":18,"min":17}],"pm25":[{"avg":64,"day":"2022-04-19","max":81,"min":45},{"avg":59,"day":"2022-04-20","max":94,"min":33},{"avg":59,"day":"2022-04-21","max":78,"min":40},{"avg":55,"day":"2022-04-22","max":63,"min":41},{"avg":58,"day":"2022-04-23","max":68,"min":53},{"avg":49,"day":"2022-04-24","max":60,"min":40},{"avg":43,"day":"2022-04-25","max":43,"min":42}],"uvi":[{"avg":1,"day":"2022-04-20","max":4,"min":0},{"avg":1,"day":"2022-04-21","max":4,"min":0},{"avg":0,"day":"2022-04-22","max":3,"min":0},{"avg":0,"day":"2022-04-23","max":3,"min":0},{"avg":1,"day":"2022-04-24","max":3,"min":0},{"avg":0,"day":"2022-04-25","max":2,"min":0},{"avg":0,"day":"2022-04-26","max":2,"min":0}]}},"debug":{"sync":"2022-04-22T10:26:00+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:20 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "82.461\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2273'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//new%20delhi/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:21 GMT
+      Location:
+      - /feed/new%20delhi/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/new%20delhi/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: "{\"status\":\"ok\",\"data\":{\"aqi\":99,\"idx\":7024,\"attributions\":[{\"url\":\"http://worldweather.wmo.int\",\"name\":\"World
+        Meteorological Organization - surface synoptic observations (WMO-SYNOP)\"},{\"url\":\"https://in.usembassy.gov/embassy-consulates/new-delhi/air-quality-data/\",\"name\":\"U.S.
+        Embassy and Consulates' Air Quality Monitor in India\",\"logo\":\"US-StateDepartment.png\"},{\"url\":\"https://waqi.info/\",\"name\":\"World
+        Air Quality Index Project\"}],\"city\":{\"geo\":[28.63576,77.22445],\"name\":\"New
+        Delhi US Embassy, India (\u0928\u0908 \u0926\u093F\u0932\u094D\u0932\u0940
+        \u0905\u092E\u0947\u0930\u093F\u0915\u0940 \u0926\u0942\u0924\u093E\u0935\u093E\u0938)\",\"url\":\"https://aqicn.org/city/india/new-delhi/us-embassy\",\"location\":\"\"},\"dominentpol\":\"pm25\",\"iaqi\":{\"dew\":{\"v\":11},\"h\":{\"v\":41},\"p\":{\"v\":1008},\"pm25\":{\"v\":99},\"t\":{\"v\":25},\"w\":{\"v\":1},\"wg\":{\"v\":9.2}},\"time\":{\"s\":\"2022-04-22
+        06:00:00\",\"tz\":\"+05:30\",\"v\":1650607200,\"iso\":\"2022-04-22T06:00:00+05:30\"},\"forecast\":{\"daily\":{\"o3\":[{\"avg\":18,\"day\":\"2022-04-20\",\"max\":53,\"min\":1},{\"avg\":7,\"day\":\"2022-04-21\",\"max\":30,\"min\":1},{\"avg\":20,\"day\":\"2022-04-22\",\"max\":70,\"min\":1},{\"avg\":23,\"day\":\"2022-04-23\",\"max\":83,\"min\":1},{\"avg\":23,\"day\":\"2022-04-24\",\"max\":47,\"min\":6},{\"avg\":15,\"day\":\"2022-04-25\",\"max\":65,\"min\":1},{\"avg\":1,\"day\":\"2022-04-26\",\"max\":1,\"min\":1},{\"avg\":1,\"day\":\"2022-04-27\",\"max\":1,\"min\":1}],\"pm10\":[{\"avg\":123,\"day\":\"2022-04-20\",\"max\":123,\"min\":123},{\"avg\":123,\"day\":\"2022-04-21\",\"max\":123,\"min\":123},{\"avg\":123,\"day\":\"2022-04-22\",\"max\":123,\"min\":123},{\"avg\":102,\"day\":\"2022-04-23\",\"max\":123,\"min\":73},{\"avg\":76,\"day\":\"2022-04-24\",\"max\":85,\"min\":73},{\"avg\":73,\"day\":\"2022-04-25\",\"max\":73,\"min\":73},{\"avg\":119,\"day\":\"2022-04-26\",\"max\":123,\"min\":73},{\"avg\":84,\"day\":\"2022-04-27\",\"max\":123,\"min\":46},{\"avg\":67,\"day\":\"2022-04-28\",\"max\":113,\"min\":51}],\"pm25\":[{\"avg\":160,\"day\":\"2022-04-20\",\"max\":161,\"min\":159},{\"avg\":184,\"day\":\"2022-04-21\",\"max\":252,\"min\":159},{\"avg\":164,\"day\":\"2022-04-22\",\"max\":174,\"min\":159},{\"avg\":156,\"day\":\"2022-04-23\",\"max\":174,\"min\":138},{\"avg\":152,\"day\":\"2022-04-24\",\"max\":174,\"min\":138},{\"avg\":146,\"day\":\"2022-04-25\",\"max\":159,\"min\":138},{\"avg\":153,\"day\":\"2022-04-26\",\"max\":165,\"min\":138},{\"avg\":143,\"day\":\"2022-04-27\",\"max\":174,\"min\":89},{\"avg\":151,\"day\":\"2022-04-28\",\"max\":159,\"min\":138}],\"uvi\":[{\"avg\":0,\"day\":\"2022-04-21\",\"max\":0,\"min\":0},{\"avg\":2,\"day\":\"2022-04-22\",\"max\":7,\"min\":0},{\"avg\":2,\"day\":\"2022-04-23\",\"max\":8,\"min\":0},{\"avg\":2,\"day\":\"2022-04-24\",\"max\":8,\"min\":0},{\"avg\":2,\"day\":\"2022-04-25\",\"max\":8,\"min\":0},{\"avg\":3,\"day\":\"2022-04-26\",\"max\":8,\"min\":0}]}},\"debug\":{\"sync\":\"2022-04-22T10:17:59+09:00\"}}}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:21 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "270.575\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2527'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//paris/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:22 GMT
+      Location:
+      - /feed/paris/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/paris/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: "{\"status\":\"ok\",\"data\":{\"aqi\":\"-\",\"idx\":5722,\"attributions\":[{\"url\":\"https://www.airparif.asso.fr/\",\"name\":\"AirParif
+        - Association de surveillance de la qualit\xE9 de l'air en \xCEle-de-France\",\"logo\":\"Paris-Air-Parif.png\"},{\"url\":\"http://www.eea.europa.eu/themes/air/\",\"name\":\"European
+        Environment Agency\",\"logo\":\"Europe-EEA.png\"},{\"url\":\"https://waqi.info/\",\"name\":\"World
+        Air Quality Index Project\"}],\"city\":{\"geo\":[48.856614,2.3522219],\"name\":\"Paris\",\"url\":\"https://aqicn.org/city/paris\",\"location\":\"\"},\"dominentpol\":\"\",\"iaqi\":{\"co\":{\"v\":0.1},\"h\":{\"v\":66.5},\"no2\":{\"v\":44.6},\"o3\":{\"v\":35},\"p\":{\"v\":1004.1},\"pm10\":{\"v\":21},\"pm25\":{\"v\":40},\"so2\":{\"v\":0.6},\"t\":{\"v\":13.3},\"w\":{\"v\":3}},\"time\":{\"s\":\"2022-04-22
+        00:00:00\",\"tz\":\"+02:00\",\"v\":1650585600,\"iso\":\"2022-04-22T00:00:00+02:00\"},\"forecast\":{\"daily\":{\"o3\":[{\"avg\":27,\"day\":\"2022-04-21\",\"max\":41,\"min\":16},{\"avg\":23,\"day\":\"2022-04-22\",\"max\":36,\"min\":13},{\"avg\":28,\"day\":\"2022-04-23\",\"max\":37,\"min\":20},{\"avg\":22,\"day\":\"2022-04-24\",\"max\":33,\"min\":12},{\"avg\":9,\"day\":\"2022-04-25\",\"max\":9,\"min\":6}],\"pm10\":[{\"avg\":14,\"day\":\"2022-04-21\",\"max\":19,\"min\":10},{\"avg\":16,\"day\":\"2022-04-22\",\"max\":19,\"min\":12},{\"avg\":13,\"day\":\"2022-04-23\",\"max\":19,\"min\":6},{\"avg\":14,\"day\":\"2022-04-24\",\"max\":20,\"min\":9},{\"avg\":22,\"day\":\"2022-04-25\",\"max\":24,\"min\":22}],\"pm25\":[{\"avg\":50,\"day\":\"2022-04-21\",\"max\":63,\"min\":40},{\"avg\":57,\"day\":\"2022-04-22\",\"max\":64,\"min\":45},{\"avg\":46,\"day\":\"2022-04-23\",\"max\":63,\"min\":23},{\"avg\":49,\"day\":\"2022-04-24\",\"max\":66,\"min\":28},{\"avg\":68,\"day\":\"2022-04-25\",\"max\":71,\"min\":68}],\"uvi\":[{\"avg\":0,\"day\":\"2022-04-21\",\"max\":4,\"min\":0},{\"avg\":1,\"day\":\"2022-04-22\",\"max\":4,\"min\":0},{\"avg\":0,\"day\":\"2022-04-23\",\"max\":3,\"min\":0},{\"avg\":0,\"day\":\"2022-04-24\",\"max\":3,\"min\":0},{\"avg\":0,\"day\":\"2022-04-25\",\"max\":4,\"min\":0},{\"avg\":1,\"day\":\"2022-04-26\",\"max\":4,\"min\":0}]}},\"debug\":{\"sync\":\"2022-04-22T10:22:51+09:00\"}}}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:22 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "104.472\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '1865'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_multiple_city_air/test_excluded_params.yaml
+++ b/tests/cassettes/test_get_multiple_city_air/test_excluded_params.yaml
@@ -1,0 +1,226 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:06 GMT
+      Location:
+      - /feed/london/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":52,"idx":5724,"attributions":[{"url":"http://uk-air.defra.gov.uk/","name":"UK-AIR,
+        air quality information resource - Defra, UK","logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"url":"https://londonair.org.uk/","name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","logo":"UK-London-Kings-College.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[51.5073509,-0.1277583],"name":"London","url":"https://aqicn.org/city/london","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":1.7},"h":{"v":80.3},"no2":{"v":6.5},"o3":{"v":32.1},"p":{"v":1010.8},"pm10":{"v":18},"pm25":{"v":52},"so2":{"v":0.6},"t":{"v":8.8},"w":{"v":3.3}},"time":{"s":"2022-04-22
+        01:00:00","tz":"+01:00","v":1650589200,"iso":"2022-04-22T01:00:00+01:00"},"forecast":{"daily":{"o3":[{"avg":17,"day":"2022-04-19","max":34,"min":2},{"avg":25,"day":"2022-04-20","max":39,"min":14},{"avg":25,"day":"2022-04-21","max":37,"min":13},{"avg":24,"day":"2022-04-22","max":33,"min":17},{"avg":28,"day":"2022-04-23","max":38,"min":19},{"avg":30,"day":"2022-04-24","max":38,"min":24},{"avg":29,"day":"2022-04-25","max":29,"min":29}],"pm10":[{"avg":23,"day":"2022-04-19","max":31,"min":13},{"avg":19,"day":"2022-04-20","max":36,"min":10},{"avg":20,"day":"2022-04-21","max":29,"min":11},{"avg":18,"day":"2022-04-22","max":23,"min":12},{"avg":19,"day":"2022-04-23","max":22,"min":17},{"avg":16,"day":"2022-04-24","max":19,"min":13},{"avg":17,"day":"2022-04-25","max":18,"min":17}],"pm25":[{"avg":64,"day":"2022-04-19","max":81,"min":45},{"avg":59,"day":"2022-04-20","max":94,"min":33},{"avg":59,"day":"2022-04-21","max":78,"min":40},{"avg":55,"day":"2022-04-22","max":63,"min":41},{"avg":58,"day":"2022-04-23","max":68,"min":53},{"avg":49,"day":"2022-04-24","max":60,"min":40},{"avg":43,"day":"2022-04-25","max":43,"min":42}],"uvi":[{"avg":1,"day":"2022-04-20","max":4,"min":0},{"avg":1,"day":"2022-04-21","max":4,"min":0},{"avg":0,"day":"2022-04-22","max":3,"min":0},{"avg":0,"day":"2022-04-23","max":3,"min":0},{"avg":1,"day":"2022-04-24","max":3,"min":0},{"avg":0,"day":"2022-04-25","max":2,"min":0},{"avg":0,"day":"2022-04-26","max":2,"min":0}]}},"debug":{"sync":"2022-04-22T10:26:00+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:06 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "80.423\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2273'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//new%20delhi/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:07 GMT
+      Location:
+      - /feed/new%20delhi/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/new%20delhi/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: "{\"status\":\"ok\",\"data\":{\"aqi\":99,\"idx\":7024,\"attributions\":[{\"url\":\"http://worldweather.wmo.int\",\"name\":\"World
+        Meteorological Organization - surface synoptic observations (WMO-SYNOP)\"},{\"url\":\"https://in.usembassy.gov/embassy-consulates/new-delhi/air-quality-data/\",\"name\":\"U.S.
+        Embassy and Consulates' Air Quality Monitor in India\",\"logo\":\"US-StateDepartment.png\"},{\"url\":\"https://waqi.info/\",\"name\":\"World
+        Air Quality Index Project\"}],\"city\":{\"geo\":[28.63576,77.22445],\"name\":\"New
+        Delhi US Embassy, India (\u0928\u0908 \u0926\u093F\u0932\u094D\u0932\u0940
+        \u0905\u092E\u0947\u0930\u093F\u0915\u0940 \u0926\u0942\u0924\u093E\u0935\u093E\u0938)\",\"url\":\"https://aqicn.org/city/india/new-delhi/us-embassy\",\"location\":\"\"},\"dominentpol\":\"pm25\",\"iaqi\":{\"dew\":{\"v\":11},\"h\":{\"v\":41},\"p\":{\"v\":1008},\"pm25\":{\"v\":99},\"t\":{\"v\":25},\"w\":{\"v\":1},\"wg\":{\"v\":9.2}},\"time\":{\"s\":\"2022-04-22
+        06:00:00\",\"tz\":\"+05:30\",\"v\":1650607200,\"iso\":\"2022-04-22T06:00:00+05:30\"},\"forecast\":{\"daily\":{\"o3\":[{\"avg\":18,\"day\":\"2022-04-20\",\"max\":53,\"min\":1},{\"avg\":7,\"day\":\"2022-04-21\",\"max\":30,\"min\":1},{\"avg\":20,\"day\":\"2022-04-22\",\"max\":70,\"min\":1},{\"avg\":23,\"day\":\"2022-04-23\",\"max\":83,\"min\":1},{\"avg\":23,\"day\":\"2022-04-24\",\"max\":47,\"min\":6},{\"avg\":15,\"day\":\"2022-04-25\",\"max\":65,\"min\":1},{\"avg\":1,\"day\":\"2022-04-26\",\"max\":1,\"min\":1},{\"avg\":1,\"day\":\"2022-04-27\",\"max\":1,\"min\":1}],\"pm10\":[{\"avg\":123,\"day\":\"2022-04-20\",\"max\":123,\"min\":123},{\"avg\":123,\"day\":\"2022-04-21\",\"max\":123,\"min\":123},{\"avg\":123,\"day\":\"2022-04-22\",\"max\":123,\"min\":123},{\"avg\":102,\"day\":\"2022-04-23\",\"max\":123,\"min\":73},{\"avg\":76,\"day\":\"2022-04-24\",\"max\":85,\"min\":73},{\"avg\":73,\"day\":\"2022-04-25\",\"max\":73,\"min\":73},{\"avg\":119,\"day\":\"2022-04-26\",\"max\":123,\"min\":73},{\"avg\":84,\"day\":\"2022-04-27\",\"max\":123,\"min\":46},{\"avg\":67,\"day\":\"2022-04-28\",\"max\":113,\"min\":51}],\"pm25\":[{\"avg\":160,\"day\":\"2022-04-20\",\"max\":161,\"min\":159},{\"avg\":184,\"day\":\"2022-04-21\",\"max\":252,\"min\":159},{\"avg\":164,\"day\":\"2022-04-22\",\"max\":174,\"min\":159},{\"avg\":156,\"day\":\"2022-04-23\",\"max\":174,\"min\":138},{\"avg\":152,\"day\":\"2022-04-24\",\"max\":174,\"min\":138},{\"avg\":146,\"day\":\"2022-04-25\",\"max\":159,\"min\":138},{\"avg\":153,\"day\":\"2022-04-26\",\"max\":165,\"min\":138},{\"avg\":143,\"day\":\"2022-04-27\",\"max\":174,\"min\":89},{\"avg\":151,\"day\":\"2022-04-28\",\"max\":159,\"min\":138}],\"uvi\":[{\"avg\":0,\"day\":\"2022-04-21\",\"max\":0,\"min\":0},{\"avg\":2,\"day\":\"2022-04-22\",\"max\":7,\"min\":0},{\"avg\":2,\"day\":\"2022-04-23\",\"max\":8,\"min\":0},{\"avg\":2,\"day\":\"2022-04-24\",\"max\":8,\"min\":0},{\"avg\":2,\"day\":\"2022-04-25\",\"max\":8,\"min\":0},{\"avg\":3,\"day\":\"2022-04-26\",\"max\":8,\"min\":0}]}},\"debug\":{\"sync\":\"2022-04-22T10:17:59+09:00\"}}}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:07 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "201.304\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2527'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//paris/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:08 GMT
+      Location:
+      - /feed/paris/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/paris/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: "{\"status\":\"ok\",\"data\":{\"aqi\":\"-\",\"idx\":5722,\"attributions\":[{\"url\":\"https://www.airparif.asso.fr/\",\"name\":\"AirParif
+        - Association de surveillance de la qualit\xE9 de l'air en \xCEle-de-France\",\"logo\":\"Paris-Air-Parif.png\"},{\"url\":\"http://www.eea.europa.eu/themes/air/\",\"name\":\"European
+        Environment Agency\",\"logo\":\"Europe-EEA.png\"},{\"url\":\"https://waqi.info/\",\"name\":\"World
+        Air Quality Index Project\"}],\"city\":{\"geo\":[48.856614,2.3522219],\"name\":\"Paris\",\"url\":\"https://aqicn.org/city/paris\",\"location\":\"\"},\"dominentpol\":\"\",\"iaqi\":{\"co\":{\"v\":0.1},\"h\":{\"v\":66.5},\"no2\":{\"v\":44.6},\"o3\":{\"v\":35},\"p\":{\"v\":1004.1},\"pm10\":{\"v\":21},\"pm25\":{\"v\":40},\"so2\":{\"v\":0.6},\"t\":{\"v\":13.3},\"w\":{\"v\":3}},\"time\":{\"s\":\"2022-04-22
+        00:00:00\",\"tz\":\"+02:00\",\"v\":1650585600,\"iso\":\"2022-04-22T00:00:00+02:00\"},\"forecast\":{\"daily\":{\"o3\":[{\"avg\":27,\"day\":\"2022-04-21\",\"max\":41,\"min\":16},{\"avg\":23,\"day\":\"2022-04-22\",\"max\":36,\"min\":13},{\"avg\":28,\"day\":\"2022-04-23\",\"max\":37,\"min\":20},{\"avg\":22,\"day\":\"2022-04-24\",\"max\":33,\"min\":12},{\"avg\":9,\"day\":\"2022-04-25\",\"max\":9,\"min\":6}],\"pm10\":[{\"avg\":14,\"day\":\"2022-04-21\",\"max\":19,\"min\":10},{\"avg\":16,\"day\":\"2022-04-22\",\"max\":19,\"min\":12},{\"avg\":13,\"day\":\"2022-04-23\",\"max\":19,\"min\":6},{\"avg\":14,\"day\":\"2022-04-24\",\"max\":20,\"min\":9},{\"avg\":22,\"day\":\"2022-04-25\",\"max\":24,\"min\":22}],\"pm25\":[{\"avg\":50,\"day\":\"2022-04-21\",\"max\":63,\"min\":40},{\"avg\":57,\"day\":\"2022-04-22\",\"max\":64,\"min\":45},{\"avg\":46,\"day\":\"2022-04-23\",\"max\":63,\"min\":23},{\"avg\":49,\"day\":\"2022-04-24\",\"max\":66,\"min\":28},{\"avg\":68,\"day\":\"2022-04-25\",\"max\":71,\"min\":68}],\"uvi\":[{\"avg\":0,\"day\":\"2022-04-21\",\"max\":4,\"min\":0},{\"avg\":1,\"day\":\"2022-04-22\",\"max\":4,\"min\":0},{\"avg\":0,\"day\":\"2022-04-23\",\"max\":3,\"min\":0},{\"avg\":0,\"day\":\"2022-04-24\",\"max\":3,\"min\":0},{\"avg\":0,\"day\":\"2022-04-25\",\"max\":4,\"min\":0},{\"avg\":1,\"day\":\"2022-04-26\",\"max\":4,\"min\":0}]}},\"debug\":{\"sync\":\"2022-04-22T10:22:51+09:00\"}}}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:08 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "110.701\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '1865'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_multiple_city_air/test_nonexistent_requested_params.yaml
+++ b/tests/cassettes/test_get_multiple_city_air/test_nonexistent_requested_params.yaml
@@ -1,0 +1,226 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:10 GMT
+      Location:
+      - /feed/london/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":52,"idx":5724,"attributions":[{"url":"http://uk-air.defra.gov.uk/","name":"UK-AIR,
+        air quality information resource - Defra, UK","logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"url":"https://londonair.org.uk/","name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","logo":"UK-London-Kings-College.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[51.5073509,-0.1277583],"name":"London","url":"https://aqicn.org/city/london","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":1.7},"h":{"v":80.3},"no2":{"v":6.5},"o3":{"v":32.1},"p":{"v":1010.8},"pm10":{"v":18},"pm25":{"v":52},"so2":{"v":0.6},"t":{"v":8.8},"w":{"v":3.3}},"time":{"s":"2022-04-22
+        01:00:00","tz":"+01:00","v":1650589200,"iso":"2022-04-22T01:00:00+01:00"},"forecast":{"daily":{"o3":[{"avg":17,"day":"2022-04-19","max":34,"min":2},{"avg":25,"day":"2022-04-20","max":39,"min":14},{"avg":25,"day":"2022-04-21","max":37,"min":13},{"avg":24,"day":"2022-04-22","max":33,"min":17},{"avg":28,"day":"2022-04-23","max":38,"min":19},{"avg":30,"day":"2022-04-24","max":38,"min":24},{"avg":29,"day":"2022-04-25","max":29,"min":29}],"pm10":[{"avg":23,"day":"2022-04-19","max":31,"min":13},{"avg":19,"day":"2022-04-20","max":36,"min":10},{"avg":20,"day":"2022-04-21","max":29,"min":11},{"avg":18,"day":"2022-04-22","max":23,"min":12},{"avg":19,"day":"2022-04-23","max":22,"min":17},{"avg":16,"day":"2022-04-24","max":19,"min":13},{"avg":17,"day":"2022-04-25","max":18,"min":17}],"pm25":[{"avg":64,"day":"2022-04-19","max":81,"min":45},{"avg":59,"day":"2022-04-20","max":94,"min":33},{"avg":59,"day":"2022-04-21","max":78,"min":40},{"avg":55,"day":"2022-04-22","max":63,"min":41},{"avg":58,"day":"2022-04-23","max":68,"min":53},{"avg":49,"day":"2022-04-24","max":60,"min":40},{"avg":43,"day":"2022-04-25","max":43,"min":42}],"uvi":[{"avg":1,"day":"2022-04-20","max":4,"min":0},{"avg":1,"day":"2022-04-21","max":4,"min":0},{"avg":0,"day":"2022-04-22","max":3,"min":0},{"avg":0,"day":"2022-04-23","max":3,"min":0},{"avg":1,"day":"2022-04-24","max":3,"min":0},{"avg":0,"day":"2022-04-25","max":2,"min":0},{"avg":0,"day":"2022-04-26","max":2,"min":0}]}},"debug":{"sync":"2022-04-22T10:26:00+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:10 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "83.412\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2273'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//new%20delhi/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:11 GMT
+      Location:
+      - /feed/new%20delhi/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/new%20delhi/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: "{\"status\":\"ok\",\"data\":{\"aqi\":99,\"idx\":7024,\"attributions\":[{\"url\":\"http://worldweather.wmo.int\",\"name\":\"World
+        Meteorological Organization - surface synoptic observations (WMO-SYNOP)\"},{\"url\":\"https://in.usembassy.gov/embassy-consulates/new-delhi/air-quality-data/\",\"name\":\"U.S.
+        Embassy and Consulates' Air Quality Monitor in India\",\"logo\":\"US-StateDepartment.png\"},{\"url\":\"https://waqi.info/\",\"name\":\"World
+        Air Quality Index Project\"}],\"city\":{\"geo\":[28.63576,77.22445],\"name\":\"New
+        Delhi US Embassy, India (\u0928\u0908 \u0926\u093F\u0932\u094D\u0932\u0940
+        \u0905\u092E\u0947\u0930\u093F\u0915\u0940 \u0926\u0942\u0924\u093E\u0935\u093E\u0938)\",\"url\":\"https://aqicn.org/city/india/new-delhi/us-embassy\",\"location\":\"\"},\"dominentpol\":\"pm25\",\"iaqi\":{\"dew\":{\"v\":11},\"h\":{\"v\":41},\"p\":{\"v\":1008},\"pm25\":{\"v\":99},\"t\":{\"v\":25},\"w\":{\"v\":1},\"wg\":{\"v\":9.2}},\"time\":{\"s\":\"2022-04-22
+        06:00:00\",\"tz\":\"+05:30\",\"v\":1650607200,\"iso\":\"2022-04-22T06:00:00+05:30\"},\"forecast\":{\"daily\":{\"o3\":[{\"avg\":18,\"day\":\"2022-04-20\",\"max\":53,\"min\":1},{\"avg\":7,\"day\":\"2022-04-21\",\"max\":30,\"min\":1},{\"avg\":20,\"day\":\"2022-04-22\",\"max\":70,\"min\":1},{\"avg\":23,\"day\":\"2022-04-23\",\"max\":83,\"min\":1},{\"avg\":23,\"day\":\"2022-04-24\",\"max\":47,\"min\":6},{\"avg\":15,\"day\":\"2022-04-25\",\"max\":65,\"min\":1},{\"avg\":1,\"day\":\"2022-04-26\",\"max\":1,\"min\":1},{\"avg\":1,\"day\":\"2022-04-27\",\"max\":1,\"min\":1}],\"pm10\":[{\"avg\":123,\"day\":\"2022-04-20\",\"max\":123,\"min\":123},{\"avg\":123,\"day\":\"2022-04-21\",\"max\":123,\"min\":123},{\"avg\":123,\"day\":\"2022-04-22\",\"max\":123,\"min\":123},{\"avg\":102,\"day\":\"2022-04-23\",\"max\":123,\"min\":73},{\"avg\":76,\"day\":\"2022-04-24\",\"max\":85,\"min\":73},{\"avg\":73,\"day\":\"2022-04-25\",\"max\":73,\"min\":73},{\"avg\":119,\"day\":\"2022-04-26\",\"max\":123,\"min\":73},{\"avg\":84,\"day\":\"2022-04-27\",\"max\":123,\"min\":46},{\"avg\":67,\"day\":\"2022-04-28\",\"max\":113,\"min\":51}],\"pm25\":[{\"avg\":160,\"day\":\"2022-04-20\",\"max\":161,\"min\":159},{\"avg\":184,\"day\":\"2022-04-21\",\"max\":252,\"min\":159},{\"avg\":164,\"day\":\"2022-04-22\",\"max\":174,\"min\":159},{\"avg\":156,\"day\":\"2022-04-23\",\"max\":174,\"min\":138},{\"avg\":152,\"day\":\"2022-04-24\",\"max\":174,\"min\":138},{\"avg\":146,\"day\":\"2022-04-25\",\"max\":159,\"min\":138},{\"avg\":153,\"day\":\"2022-04-26\",\"max\":165,\"min\":138},{\"avg\":143,\"day\":\"2022-04-27\",\"max\":174,\"min\":89},{\"avg\":151,\"day\":\"2022-04-28\",\"max\":159,\"min\":138}],\"uvi\":[{\"avg\":0,\"day\":\"2022-04-21\",\"max\":0,\"min\":0},{\"avg\":2,\"day\":\"2022-04-22\",\"max\":7,\"min\":0},{\"avg\":2,\"day\":\"2022-04-23\",\"max\":8,\"min\":0},{\"avg\":2,\"day\":\"2022-04-24\",\"max\":8,\"min\":0},{\"avg\":2,\"day\":\"2022-04-25\",\"max\":8,\"min\":0},{\"avg\":3,\"day\":\"2022-04-26\",\"max\":8,\"min\":0}]}},\"debug\":{\"sync\":\"2022-04-22T10:17:59+09:00\"}}}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:11 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "157.123\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2527'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//paris/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:12 GMT
+      Location:
+      - /feed/paris/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/paris/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: "{\"status\":\"ok\",\"data\":{\"aqi\":\"-\",\"idx\":5722,\"attributions\":[{\"url\":\"https://www.airparif.asso.fr/\",\"name\":\"AirParif
+        - Association de surveillance de la qualit\xE9 de l'air en \xCEle-de-France\",\"logo\":\"Paris-Air-Parif.png\"},{\"url\":\"http://www.eea.europa.eu/themes/air/\",\"name\":\"European
+        Environment Agency\",\"logo\":\"Europe-EEA.png\"},{\"url\":\"https://waqi.info/\",\"name\":\"World
+        Air Quality Index Project\"}],\"city\":{\"geo\":[48.856614,2.3522219],\"name\":\"Paris\",\"url\":\"https://aqicn.org/city/paris\",\"location\":\"\"},\"dominentpol\":\"\",\"iaqi\":{\"co\":{\"v\":0.1},\"h\":{\"v\":66.5},\"no2\":{\"v\":44.6},\"o3\":{\"v\":35},\"p\":{\"v\":1004.1},\"pm10\":{\"v\":21},\"pm25\":{\"v\":40},\"so2\":{\"v\":0.6},\"t\":{\"v\":13.3},\"w\":{\"v\":3}},\"time\":{\"s\":\"2022-04-22
+        00:00:00\",\"tz\":\"+02:00\",\"v\":1650585600,\"iso\":\"2022-04-22T00:00:00+02:00\"},\"forecast\":{\"daily\":{\"o3\":[{\"avg\":27,\"day\":\"2022-04-21\",\"max\":41,\"min\":16},{\"avg\":23,\"day\":\"2022-04-22\",\"max\":36,\"min\":13},{\"avg\":28,\"day\":\"2022-04-23\",\"max\":37,\"min\":20},{\"avg\":22,\"day\":\"2022-04-24\",\"max\":33,\"min\":12},{\"avg\":9,\"day\":\"2022-04-25\",\"max\":9,\"min\":6}],\"pm10\":[{\"avg\":14,\"day\":\"2022-04-21\",\"max\":19,\"min\":10},{\"avg\":16,\"day\":\"2022-04-22\",\"max\":19,\"min\":12},{\"avg\":13,\"day\":\"2022-04-23\",\"max\":19,\"min\":6},{\"avg\":14,\"day\":\"2022-04-24\",\"max\":20,\"min\":9},{\"avg\":22,\"day\":\"2022-04-25\",\"max\":24,\"min\":22}],\"pm25\":[{\"avg\":50,\"day\":\"2022-04-21\",\"max\":63,\"min\":40},{\"avg\":57,\"day\":\"2022-04-22\",\"max\":64,\"min\":45},{\"avg\":46,\"day\":\"2022-04-23\",\"max\":63,\"min\":23},{\"avg\":49,\"day\":\"2022-04-24\",\"max\":66,\"min\":28},{\"avg\":68,\"day\":\"2022-04-25\",\"max\":71,\"min\":68}],\"uvi\":[{\"avg\":0,\"day\":\"2022-04-21\",\"max\":4,\"min\":0},{\"avg\":1,\"day\":\"2022-04-22\",\"max\":4,\"min\":0},{\"avg\":0,\"day\":\"2022-04-23\",\"max\":3,\"min\":0},{\"avg\":0,\"day\":\"2022-04-24\",\"max\":3,\"min\":0},{\"avg\":0,\"day\":\"2022-04-25\",\"max\":4,\"min\":0},{\"avg\":1,\"day\":\"2022-04-26\",\"max\":4,\"min\":0}]}},\"debug\":{\"sync\":\"2022-04-22T10:22:51+09:00\"}}}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:12 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "93.361\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '1865'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_multiple_city_air/test_return_value_and_format.yaml
+++ b/tests/cassettes/test_get_multiple_city_air/test_return_value_and_format.yaml
@@ -1,0 +1,226 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:25:54 GMT
+      Location:
+      - /feed/london/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":39,"idx":5724,"attributions":[{"url":"http://uk-air.defra.gov.uk/","name":"UK-AIR,
+        air quality information resource - Defra, UK","logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"url":"https://londonair.org.uk/","name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","logo":"UK-London-Kings-College.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[51.5073509,-0.1277583],"name":"London","url":"https://aqicn.org/city/london","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":1.7},"h":{"v":78},"no2":{"v":8.8},"o3":{"v":32.5},"p":{"v":1011.3},"pm10":{"v":17},"pm25":{"v":39},"so2":{"v":0.5},"t":{"v":8.8},"w":{"v":4}},"time":{"s":"2022-04-22
+        00:00:00","tz":"+01:00","v":1650585600,"iso":"2022-04-22T00:00:00+01:00"},"forecast":{"daily":{"o3":[{"avg":17,"day":"2022-04-19","max":34,"min":2},{"avg":25,"day":"2022-04-20","max":39,"min":14},{"avg":25,"day":"2022-04-21","max":37,"min":13},{"avg":24,"day":"2022-04-22","max":33,"min":17},{"avg":28,"day":"2022-04-23","max":38,"min":19},{"avg":30,"day":"2022-04-24","max":38,"min":24},{"avg":29,"day":"2022-04-25","max":29,"min":29}],"pm10":[{"avg":23,"day":"2022-04-19","max":31,"min":13},{"avg":19,"day":"2022-04-20","max":36,"min":10},{"avg":20,"day":"2022-04-21","max":29,"min":11},{"avg":18,"day":"2022-04-22","max":23,"min":12},{"avg":19,"day":"2022-04-23","max":22,"min":17},{"avg":16,"day":"2022-04-24","max":19,"min":13},{"avg":17,"day":"2022-04-25","max":18,"min":17}],"pm25":[{"avg":64,"day":"2022-04-19","max":81,"min":45},{"avg":59,"day":"2022-04-20","max":94,"min":33},{"avg":59,"day":"2022-04-21","max":78,"min":40},{"avg":55,"day":"2022-04-22","max":63,"min":41},{"avg":58,"day":"2022-04-23","max":68,"min":53},{"avg":49,"day":"2022-04-24","max":60,"min":40},{"avg":43,"day":"2022-04-25","max":43,"min":42}],"uvi":[{"avg":1,"day":"2022-04-20","max":4,"min":0},{"avg":1,"day":"2022-04-21","max":4,"min":0},{"avg":0,"day":"2022-04-22","max":3,"min":0},{"avg":0,"day":"2022-04-23","max":3,"min":0},{"avg":1,"day":"2022-04-24","max":3,"min":0},{"avg":0,"day":"2022-04-25","max":2,"min":0},{"avg":0,"day":"2022-04-26","max":2,"min":0}]}},"debug":{"sync":"2022-04-22T09:24:17+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:25:54 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "276.394\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2269'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//new%20delhi/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:25:55 GMT
+      Location:
+      - /feed/new%20delhi/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/new%20delhi/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: "{\"status\":\"ok\",\"data\":{\"aqi\":99,\"idx\":7024,\"attributions\":[{\"url\":\"http://worldweather.wmo.int\",\"name\":\"World
+        Meteorological Organization - surface synoptic observations (WMO-SYNOP)\"},{\"url\":\"https://in.usembassy.gov/embassy-consulates/new-delhi/air-quality-data/\",\"name\":\"U.S.
+        Embassy and Consulates' Air Quality Monitor in India\",\"logo\":\"US-StateDepartment.png\"},{\"url\":\"https://waqi.info/\",\"name\":\"World
+        Air Quality Index Project\"}],\"city\":{\"geo\":[28.63576,77.22445],\"name\":\"New
+        Delhi US Embassy, India (\u0928\u0908 \u0926\u093F\u0932\u094D\u0932\u0940
+        \u0905\u092E\u0947\u0930\u093F\u0915\u0940 \u0926\u0942\u0924\u093E\u0935\u093E\u0938)\",\"url\":\"https://aqicn.org/city/india/new-delhi/us-embassy\",\"location\":\"\"},\"dominentpol\":\"pm25\",\"iaqi\":{\"dew\":{\"v\":11},\"h\":{\"v\":41},\"p\":{\"v\":1008},\"pm25\":{\"v\":99},\"t\":{\"v\":25},\"w\":{\"v\":1},\"wg\":{\"v\":9.2}},\"time\":{\"s\":\"2022-04-22
+        06:00:00\",\"tz\":\"+05:30\",\"v\":1650607200,\"iso\":\"2022-04-22T06:00:00+05:30\"},\"forecast\":{\"daily\":{\"o3\":[{\"avg\":18,\"day\":\"2022-04-20\",\"max\":53,\"min\":1},{\"avg\":7,\"day\":\"2022-04-21\",\"max\":30,\"min\":1},{\"avg\":20,\"day\":\"2022-04-22\",\"max\":70,\"min\":1},{\"avg\":23,\"day\":\"2022-04-23\",\"max\":83,\"min\":1},{\"avg\":23,\"day\":\"2022-04-24\",\"max\":47,\"min\":6},{\"avg\":15,\"day\":\"2022-04-25\",\"max\":65,\"min\":1},{\"avg\":1,\"day\":\"2022-04-26\",\"max\":1,\"min\":1},{\"avg\":1,\"day\":\"2022-04-27\",\"max\":1,\"min\":1}],\"pm10\":[{\"avg\":123,\"day\":\"2022-04-20\",\"max\":123,\"min\":123},{\"avg\":123,\"day\":\"2022-04-21\",\"max\":123,\"min\":123},{\"avg\":123,\"day\":\"2022-04-22\",\"max\":123,\"min\":123},{\"avg\":102,\"day\":\"2022-04-23\",\"max\":123,\"min\":73},{\"avg\":76,\"day\":\"2022-04-24\",\"max\":85,\"min\":73},{\"avg\":73,\"day\":\"2022-04-25\",\"max\":73,\"min\":73},{\"avg\":119,\"day\":\"2022-04-26\",\"max\":123,\"min\":73},{\"avg\":84,\"day\":\"2022-04-27\",\"max\":123,\"min\":46},{\"avg\":67,\"day\":\"2022-04-28\",\"max\":113,\"min\":51}],\"pm25\":[{\"avg\":160,\"day\":\"2022-04-20\",\"max\":161,\"min\":159},{\"avg\":184,\"day\":\"2022-04-21\",\"max\":252,\"min\":159},{\"avg\":164,\"day\":\"2022-04-22\",\"max\":174,\"min\":159},{\"avg\":156,\"day\":\"2022-04-23\",\"max\":174,\"min\":138},{\"avg\":152,\"day\":\"2022-04-24\",\"max\":174,\"min\":138},{\"avg\":146,\"day\":\"2022-04-25\",\"max\":159,\"min\":138},{\"avg\":153,\"day\":\"2022-04-26\",\"max\":165,\"min\":138},{\"avg\":143,\"day\":\"2022-04-27\",\"max\":174,\"min\":89},{\"avg\":151,\"day\":\"2022-04-28\",\"max\":159,\"min\":138}],\"uvi\":[{\"avg\":0,\"day\":\"2022-04-21\",\"max\":0,\"min\":0},{\"avg\":2,\"day\":\"2022-04-22\",\"max\":7,\"min\":0},{\"avg\":2,\"day\":\"2022-04-23\",\"max\":8,\"min\":0},{\"avg\":2,\"day\":\"2022-04-24\",\"max\":8,\"min\":0},{\"avg\":2,\"day\":\"2022-04-25\",\"max\":8,\"min\":0},{\"avg\":3,\"day\":\"2022-04-26\",\"max\":8,\"min\":0}]}},\"debug\":{\"sync\":\"2022-04-22T10:17:59+09:00\"}}}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:25:55 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "183.633\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2527'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//paris/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:25:57 GMT
+      Location:
+      - /feed/paris/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/paris/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: "{\"status\":\"ok\",\"data\":{\"aqi\":\"-\",\"idx\":5722,\"attributions\":[{\"url\":\"https://www.airparif.asso.fr/\",\"name\":\"AirParif
+        - Association de surveillance de la qualit\xE9 de l'air en \xCEle-de-France\",\"logo\":\"Paris-Air-Parif.png\"},{\"url\":\"http://www.eea.europa.eu/themes/air/\",\"name\":\"European
+        Environment Agency\",\"logo\":\"Europe-EEA.png\"},{\"url\":\"https://waqi.info/\",\"name\":\"World
+        Air Quality Index Project\"}],\"city\":{\"geo\":[48.856614,2.3522219],\"name\":\"Paris\",\"url\":\"https://aqicn.org/city/paris\",\"location\":\"\"},\"dominentpol\":\"\",\"iaqi\":{\"co\":{\"v\":0.1},\"h\":{\"v\":66.5},\"no2\":{\"v\":44.6},\"o3\":{\"v\":35},\"p\":{\"v\":1004.1},\"pm10\":{\"v\":21},\"pm25\":{\"v\":40},\"so2\":{\"v\":0.6},\"t\":{\"v\":13.3},\"w\":{\"v\":3}},\"time\":{\"s\":\"2022-04-22
+        00:00:00\",\"tz\":\"+02:00\",\"v\":1650585600,\"iso\":\"2022-04-22T00:00:00+02:00\"},\"forecast\":{\"daily\":{\"o3\":[{\"avg\":27,\"day\":\"2022-04-21\",\"max\":41,\"min\":16},{\"avg\":23,\"day\":\"2022-04-22\",\"max\":36,\"min\":13},{\"avg\":28,\"day\":\"2022-04-23\",\"max\":37,\"min\":20},{\"avg\":22,\"day\":\"2022-04-24\",\"max\":33,\"min\":12},{\"avg\":9,\"day\":\"2022-04-25\",\"max\":9,\"min\":6}],\"pm10\":[{\"avg\":14,\"day\":\"2022-04-21\",\"max\":19,\"min\":10},{\"avg\":16,\"day\":\"2022-04-22\",\"max\":19,\"min\":12},{\"avg\":13,\"day\":\"2022-04-23\",\"max\":19,\"min\":6},{\"avg\":14,\"day\":\"2022-04-24\",\"max\":20,\"min\":9},{\"avg\":22,\"day\":\"2022-04-25\",\"max\":24,\"min\":22}],\"pm25\":[{\"avg\":50,\"day\":\"2022-04-21\",\"max\":63,\"min\":40},{\"avg\":57,\"day\":\"2022-04-22\",\"max\":64,\"min\":45},{\"avg\":46,\"day\":\"2022-04-23\",\"max\":63,\"min\":23},{\"avg\":49,\"day\":\"2022-04-24\",\"max\":66,\"min\":28},{\"avg\":68,\"day\":\"2022-04-25\",\"max\":71,\"min\":68}],\"uvi\":[{\"avg\":0,\"day\":\"2022-04-21\",\"max\":4,\"min\":0},{\"avg\":1,\"day\":\"2022-04-22\",\"max\":4,\"min\":0},{\"avg\":0,\"day\":\"2022-04-23\",\"max\":3,\"min\":0},{\"avg\":0,\"day\":\"2022-04-24\",\"max\":3,\"min\":0},{\"avg\":0,\"day\":\"2022-04-25\",\"max\":4,\"min\":0},{\"avg\":1,\"day\":\"2022-04-26\",\"max\":4,\"min\":0}]}},\"debug\":{\"sync\":\"2022-04-22T10:22:51+09:00\"}}}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:25:57 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "107.121\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '1865'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_multiple_coordinate_air/test_bad_coordinates.yaml
+++ b/tests/cassettes/test_get_multiple_coordinate_air/test_bad_coordinates.yaml
@@ -1,0 +1,220 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:50;0/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:40 GMT
+      Location:
+      - /feed/geo:50;0/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:50;0/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":57,"idx":8620,"attributions":[{"url":"http://www.airnormand.fr/","name":"Air
+        Normand and Air C.O.M.","logo":"France-AirNormand.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[49.5142141381999,0.100861111709392],"name":"Ville-haute
+        EREA Genevoix, Le Havre, France","url":"https://aqicn.org/city/france/le-havre/ville-haute-erea-genevoix","location":""},"dominentpol":"pm25","iaqi":{"dew":{"v":6},"h":{"v":81},"no2":{"v":4.6},"o3":{"v":27.7},"p":{"v":1005},"pm10":{"v":23},"pm25":{"v":57},"so2":{"v":0.6},"t":{"v":9},"w":{"v":4.1}},"time":{"s":"2022-04-22
+        03:00:00","tz":"+02:00","v":1650596400,"iso":"2022-04-22T03:00:00+02:00"},"forecast":{"daily":{"o3":[{"avg":28,"day":"2022-04-21","max":39,"min":19},{"avg":23,"day":"2022-04-22","max":30,"min":16},{"avg":27,"day":"2022-04-23","max":36,"min":20},{"avg":28,"day":"2022-04-24","max":33,"min":23},{"avg":29,"day":"2022-04-25","max":29,"min":24}],"pm10":[{"avg":15,"day":"2022-04-21","max":18,"min":11},{"avg":20,"day":"2022-04-22","max":27,"min":14},{"avg":16,"day":"2022-04-23","max":22,"min":9},{"avg":18,"day":"2022-04-24","max":25,"min":8},{"avg":26,"day":"2022-04-25","max":29,"min":26}],"pm25":[{"avg":53,"day":"2022-04-21","max":59,"min":44},{"avg":65,"day":"2022-04-22","max":79,"min":52},{"avg":55,"day":"2022-04-23","max":70,"min":32},{"avg":54,"day":"2022-04-24","max":64,"min":28},{"avg":52,"day":"2022-04-25","max":62,"min":52}],"uvi":[{"avg":0,"day":"2022-04-21","max":4,"min":0},{"avg":0,"day":"2022-04-22","max":2,"min":0},{"avg":0,"day":"2022-04-23","max":3,"min":0},{"avg":1,"day":"2022-04-24","max":4,"min":0},{"avg":0,"day":"2022-04-25","max":4,"min":0},{"avg":1,"day":"2022-04-26","max":4,"min":0}]}},"debug":{"sync":"2022-04-22T10:13:48+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:41 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "302.386\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '1791'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:50;1/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:41 GMT
+      Location:
+      - /feed/geo:50;1/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:50;1/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":53,"idx":10088,"attributions":[{"url":"http://www.airnormand.fr/","name":"Air
+        Normand and Air C.O.M.","logo":"France-AirNormand.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[49.9180080986299,1.07397213322362],"name":"Dieppe,
+        avenue Gambetta, Trafic, France","url":"https://aqicn.org/city/france/normandie/dieppe--avenue-gambetta--trafic","location":""},"dominentpol":"pm25","iaqi":{"h":{"v":92.5},"no2":{"v":10.1},"p":{"v":1005.9},"pm10":{"v":35},"pm25":{"v":53},"t":{"v":4.4},"w":{"v":0.3},"wg":{"v":0.2}},"time":{"s":"2022-04-22
+        02:00:00","tz":"+02:00","v":1650592800,"iso":"2022-04-22T02:00:00+02:00"},"forecast":{"daily":{"o3":[{"avg":32,"day":"2022-04-21","max":40,"min":25},{"avg":23,"day":"2022-04-22","max":33,"min":17},{"avg":28,"day":"2022-04-23","max":38,"min":20},{"avg":28,"day":"2022-04-24","max":34,"min":22},{"avg":28,"day":"2022-04-25","max":28,"min":24}],"pm10":[{"avg":14,"day":"2022-04-21","max":17,"min":9},{"avg":17,"day":"2022-04-22","max":23,"min":13},{"avg":14,"day":"2022-04-23","max":19,"min":7},{"avg":17,"day":"2022-04-24","max":20,"min":8},{"avg":21,"day":"2022-04-25","max":23,"min":21}],"pm25":[{"avg":49,"day":"2022-04-21","max":61,"min":28},{"avg":57,"day":"2022-04-22","max":72,"min":47},{"avg":48,"day":"2022-04-23","max":64,"min":25},{"avg":56,"day":"2022-04-24","max":65,"min":32},{"avg":57,"day":"2022-04-25","max":71,"min":57}],"uvi":[{"avg":0,"day":"2022-04-21","max":4,"min":0},{"avg":0,"day":"2022-04-22","max":3,"min":0},{"avg":0,"day":"2022-04-23","max":4,"min":0},{"avg":1,"day":"2022-04-24","max":4,"min":0},{"avg":0,"day":"2022-04-25","max":4,"min":0},{"avg":1,"day":"2022-04-26","max":4,"min":0}]}},"debug":{"sync":"2022-04-22T10:08:51+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:42 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "205.204\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '1769'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:lol;bruh/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:43 GMT
+      Location:
+      - /feed/geo:lol;bruh/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:lol;bruh/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"error","data":"Invalid geo position - Can not parse ''lol,bruh''"}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:43 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "94.611\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '75'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_multiple_coordinate_air/test_bad_data_format.yaml
+++ b/tests/cassettes/test_get_multiple_coordinate_air/test_bad_data_format.yaml
@@ -1,0 +1,225 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:0;0/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:44 GMT
+      Location:
+      - /feed/geo:0;0/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:0;0/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":165,"idx":12826,"attributions":[{"url":"https://gh.usembassy.gov/","name":"Accra
+        Air Quality Monitor - US EPA","logo":"US-StateDepartment.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[5.580642,-0.170724],"name":"Accra
+        US Embassy, Ghana","url":"https://aqicn.org/city/ghana/accra/us-embassy","location":""},"dominentpol":"pm25","iaqi":{"dew":{"v":24},"h":{"v":88},"p":{"v":1011},"pm25":{"v":165},"t":{"v":26},"w":{"v":3.6},"wg":{"v":11.8}},"time":{"s":"2022-04-22
+        00:00:00","tz":"+00:00","v":1650585600,"iso":"2022-04-22T00:00:00Z"},"forecast":{"daily":{"o3":[{"avg":6,"day":"2022-04-20","max":22,"min":1},{"avg":3,"day":"2022-04-21","max":6,"min":1},{"avg":6,"day":"2022-04-22","max":13,"min":1},{"avg":4,"day":"2022-04-23","max":10,"min":1},{"avg":5,"day":"2022-04-24","max":19,"min":1},{"avg":1,"day":"2022-04-25","max":2,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1},{"avg":1,"day":"2022-04-27","max":1,"min":1}],"pm10":[{"avg":26,"day":"2022-04-20","max":37,"min":15},{"avg":29,"day":"2022-04-21","max":45,"min":12},{"avg":28,"day":"2022-04-22","max":44,"min":12},{"avg":28,"day":"2022-04-23","max":51,"min":9},{"avg":24,"day":"2022-04-24","max":39,"min":10},{"avg":18,"day":"2022-04-25","max":40,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1},{"avg":1,"day":"2022-04-27","max":1,"min":1}],"pm25":[{"avg":55,"day":"2022-04-20","max":71,"min":30},{"avg":56,"day":"2022-04-21","max":78,"min":28},{"avg":60,"day":"2022-04-22","max":98,"min":27},{"avg":59,"day":"2022-04-23","max":102,"min":15},{"avg":46,"day":"2022-04-24","max":80,"min":1},{"avg":1,"day":"2022-04-25","max":1,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1},{"avg":1,"day":"2022-04-27","max":1,"min":1}]}},"debug":{"sync":"2022-04-22T10:12:55+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:45 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "466.888\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '1816'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:50;0/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:45 GMT
+      Location:
+      - /feed/geo:50;0/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:50;0/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":57,"idx":8620,"attributions":[{"url":"http://www.airnormand.fr/","name":"Air
+        Normand and Air C.O.M.","logo":"France-AirNormand.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[49.5142141381999,0.100861111709392],"name":"Ville-haute
+        EREA Genevoix, Le Havre, France","url":"https://aqicn.org/city/france/le-havre/ville-haute-erea-genevoix","location":""},"dominentpol":"pm25","iaqi":{"dew":{"v":6},"h":{"v":81},"no2":{"v":4.6},"o3":{"v":27.7},"p":{"v":1005},"pm10":{"v":23},"pm25":{"v":57},"so2":{"v":0.6},"t":{"v":9},"w":{"v":4.1}},"time":{"s":"2022-04-22
+        03:00:00","tz":"+02:00","v":1650596400,"iso":"2022-04-22T03:00:00+02:00"},"forecast":{"daily":{"o3":[{"avg":28,"day":"2022-04-21","max":39,"min":19},{"avg":23,"day":"2022-04-22","max":30,"min":16},{"avg":27,"day":"2022-04-23","max":36,"min":20},{"avg":28,"day":"2022-04-24","max":33,"min":23},{"avg":29,"day":"2022-04-25","max":29,"min":24}],"pm10":[{"avg":15,"day":"2022-04-21","max":18,"min":11},{"avg":20,"day":"2022-04-22","max":27,"min":14},{"avg":16,"day":"2022-04-23","max":22,"min":9},{"avg":18,"day":"2022-04-24","max":25,"min":8},{"avg":26,"day":"2022-04-25","max":29,"min":26}],"pm25":[{"avg":53,"day":"2022-04-21","max":59,"min":44},{"avg":65,"day":"2022-04-22","max":79,"min":52},{"avg":55,"day":"2022-04-23","max":70,"min":32},{"avg":54,"day":"2022-04-24","max":64,"min":28},{"avg":52,"day":"2022-04-25","max":62,"min":52}],"uvi":[{"avg":0,"day":"2022-04-21","max":4,"min":0},{"avg":0,"day":"2022-04-22","max":2,"min":0},{"avg":0,"day":"2022-04-23","max":3,"min":0},{"avg":1,"day":"2022-04-24","max":4,"min":0},{"avg":0,"day":"2022-04-25","max":4,"min":0},{"avg":1,"day":"2022-04-26","max":4,"min":0}]}},"debug":{"sync":"2022-04-22T10:13:48+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:46 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "353.567\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '1791'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:40;-75/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:46 GMT
+      Location:
+      - /feed/geo:40;-75/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:40;-75/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":22,"idx":10168,"attributions":[{"url":"http://www.nj.gov/dep/daq/","name":"NJDEP/DAQ
+        - New Jersey Department of Environmental Protection - Division of Air Quality","logo":"US-NJDEC.png"},{"url":"http://www.airnow.gov/","name":"Air
+        Now - US EPA"},{"url":"https://waqi.info/","name":"World Air Quality Index
+        Project"}],"city":{"geo":[39.934635,-75.126126],"name":"Camden Spruce St,
+        NewJersey, USA","url":"https://aqicn.org/city/usa/newjersey/camden-spruce-st","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":5.6},"h":{"v":58.8},"no2":{"v":0.2},"o3":{"v":4.8},"p":{"v":1024.4},"pm25":{"v":22},"so2":{"v":1.5},"t":{"v":14.7},"w":{"v":5},"wg":{"v":10.2}},"time":{"s":"2022-04-21
+        20:00:00","tz":"-05:00","v":1650571200,"iso":"2022-04-21T20:00:00-05:00"},"forecast":{"daily":{"o3":[{"avg":18,"day":"2022-04-19","max":19,"min":18},{"avg":9,"day":"2022-04-20","max":21,"min":1},{"avg":15,"day":"2022-04-21","max":23,"min":4},{"avg":11,"day":"2022-04-22","max":27,"min":4},{"avg":14,"day":"2022-04-23","max":22,"min":7},{"avg":18,"day":"2022-04-24","max":40,"min":12},{"avg":2,"day":"2022-04-25","max":18,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1}],"pm10":[{"avg":4,"day":"2022-04-19","max":5,"min":4},{"avg":12,"day":"2022-04-20","max":32,"min":4},{"avg":9,"day":"2022-04-21","max":27,"min":5},{"avg":15,"day":"2022-04-22","max":19,"min":8},{"avg":10,"day":"2022-04-23","max":15,"min":5},{"avg":23,"day":"2022-04-24","max":41,"min":9},{"avg":6,"day":"2022-04-25","max":10,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1}],"pm25":[{"avg":12,"day":"2022-04-19","max":13,"min":11},{"avg":33,"day":"2022-04-20","max":77,"min":10},{"avg":26,"day":"2022-04-21","max":73,"min":14},{"avg":47,"day":"2022-04-22","max":60,"min":20},{"avg":32,"day":"2022-04-23","max":49,"min":15},{"avg":42,"day":"2022-04-24","max":110,"min":1},{"avg":1,"day":"2022-04-25","max":1,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1}],"uvi":[{"avg":2,"day":"2022-04-21","max":6,"min":0},{"avg":2,"day":"2022-04-22","max":8,"min":0},{"avg":1,"day":"2022-04-23","max":3,"min":0},{"avg":2,"day":"2022-04-24","max":7,"min":0},{"avg":1,"day":"2022-04-25","max":6,"min":0},{"avg":0,"day":"2022-04-26","max":0,"min":0}]}},"debug":{"sync":"2022-04-22T10:22:09+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:47 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - 1.09533ms
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2277'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_multiple_coordinate_air/test_column_expected_contents.yaml
+++ b/tests/cassettes/test_get_multiple_coordinate_air/test_column_expected_contents.yaml
@@ -1,0 +1,225 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:0;0/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:26 GMT
+      Location:
+      - /feed/geo:0;0/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:0;0/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":165,"idx":12826,"attributions":[{"url":"https://gh.usembassy.gov/","name":"Accra
+        Air Quality Monitor - US EPA","logo":"US-StateDepartment.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[5.580642,-0.170724],"name":"Accra
+        US Embassy, Ghana","url":"https://aqicn.org/city/ghana/accra/us-embassy","location":""},"dominentpol":"pm25","iaqi":{"dew":{"v":24},"h":{"v":88},"p":{"v":1011},"pm25":{"v":165},"t":{"v":26},"w":{"v":3.6},"wg":{"v":11.8}},"time":{"s":"2022-04-22
+        00:00:00","tz":"+00:00","v":1650585600,"iso":"2022-04-22T00:00:00Z"},"forecast":{"daily":{"o3":[{"avg":6,"day":"2022-04-20","max":22,"min":1},{"avg":3,"day":"2022-04-21","max":6,"min":1},{"avg":6,"day":"2022-04-22","max":13,"min":1},{"avg":4,"day":"2022-04-23","max":10,"min":1},{"avg":5,"day":"2022-04-24","max":19,"min":1},{"avg":1,"day":"2022-04-25","max":2,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1},{"avg":1,"day":"2022-04-27","max":1,"min":1}],"pm10":[{"avg":26,"day":"2022-04-20","max":37,"min":15},{"avg":29,"day":"2022-04-21","max":45,"min":12},{"avg":28,"day":"2022-04-22","max":44,"min":12},{"avg":28,"day":"2022-04-23","max":51,"min":9},{"avg":24,"day":"2022-04-24","max":39,"min":10},{"avg":18,"day":"2022-04-25","max":40,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1},{"avg":1,"day":"2022-04-27","max":1,"min":1}],"pm25":[{"avg":55,"day":"2022-04-20","max":71,"min":30},{"avg":56,"day":"2022-04-21","max":78,"min":28},{"avg":60,"day":"2022-04-22","max":98,"min":27},{"avg":59,"day":"2022-04-23","max":102,"min":15},{"avg":46,"day":"2022-04-24","max":80,"min":1},{"avg":1,"day":"2022-04-25","max":1,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1},{"avg":1,"day":"2022-04-27","max":1,"min":1}]}},"debug":{"sync":"2022-04-22T10:12:55+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:27 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "354.986\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '1816'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:50;0/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:28 GMT
+      Location:
+      - /feed/geo:50;0/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:50;0/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":57,"idx":8620,"attributions":[{"url":"http://www.airnormand.fr/","name":"Air
+        Normand and Air C.O.M.","logo":"France-AirNormand.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[49.5142141381999,0.100861111709392],"name":"Ville-haute
+        EREA Genevoix, Le Havre, France","url":"https://aqicn.org/city/france/le-havre/ville-haute-erea-genevoix","location":""},"dominentpol":"pm25","iaqi":{"dew":{"v":6},"h":{"v":81},"no2":{"v":4.6},"o3":{"v":27.7},"p":{"v":1005},"pm10":{"v":23},"pm25":{"v":57},"so2":{"v":0.6},"t":{"v":9},"w":{"v":4.1}},"time":{"s":"2022-04-22
+        03:00:00","tz":"+02:00","v":1650596400,"iso":"2022-04-22T03:00:00+02:00"},"forecast":{"daily":{"o3":[{"avg":28,"day":"2022-04-21","max":39,"min":19},{"avg":23,"day":"2022-04-22","max":30,"min":16},{"avg":27,"day":"2022-04-23","max":36,"min":20},{"avg":28,"day":"2022-04-24","max":33,"min":23},{"avg":29,"day":"2022-04-25","max":29,"min":24}],"pm10":[{"avg":15,"day":"2022-04-21","max":18,"min":11},{"avg":20,"day":"2022-04-22","max":27,"min":14},{"avg":16,"day":"2022-04-23","max":22,"min":9},{"avg":18,"day":"2022-04-24","max":25,"min":8},{"avg":26,"day":"2022-04-25","max":29,"min":26}],"pm25":[{"avg":53,"day":"2022-04-21","max":59,"min":44},{"avg":65,"day":"2022-04-22","max":79,"min":52},{"avg":55,"day":"2022-04-23","max":70,"min":32},{"avg":54,"day":"2022-04-24","max":64,"min":28},{"avg":52,"day":"2022-04-25","max":62,"min":52}],"uvi":[{"avg":0,"day":"2022-04-21","max":4,"min":0},{"avg":0,"day":"2022-04-22","max":2,"min":0},{"avg":0,"day":"2022-04-23","max":3,"min":0},{"avg":1,"day":"2022-04-24","max":4,"min":0},{"avg":0,"day":"2022-04-25","max":4,"min":0},{"avg":1,"day":"2022-04-26","max":4,"min":0}]}},"debug":{"sync":"2022-04-22T10:13:48+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:28 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "212.764\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '1791'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:40;-75/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:29 GMT
+      Location:
+      - /feed/geo:40;-75/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:40;-75/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":22,"idx":10168,"attributions":[{"url":"http://www.nj.gov/dep/daq/","name":"NJDEP/DAQ
+        - New Jersey Department of Environmental Protection - Division of Air Quality","logo":"US-NJDEC.png"},{"url":"http://www.airnow.gov/","name":"Air
+        Now - US EPA"},{"url":"https://waqi.info/","name":"World Air Quality Index
+        Project"}],"city":{"geo":[39.934635,-75.126126],"name":"Camden Spruce St,
+        NewJersey, USA","url":"https://aqicn.org/city/usa/newjersey/camden-spruce-st","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":5.6},"h":{"v":58.8},"no2":{"v":0.2},"o3":{"v":4.8},"p":{"v":1024.4},"pm25":{"v":22},"so2":{"v":1.5},"t":{"v":14.7},"w":{"v":5},"wg":{"v":10.2}},"time":{"s":"2022-04-21
+        20:00:00","tz":"-05:00","v":1650571200,"iso":"2022-04-21T20:00:00-05:00"},"forecast":{"daily":{"o3":[{"avg":18,"day":"2022-04-19","max":19,"min":18},{"avg":9,"day":"2022-04-20","max":21,"min":1},{"avg":15,"day":"2022-04-21","max":23,"min":4},{"avg":11,"day":"2022-04-22","max":27,"min":4},{"avg":14,"day":"2022-04-23","max":22,"min":7},{"avg":18,"day":"2022-04-24","max":40,"min":12},{"avg":2,"day":"2022-04-25","max":18,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1}],"pm10":[{"avg":4,"day":"2022-04-19","max":5,"min":4},{"avg":12,"day":"2022-04-20","max":32,"min":4},{"avg":9,"day":"2022-04-21","max":27,"min":5},{"avg":15,"day":"2022-04-22","max":19,"min":8},{"avg":10,"day":"2022-04-23","max":15,"min":5},{"avg":23,"day":"2022-04-24","max":41,"min":9},{"avg":6,"day":"2022-04-25","max":10,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1}],"pm25":[{"avg":12,"day":"2022-04-19","max":13,"min":11},{"avg":33,"day":"2022-04-20","max":77,"min":10},{"avg":26,"day":"2022-04-21","max":73,"min":14},{"avg":47,"day":"2022-04-22","max":60,"min":20},{"avg":32,"day":"2022-04-23","max":49,"min":15},{"avg":42,"day":"2022-04-24","max":110,"min":1},{"avg":1,"day":"2022-04-25","max":1,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1}],"uvi":[{"avg":2,"day":"2022-04-21","max":6,"min":0},{"avg":2,"day":"2022-04-22","max":8,"min":0},{"avg":1,"day":"2022-04-23","max":3,"min":0},{"avg":2,"day":"2022-04-24","max":7,"min":0},{"avg":1,"day":"2022-04-25","max":6,"min":0},{"avg":0,"day":"2022-04-26","max":0,"min":0}]}},"debug":{"sync":"2022-04-22T10:22:09+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:29 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "137.532\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2277'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_multiple_coordinate_air/test_column_types.yaml
+++ b/tests/cassettes/test_get_multiple_coordinate_air/test_column_types.yaml
@@ -1,0 +1,225 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:0;0/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:30 GMT
+      Location:
+      - /feed/geo:0;0/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:0;0/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":165,"idx":12826,"attributions":[{"url":"https://gh.usembassy.gov/","name":"Accra
+        Air Quality Monitor - US EPA","logo":"US-StateDepartment.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[5.580642,-0.170724],"name":"Accra
+        US Embassy, Ghana","url":"https://aqicn.org/city/ghana/accra/us-embassy","location":""},"dominentpol":"pm25","iaqi":{"dew":{"v":24},"h":{"v":88},"p":{"v":1011},"pm25":{"v":165},"t":{"v":26},"w":{"v":3.6},"wg":{"v":11.8}},"time":{"s":"2022-04-22
+        00:00:00","tz":"+00:00","v":1650585600,"iso":"2022-04-22T00:00:00Z"},"forecast":{"daily":{"o3":[{"avg":6,"day":"2022-04-20","max":22,"min":1},{"avg":3,"day":"2022-04-21","max":6,"min":1},{"avg":6,"day":"2022-04-22","max":13,"min":1},{"avg":4,"day":"2022-04-23","max":10,"min":1},{"avg":5,"day":"2022-04-24","max":19,"min":1},{"avg":1,"day":"2022-04-25","max":2,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1},{"avg":1,"day":"2022-04-27","max":1,"min":1}],"pm10":[{"avg":26,"day":"2022-04-20","max":37,"min":15},{"avg":29,"day":"2022-04-21","max":45,"min":12},{"avg":28,"day":"2022-04-22","max":44,"min":12},{"avg":28,"day":"2022-04-23","max":51,"min":9},{"avg":24,"day":"2022-04-24","max":39,"min":10},{"avg":18,"day":"2022-04-25","max":40,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1},{"avg":1,"day":"2022-04-27","max":1,"min":1}],"pm25":[{"avg":55,"day":"2022-04-20","max":71,"min":30},{"avg":56,"day":"2022-04-21","max":78,"min":28},{"avg":60,"day":"2022-04-22","max":98,"min":27},{"avg":59,"day":"2022-04-23","max":102,"min":15},{"avg":46,"day":"2022-04-24","max":80,"min":1},{"avg":1,"day":"2022-04-25","max":1,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1},{"avg":1,"day":"2022-04-27","max":1,"min":1}]}},"debug":{"sync":"2022-04-22T10:12:55+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:30 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "194.063\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '1816'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:50;0/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:31 GMT
+      Location:
+      - /feed/geo:50;0/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:50;0/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":57,"idx":8620,"attributions":[{"url":"http://www.airnormand.fr/","name":"Air
+        Normand and Air C.O.M.","logo":"France-AirNormand.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[49.5142141381999,0.100861111709392],"name":"Ville-haute
+        EREA Genevoix, Le Havre, France","url":"https://aqicn.org/city/france/le-havre/ville-haute-erea-genevoix","location":""},"dominentpol":"pm25","iaqi":{"dew":{"v":6},"h":{"v":81},"no2":{"v":4.6},"o3":{"v":27.7},"p":{"v":1005},"pm10":{"v":23},"pm25":{"v":57},"so2":{"v":0.6},"t":{"v":9},"w":{"v":4.1}},"time":{"s":"2022-04-22
+        03:00:00","tz":"+02:00","v":1650596400,"iso":"2022-04-22T03:00:00+02:00"},"forecast":{"daily":{"o3":[{"avg":28,"day":"2022-04-21","max":39,"min":19},{"avg":23,"day":"2022-04-22","max":30,"min":16},{"avg":27,"day":"2022-04-23","max":36,"min":20},{"avg":28,"day":"2022-04-24","max":33,"min":23},{"avg":29,"day":"2022-04-25","max":29,"min":24}],"pm10":[{"avg":15,"day":"2022-04-21","max":18,"min":11},{"avg":20,"day":"2022-04-22","max":27,"min":14},{"avg":16,"day":"2022-04-23","max":22,"min":9},{"avg":18,"day":"2022-04-24","max":25,"min":8},{"avg":26,"day":"2022-04-25","max":29,"min":26}],"pm25":[{"avg":53,"day":"2022-04-21","max":59,"min":44},{"avg":65,"day":"2022-04-22","max":79,"min":52},{"avg":55,"day":"2022-04-23","max":70,"min":32},{"avg":54,"day":"2022-04-24","max":64,"min":28},{"avg":52,"day":"2022-04-25","max":62,"min":52}],"uvi":[{"avg":0,"day":"2022-04-21","max":4,"min":0},{"avg":0,"day":"2022-04-22","max":2,"min":0},{"avg":0,"day":"2022-04-23","max":3,"min":0},{"avg":1,"day":"2022-04-24","max":4,"min":0},{"avg":0,"day":"2022-04-25","max":4,"min":0},{"avg":1,"day":"2022-04-26","max":4,"min":0}]}},"debug":{"sync":"2022-04-22T10:13:48+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:32 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "284.505\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '1791'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:40;-75/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:33 GMT
+      Location:
+      - /feed/geo:40;-75/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:40;-75/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":22,"idx":10168,"attributions":[{"url":"http://www.nj.gov/dep/daq/","name":"NJDEP/DAQ
+        - New Jersey Department of Environmental Protection - Division of Air Quality","logo":"US-NJDEC.png"},{"url":"http://www.airnow.gov/","name":"Air
+        Now - US EPA"},{"url":"https://waqi.info/","name":"World Air Quality Index
+        Project"}],"city":{"geo":[39.934635,-75.126126],"name":"Camden Spruce St,
+        NewJersey, USA","url":"https://aqicn.org/city/usa/newjersey/camden-spruce-st","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":5.6},"h":{"v":58.8},"no2":{"v":0.2},"o3":{"v":4.8},"p":{"v":1024.4},"pm25":{"v":22},"so2":{"v":1.5},"t":{"v":14.7},"w":{"v":5},"wg":{"v":10.2}},"time":{"s":"2022-04-21
+        20:00:00","tz":"-05:00","v":1650571200,"iso":"2022-04-21T20:00:00-05:00"},"forecast":{"daily":{"o3":[{"avg":18,"day":"2022-04-19","max":19,"min":18},{"avg":9,"day":"2022-04-20","max":21,"min":1},{"avg":15,"day":"2022-04-21","max":23,"min":4},{"avg":11,"day":"2022-04-22","max":27,"min":4},{"avg":14,"day":"2022-04-23","max":22,"min":7},{"avg":18,"day":"2022-04-24","max":40,"min":12},{"avg":2,"day":"2022-04-25","max":18,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1}],"pm10":[{"avg":4,"day":"2022-04-19","max":5,"min":4},{"avg":12,"day":"2022-04-20","max":32,"min":4},{"avg":9,"day":"2022-04-21","max":27,"min":5},{"avg":15,"day":"2022-04-22","max":19,"min":8},{"avg":10,"day":"2022-04-23","max":15,"min":5},{"avg":23,"day":"2022-04-24","max":41,"min":9},{"avg":6,"day":"2022-04-25","max":10,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1}],"pm25":[{"avg":12,"day":"2022-04-19","max":13,"min":11},{"avg":33,"day":"2022-04-20","max":77,"min":10},{"avg":26,"day":"2022-04-21","max":73,"min":14},{"avg":47,"day":"2022-04-22","max":60,"min":20},{"avg":32,"day":"2022-04-23","max":49,"min":15},{"avg":42,"day":"2022-04-24","max":110,"min":1},{"avg":1,"day":"2022-04-25","max":1,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1}],"uvi":[{"avg":2,"day":"2022-04-21","max":6,"min":0},{"avg":2,"day":"2022-04-22","max":8,"min":0},{"avg":1,"day":"2022-04-23","max":3,"min":0},{"avg":2,"day":"2022-04-24","max":7,"min":0},{"avg":1,"day":"2022-04-25","max":6,"min":0},{"avg":0,"day":"2022-04-26","max":0,"min":0}]}},"debug":{"sync":"2022-04-22T10:22:09+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:33 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "174.604\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2277'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_multiple_coordinate_air/test_excluded_params.yaml
+++ b/tests/cassettes/test_get_multiple_coordinate_air/test_excluded_params.yaml
@@ -1,0 +1,225 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:0;0/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:34 GMT
+      Location:
+      - /feed/geo:0;0/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:0;0/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":165,"idx":12826,"attributions":[{"url":"https://gh.usembassy.gov/","name":"Accra
+        Air Quality Monitor - US EPA","logo":"US-StateDepartment.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[5.580642,-0.170724],"name":"Accra
+        US Embassy, Ghana","url":"https://aqicn.org/city/ghana/accra/us-embassy","location":""},"dominentpol":"pm25","iaqi":{"dew":{"v":24},"h":{"v":88},"p":{"v":1011},"pm25":{"v":165},"t":{"v":26},"w":{"v":3.6},"wg":{"v":11.8}},"time":{"s":"2022-04-22
+        00:00:00","tz":"+00:00","v":1650585600,"iso":"2022-04-22T00:00:00Z"},"forecast":{"daily":{"o3":[{"avg":6,"day":"2022-04-20","max":22,"min":1},{"avg":3,"day":"2022-04-21","max":6,"min":1},{"avg":6,"day":"2022-04-22","max":13,"min":1},{"avg":4,"day":"2022-04-23","max":10,"min":1},{"avg":5,"day":"2022-04-24","max":19,"min":1},{"avg":1,"day":"2022-04-25","max":2,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1},{"avg":1,"day":"2022-04-27","max":1,"min":1}],"pm10":[{"avg":26,"day":"2022-04-20","max":37,"min":15},{"avg":29,"day":"2022-04-21","max":45,"min":12},{"avg":28,"day":"2022-04-22","max":44,"min":12},{"avg":28,"day":"2022-04-23","max":51,"min":9},{"avg":24,"day":"2022-04-24","max":39,"min":10},{"avg":18,"day":"2022-04-25","max":40,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1},{"avg":1,"day":"2022-04-27","max":1,"min":1}],"pm25":[{"avg":55,"day":"2022-04-20","max":71,"min":30},{"avg":56,"day":"2022-04-21","max":78,"min":28},{"avg":60,"day":"2022-04-22","max":98,"min":27},{"avg":59,"day":"2022-04-23","max":102,"min":15},{"avg":46,"day":"2022-04-24","max":80,"min":1},{"avg":1,"day":"2022-04-25","max":1,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1},{"avg":1,"day":"2022-04-27","max":1,"min":1}]}},"debug":{"sync":"2022-04-22T10:12:55+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:34 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "489.489\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '1816'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:50;0/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:35 GMT
+      Location:
+      - /feed/geo:50;0/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:50;0/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":57,"idx":8620,"attributions":[{"url":"http://www.airnormand.fr/","name":"Air
+        Normand and Air C.O.M.","logo":"France-AirNormand.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[49.5142141381999,0.100861111709392],"name":"Ville-haute
+        EREA Genevoix, Le Havre, France","url":"https://aqicn.org/city/france/le-havre/ville-haute-erea-genevoix","location":""},"dominentpol":"pm25","iaqi":{"dew":{"v":6},"h":{"v":81},"no2":{"v":4.6},"o3":{"v":27.7},"p":{"v":1005},"pm10":{"v":23},"pm25":{"v":57},"so2":{"v":0.6},"t":{"v":9},"w":{"v":4.1}},"time":{"s":"2022-04-22
+        03:00:00","tz":"+02:00","v":1650596400,"iso":"2022-04-22T03:00:00+02:00"},"forecast":{"daily":{"o3":[{"avg":28,"day":"2022-04-21","max":39,"min":19},{"avg":23,"day":"2022-04-22","max":30,"min":16},{"avg":27,"day":"2022-04-23","max":36,"min":20},{"avg":28,"day":"2022-04-24","max":33,"min":23},{"avg":29,"day":"2022-04-25","max":29,"min":24}],"pm10":[{"avg":15,"day":"2022-04-21","max":18,"min":11},{"avg":20,"day":"2022-04-22","max":27,"min":14},{"avg":16,"day":"2022-04-23","max":22,"min":9},{"avg":18,"day":"2022-04-24","max":25,"min":8},{"avg":26,"day":"2022-04-25","max":29,"min":26}],"pm25":[{"avg":53,"day":"2022-04-21","max":59,"min":44},{"avg":65,"day":"2022-04-22","max":79,"min":52},{"avg":55,"day":"2022-04-23","max":70,"min":32},{"avg":54,"day":"2022-04-24","max":64,"min":28},{"avg":52,"day":"2022-04-25","max":62,"min":52}],"uvi":[{"avg":0,"day":"2022-04-21","max":4,"min":0},{"avg":0,"day":"2022-04-22","max":2,"min":0},{"avg":0,"day":"2022-04-23","max":3,"min":0},{"avg":1,"day":"2022-04-24","max":4,"min":0},{"avg":0,"day":"2022-04-25","max":4,"min":0},{"avg":1,"day":"2022-04-26","max":4,"min":0}]}},"debug":{"sync":"2022-04-22T10:13:48+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:35 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "387.557\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '1791'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:40;-75/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:36 GMT
+      Location:
+      - /feed/geo:40;-75/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:40;-75/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":22,"idx":10168,"attributions":[{"url":"http://www.nj.gov/dep/daq/","name":"NJDEP/DAQ
+        - New Jersey Department of Environmental Protection - Division of Air Quality","logo":"US-NJDEC.png"},{"url":"http://www.airnow.gov/","name":"Air
+        Now - US EPA"},{"url":"https://waqi.info/","name":"World Air Quality Index
+        Project"}],"city":{"geo":[39.934635,-75.126126],"name":"Camden Spruce St,
+        NewJersey, USA","url":"https://aqicn.org/city/usa/newjersey/camden-spruce-st","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":5.6},"h":{"v":58.8},"no2":{"v":0.2},"o3":{"v":4.8},"p":{"v":1024.4},"pm25":{"v":22},"so2":{"v":1.5},"t":{"v":14.7},"w":{"v":5},"wg":{"v":10.2}},"time":{"s":"2022-04-21
+        20:00:00","tz":"-05:00","v":1650571200,"iso":"2022-04-21T20:00:00-05:00"},"forecast":{"daily":{"o3":[{"avg":18,"day":"2022-04-19","max":19,"min":18},{"avg":9,"day":"2022-04-20","max":21,"min":1},{"avg":15,"day":"2022-04-21","max":23,"min":4},{"avg":11,"day":"2022-04-22","max":27,"min":4},{"avg":14,"day":"2022-04-23","max":22,"min":7},{"avg":18,"day":"2022-04-24","max":40,"min":12},{"avg":2,"day":"2022-04-25","max":18,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1}],"pm10":[{"avg":4,"day":"2022-04-19","max":5,"min":4},{"avg":12,"day":"2022-04-20","max":32,"min":4},{"avg":9,"day":"2022-04-21","max":27,"min":5},{"avg":15,"day":"2022-04-22","max":19,"min":8},{"avg":10,"day":"2022-04-23","max":15,"min":5},{"avg":23,"day":"2022-04-24","max":41,"min":9},{"avg":6,"day":"2022-04-25","max":10,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1}],"pm25":[{"avg":12,"day":"2022-04-19","max":13,"min":11},{"avg":33,"day":"2022-04-20","max":77,"min":10},{"avg":26,"day":"2022-04-21","max":73,"min":14},{"avg":47,"day":"2022-04-22","max":60,"min":20},{"avg":32,"day":"2022-04-23","max":49,"min":15},{"avg":42,"day":"2022-04-24","max":110,"min":1},{"avg":1,"day":"2022-04-25","max":1,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1}],"uvi":[{"avg":2,"day":"2022-04-21","max":6,"min":0},{"avg":2,"day":"2022-04-22","max":8,"min":0},{"avg":1,"day":"2022-04-23","max":3,"min":0},{"avg":2,"day":"2022-04-24","max":7,"min":0},{"avg":1,"day":"2022-04-25","max":6,"min":0},{"avg":0,"day":"2022-04-26","max":0,"min":0}]}},"debug":{"sync":"2022-04-22T10:22:09+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:36 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "465.548\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2277'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_multiple_coordinate_air/test_nonexistent_requested_params.yaml
+++ b/tests/cassettes/test_get_multiple_coordinate_air/test_nonexistent_requested_params.yaml
@@ -1,0 +1,225 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:0;0/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:37 GMT
+      Location:
+      - /feed/geo:0;0/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:0;0/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":165,"idx":12826,"attributions":[{"url":"https://gh.usembassy.gov/","name":"Accra
+        Air Quality Monitor - US EPA","logo":"US-StateDepartment.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[5.580642,-0.170724],"name":"Accra
+        US Embassy, Ghana","url":"https://aqicn.org/city/ghana/accra/us-embassy","location":""},"dominentpol":"pm25","iaqi":{"dew":{"v":24},"h":{"v":88},"p":{"v":1011},"pm25":{"v":165},"t":{"v":26},"w":{"v":3.6},"wg":{"v":11.8}},"time":{"s":"2022-04-22
+        00:00:00","tz":"+00:00","v":1650585600,"iso":"2022-04-22T00:00:00Z"},"forecast":{"daily":{"o3":[{"avg":6,"day":"2022-04-20","max":22,"min":1},{"avg":3,"day":"2022-04-21","max":6,"min":1},{"avg":6,"day":"2022-04-22","max":13,"min":1},{"avg":4,"day":"2022-04-23","max":10,"min":1},{"avg":5,"day":"2022-04-24","max":19,"min":1},{"avg":1,"day":"2022-04-25","max":2,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1},{"avg":1,"day":"2022-04-27","max":1,"min":1}],"pm10":[{"avg":26,"day":"2022-04-20","max":37,"min":15},{"avg":29,"day":"2022-04-21","max":45,"min":12},{"avg":28,"day":"2022-04-22","max":44,"min":12},{"avg":28,"day":"2022-04-23","max":51,"min":9},{"avg":24,"day":"2022-04-24","max":39,"min":10},{"avg":18,"day":"2022-04-25","max":40,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1},{"avg":1,"day":"2022-04-27","max":1,"min":1}],"pm25":[{"avg":55,"day":"2022-04-20","max":71,"min":30},{"avg":56,"day":"2022-04-21","max":78,"min":28},{"avg":60,"day":"2022-04-22","max":98,"min":27},{"avg":59,"day":"2022-04-23","max":102,"min":15},{"avg":46,"day":"2022-04-24","max":80,"min":1},{"avg":1,"day":"2022-04-25","max":1,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1},{"avg":1,"day":"2022-04-27","max":1,"min":1}]}},"debug":{"sync":"2022-04-22T10:12:55+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:37 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "248.785\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '1816'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:50;0/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:38 GMT
+      Location:
+      - /feed/geo:50;0/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:50;0/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":57,"idx":8620,"attributions":[{"url":"http://www.airnormand.fr/","name":"Air
+        Normand and Air C.O.M.","logo":"France-AirNormand.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[49.5142141381999,0.100861111709392],"name":"Ville-haute
+        EREA Genevoix, Le Havre, France","url":"https://aqicn.org/city/france/le-havre/ville-haute-erea-genevoix","location":""},"dominentpol":"pm25","iaqi":{"dew":{"v":6},"h":{"v":81},"no2":{"v":4.6},"o3":{"v":27.7},"p":{"v":1005},"pm10":{"v":23},"pm25":{"v":57},"so2":{"v":0.6},"t":{"v":9},"w":{"v":4.1}},"time":{"s":"2022-04-22
+        03:00:00","tz":"+02:00","v":1650596400,"iso":"2022-04-22T03:00:00+02:00"},"forecast":{"daily":{"o3":[{"avg":28,"day":"2022-04-21","max":39,"min":19},{"avg":23,"day":"2022-04-22","max":30,"min":16},{"avg":27,"day":"2022-04-23","max":36,"min":20},{"avg":28,"day":"2022-04-24","max":33,"min":23},{"avg":29,"day":"2022-04-25","max":29,"min":24}],"pm10":[{"avg":15,"day":"2022-04-21","max":18,"min":11},{"avg":20,"day":"2022-04-22","max":27,"min":14},{"avg":16,"day":"2022-04-23","max":22,"min":9},{"avg":18,"day":"2022-04-24","max":25,"min":8},{"avg":26,"day":"2022-04-25","max":29,"min":26}],"pm25":[{"avg":53,"day":"2022-04-21","max":59,"min":44},{"avg":65,"day":"2022-04-22","max":79,"min":52},{"avg":55,"day":"2022-04-23","max":70,"min":32},{"avg":54,"day":"2022-04-24","max":64,"min":28},{"avg":52,"day":"2022-04-25","max":62,"min":52}],"uvi":[{"avg":0,"day":"2022-04-21","max":4,"min":0},{"avg":0,"day":"2022-04-22","max":2,"min":0},{"avg":0,"day":"2022-04-23","max":3,"min":0},{"avg":1,"day":"2022-04-24","max":4,"min":0},{"avg":0,"day":"2022-04-25","max":4,"min":0},{"avg":1,"day":"2022-04-26","max":4,"min":0}]}},"debug":{"sync":"2022-04-22T10:13:48+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:39 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "609.131\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '1791'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:40;-75/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:39 GMT
+      Location:
+      - /feed/geo:40;-75/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:40;-75/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":22,"idx":10168,"attributions":[{"url":"http://www.nj.gov/dep/daq/","name":"NJDEP/DAQ
+        - New Jersey Department of Environmental Protection - Division of Air Quality","logo":"US-NJDEC.png"},{"url":"http://www.airnow.gov/","name":"Air
+        Now - US EPA"},{"url":"https://waqi.info/","name":"World Air Quality Index
+        Project"}],"city":{"geo":[39.934635,-75.126126],"name":"Camden Spruce St,
+        NewJersey, USA","url":"https://aqicn.org/city/usa/newjersey/camden-spruce-st","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":5.6},"h":{"v":58.8},"no2":{"v":0.2},"o3":{"v":4.8},"p":{"v":1024.4},"pm25":{"v":22},"so2":{"v":1.5},"t":{"v":14.7},"w":{"v":5},"wg":{"v":10.2}},"time":{"s":"2022-04-21
+        20:00:00","tz":"-05:00","v":1650571200,"iso":"2022-04-21T20:00:00-05:00"},"forecast":{"daily":{"o3":[{"avg":18,"day":"2022-04-19","max":19,"min":18},{"avg":9,"day":"2022-04-20","max":21,"min":1},{"avg":15,"day":"2022-04-21","max":23,"min":4},{"avg":11,"day":"2022-04-22","max":27,"min":4},{"avg":14,"day":"2022-04-23","max":22,"min":7},{"avg":18,"day":"2022-04-24","max":40,"min":12},{"avg":2,"day":"2022-04-25","max":18,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1}],"pm10":[{"avg":4,"day":"2022-04-19","max":5,"min":4},{"avg":12,"day":"2022-04-20","max":32,"min":4},{"avg":9,"day":"2022-04-21","max":27,"min":5},{"avg":15,"day":"2022-04-22","max":19,"min":8},{"avg":10,"day":"2022-04-23","max":15,"min":5},{"avg":23,"day":"2022-04-24","max":41,"min":9},{"avg":6,"day":"2022-04-25","max":10,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1}],"pm25":[{"avg":12,"day":"2022-04-19","max":13,"min":11},{"avg":33,"day":"2022-04-20","max":77,"min":10},{"avg":26,"day":"2022-04-21","max":73,"min":14},{"avg":47,"day":"2022-04-22","max":60,"min":20},{"avg":32,"day":"2022-04-23","max":49,"min":15},{"avg":42,"day":"2022-04-24","max":110,"min":1},{"avg":1,"day":"2022-04-25","max":1,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1}],"uvi":[{"avg":2,"day":"2022-04-21","max":6,"min":0},{"avg":2,"day":"2022-04-22","max":8,"min":0},{"avg":1,"day":"2022-04-23","max":3,"min":0},{"avg":2,"day":"2022-04-24","max":7,"min":0},{"avg":1,"day":"2022-04-25","max":6,"min":0},{"avg":0,"day":"2022-04-26","max":0,"min":0}]}},"debug":{"sync":"2022-04-22T10:22:09+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:40 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "335.816\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2277'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_multiple_coordinate_air/test_output_formats.yaml
+++ b/tests/cassettes/test_get_multiple_coordinate_air/test_output_formats.yaml
@@ -1,0 +1,671 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:0;0/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:48 GMT
+      Location:
+      - /feed/geo:0;0/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:0;0/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":165,"idx":12826,"attributions":[{"url":"https://gh.usembassy.gov/","name":"Accra
+        Air Quality Monitor - US EPA","logo":"US-StateDepartment.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[5.580642,-0.170724],"name":"Accra
+        US Embassy, Ghana","url":"https://aqicn.org/city/ghana/accra/us-embassy","location":""},"dominentpol":"pm25","iaqi":{"dew":{"v":24},"h":{"v":88},"p":{"v":1011},"pm25":{"v":165},"t":{"v":26},"w":{"v":3.6},"wg":{"v":11.8}},"time":{"s":"2022-04-22
+        00:00:00","tz":"+00:00","v":1650585600,"iso":"2022-04-22T00:00:00Z"},"forecast":{"daily":{"o3":[{"avg":6,"day":"2022-04-20","max":22,"min":1},{"avg":3,"day":"2022-04-21","max":6,"min":1},{"avg":6,"day":"2022-04-22","max":13,"min":1},{"avg":4,"day":"2022-04-23","max":10,"min":1},{"avg":5,"day":"2022-04-24","max":19,"min":1},{"avg":1,"day":"2022-04-25","max":2,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1},{"avg":1,"day":"2022-04-27","max":1,"min":1}],"pm10":[{"avg":26,"day":"2022-04-20","max":37,"min":15},{"avg":29,"day":"2022-04-21","max":45,"min":12},{"avg":28,"day":"2022-04-22","max":44,"min":12},{"avg":28,"day":"2022-04-23","max":51,"min":9},{"avg":24,"day":"2022-04-24","max":39,"min":10},{"avg":18,"day":"2022-04-25","max":40,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1},{"avg":1,"day":"2022-04-27","max":1,"min":1}],"pm25":[{"avg":55,"day":"2022-04-20","max":71,"min":30},{"avg":56,"day":"2022-04-21","max":78,"min":28},{"avg":60,"day":"2022-04-22","max":98,"min":27},{"avg":59,"day":"2022-04-23","max":102,"min":15},{"avg":46,"day":"2022-04-24","max":80,"min":1},{"avg":1,"day":"2022-04-25","max":1,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1},{"avg":1,"day":"2022-04-27","max":1,"min":1}]}},"debug":{"sync":"2022-04-22T10:12:55+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:48 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "477.24\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '1816'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:50;0/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:49 GMT
+      Location:
+      - /feed/geo:50;0/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:50;0/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":57,"idx":8620,"attributions":[{"url":"http://www.airnormand.fr/","name":"Air
+        Normand and Air C.O.M.","logo":"France-AirNormand.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[49.5142141381999,0.100861111709392],"name":"Ville-haute
+        EREA Genevoix, Le Havre, France","url":"https://aqicn.org/city/france/le-havre/ville-haute-erea-genevoix","location":""},"dominentpol":"pm25","iaqi":{"dew":{"v":6},"h":{"v":81},"no2":{"v":4.6},"o3":{"v":27.7},"p":{"v":1005},"pm10":{"v":23},"pm25":{"v":57},"so2":{"v":0.6},"t":{"v":9},"w":{"v":4.1}},"time":{"s":"2022-04-22
+        03:00:00","tz":"+02:00","v":1650596400,"iso":"2022-04-22T03:00:00+02:00"},"forecast":{"daily":{"o3":[{"avg":28,"day":"2022-04-21","max":39,"min":19},{"avg":23,"day":"2022-04-22","max":30,"min":16},{"avg":27,"day":"2022-04-23","max":36,"min":20},{"avg":28,"day":"2022-04-24","max":33,"min":23},{"avg":29,"day":"2022-04-25","max":29,"min":24}],"pm10":[{"avg":15,"day":"2022-04-21","max":18,"min":11},{"avg":20,"day":"2022-04-22","max":27,"min":14},{"avg":16,"day":"2022-04-23","max":22,"min":9},{"avg":18,"day":"2022-04-24","max":25,"min":8},{"avg":26,"day":"2022-04-25","max":29,"min":26}],"pm25":[{"avg":53,"day":"2022-04-21","max":59,"min":44},{"avg":65,"day":"2022-04-22","max":79,"min":52},{"avg":55,"day":"2022-04-23","max":70,"min":32},{"avg":54,"day":"2022-04-24","max":64,"min":28},{"avg":52,"day":"2022-04-25","max":62,"min":52}],"uvi":[{"avg":0,"day":"2022-04-21","max":4,"min":0},{"avg":0,"day":"2022-04-22","max":2,"min":0},{"avg":0,"day":"2022-04-23","max":3,"min":0},{"avg":1,"day":"2022-04-24","max":4,"min":0},{"avg":0,"day":"2022-04-25","max":4,"min":0},{"avg":1,"day":"2022-04-26","max":4,"min":0}]}},"debug":{"sync":"2022-04-22T10:13:48+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:49 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "178.784\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '1791'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:40;-75/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:50 GMT
+      Location:
+      - /feed/geo:40;-75/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:40;-75/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":22,"idx":10168,"attributions":[{"url":"http://www.nj.gov/dep/daq/","name":"NJDEP/DAQ
+        - New Jersey Department of Environmental Protection - Division of Air Quality","logo":"US-NJDEC.png"},{"url":"http://www.airnow.gov/","name":"Air
+        Now - US EPA"},{"url":"https://waqi.info/","name":"World Air Quality Index
+        Project"}],"city":{"geo":[39.934635,-75.126126],"name":"Camden Spruce St,
+        NewJersey, USA","url":"https://aqicn.org/city/usa/newjersey/camden-spruce-st","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":5.6},"h":{"v":58.8},"no2":{"v":0.2},"o3":{"v":4.8},"p":{"v":1024.4},"pm25":{"v":22},"so2":{"v":1.5},"t":{"v":14.7},"w":{"v":5},"wg":{"v":10.2}},"time":{"s":"2022-04-21
+        20:00:00","tz":"-05:00","v":1650571200,"iso":"2022-04-21T20:00:00-05:00"},"forecast":{"daily":{"o3":[{"avg":18,"day":"2022-04-19","max":19,"min":18},{"avg":9,"day":"2022-04-20","max":21,"min":1},{"avg":15,"day":"2022-04-21","max":23,"min":4},{"avg":11,"day":"2022-04-22","max":27,"min":4},{"avg":14,"day":"2022-04-23","max":22,"min":7},{"avg":18,"day":"2022-04-24","max":40,"min":12},{"avg":2,"day":"2022-04-25","max":18,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1}],"pm10":[{"avg":4,"day":"2022-04-19","max":5,"min":4},{"avg":12,"day":"2022-04-20","max":32,"min":4},{"avg":9,"day":"2022-04-21","max":27,"min":5},{"avg":15,"day":"2022-04-22","max":19,"min":8},{"avg":10,"day":"2022-04-23","max":15,"min":5},{"avg":23,"day":"2022-04-24","max":41,"min":9},{"avg":6,"day":"2022-04-25","max":10,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1}],"pm25":[{"avg":12,"day":"2022-04-19","max":13,"min":11},{"avg":33,"day":"2022-04-20","max":77,"min":10},{"avg":26,"day":"2022-04-21","max":73,"min":14},{"avg":47,"day":"2022-04-22","max":60,"min":20},{"avg":32,"day":"2022-04-23","max":49,"min":15},{"avg":42,"day":"2022-04-24","max":110,"min":1},{"avg":1,"day":"2022-04-25","max":1,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1}],"uvi":[{"avg":2,"day":"2022-04-21","max":6,"min":0},{"avg":2,"day":"2022-04-22","max":8,"min":0},{"avg":1,"day":"2022-04-23","max":3,"min":0},{"avg":2,"day":"2022-04-24","max":7,"min":0},{"avg":1,"day":"2022-04-25","max":6,"min":0},{"avg":0,"day":"2022-04-26","max":0,"min":0}]}},"debug":{"sync":"2022-04-22T10:22:09+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:50 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "427.218\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2277'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:0;0/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:51 GMT
+      Location:
+      - /feed/geo:0;0/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:0;0/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":165,"idx":12826,"attributions":[{"url":"https://gh.usembassy.gov/","name":"Accra
+        Air Quality Monitor - US EPA","logo":"US-StateDepartment.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[5.580642,-0.170724],"name":"Accra
+        US Embassy, Ghana","url":"https://aqicn.org/city/ghana/accra/us-embassy","location":""},"dominentpol":"pm25","iaqi":{"dew":{"v":24},"h":{"v":88},"p":{"v":1011},"pm25":{"v":165},"t":{"v":26},"w":{"v":3.6},"wg":{"v":11.8}},"time":{"s":"2022-04-22
+        00:00:00","tz":"+00:00","v":1650585600,"iso":"2022-04-22T00:00:00Z"},"forecast":{"daily":{"o3":[{"avg":6,"day":"2022-04-20","max":22,"min":1},{"avg":3,"day":"2022-04-21","max":6,"min":1},{"avg":6,"day":"2022-04-22","max":13,"min":1},{"avg":4,"day":"2022-04-23","max":10,"min":1},{"avg":5,"day":"2022-04-24","max":19,"min":1},{"avg":1,"day":"2022-04-25","max":2,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1},{"avg":1,"day":"2022-04-27","max":1,"min":1}],"pm10":[{"avg":26,"day":"2022-04-20","max":37,"min":15},{"avg":29,"day":"2022-04-21","max":45,"min":12},{"avg":28,"day":"2022-04-22","max":44,"min":12},{"avg":28,"day":"2022-04-23","max":51,"min":9},{"avg":24,"day":"2022-04-24","max":39,"min":10},{"avg":18,"day":"2022-04-25","max":40,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1},{"avg":1,"day":"2022-04-27","max":1,"min":1}],"pm25":[{"avg":55,"day":"2022-04-20","max":71,"min":30},{"avg":56,"day":"2022-04-21","max":78,"min":28},{"avg":60,"day":"2022-04-22","max":98,"min":27},{"avg":59,"day":"2022-04-23","max":102,"min":15},{"avg":46,"day":"2022-04-24","max":80,"min":1},{"avg":1,"day":"2022-04-25","max":1,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1},{"avg":1,"day":"2022-04-27","max":1,"min":1}]}},"debug":{"sync":"2022-04-22T10:12:55+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:51 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "192.613\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '1816'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:50;0/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:52 GMT
+      Location:
+      - /feed/geo:50;0/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:50;0/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":57,"idx":8620,"attributions":[{"url":"http://www.airnormand.fr/","name":"Air
+        Normand and Air C.O.M.","logo":"France-AirNormand.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[49.5142141381999,0.100861111709392],"name":"Ville-haute
+        EREA Genevoix, Le Havre, France","url":"https://aqicn.org/city/france/le-havre/ville-haute-erea-genevoix","location":""},"dominentpol":"pm25","iaqi":{"dew":{"v":6},"h":{"v":81},"no2":{"v":4.6},"o3":{"v":27.7},"p":{"v":1005},"pm10":{"v":23},"pm25":{"v":57},"so2":{"v":0.6},"t":{"v":9},"w":{"v":4.1}},"time":{"s":"2022-04-22
+        03:00:00","tz":"+02:00","v":1650596400,"iso":"2022-04-22T03:00:00+02:00"},"forecast":{"daily":{"o3":[{"avg":28,"day":"2022-04-21","max":39,"min":19},{"avg":23,"day":"2022-04-22","max":30,"min":16},{"avg":27,"day":"2022-04-23","max":36,"min":20},{"avg":28,"day":"2022-04-24","max":33,"min":23},{"avg":29,"day":"2022-04-25","max":29,"min":24}],"pm10":[{"avg":15,"day":"2022-04-21","max":18,"min":11},{"avg":20,"day":"2022-04-22","max":27,"min":14},{"avg":16,"day":"2022-04-23","max":22,"min":9},{"avg":18,"day":"2022-04-24","max":25,"min":8},{"avg":26,"day":"2022-04-25","max":29,"min":26}],"pm25":[{"avg":53,"day":"2022-04-21","max":59,"min":44},{"avg":65,"day":"2022-04-22","max":79,"min":52},{"avg":55,"day":"2022-04-23","max":70,"min":32},{"avg":54,"day":"2022-04-24","max":64,"min":28},{"avg":52,"day":"2022-04-25","max":62,"min":52}],"uvi":[{"avg":0,"day":"2022-04-21","max":4,"min":0},{"avg":0,"day":"2022-04-22","max":2,"min":0},{"avg":0,"day":"2022-04-23","max":3,"min":0},{"avg":1,"day":"2022-04-24","max":4,"min":0},{"avg":0,"day":"2022-04-25","max":4,"min":0},{"avg":1,"day":"2022-04-26","max":4,"min":0}]}},"debug":{"sync":"2022-04-22T10:13:48+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:52 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "267.074\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '1791'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:40;-75/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:53 GMT
+      Location:
+      - /feed/geo:40;-75/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:40;-75/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":22,"idx":10168,"attributions":[{"url":"http://www.nj.gov/dep/daq/","name":"NJDEP/DAQ
+        - New Jersey Department of Environmental Protection - Division of Air Quality","logo":"US-NJDEC.png"},{"url":"http://www.airnow.gov/","name":"Air
+        Now - US EPA"},{"url":"https://waqi.info/","name":"World Air Quality Index
+        Project"}],"city":{"geo":[39.934635,-75.126126],"name":"Camden Spruce St,
+        NewJersey, USA","url":"https://aqicn.org/city/usa/newjersey/camden-spruce-st","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":5.6},"h":{"v":58.8},"no2":{"v":0.2},"o3":{"v":4.8},"p":{"v":1024.4},"pm25":{"v":22},"so2":{"v":1.5},"t":{"v":14.7},"w":{"v":5},"wg":{"v":10.2}},"time":{"s":"2022-04-21
+        20:00:00","tz":"-05:00","v":1650571200,"iso":"2022-04-21T20:00:00-05:00"},"forecast":{"daily":{"o3":[{"avg":18,"day":"2022-04-19","max":19,"min":18},{"avg":9,"day":"2022-04-20","max":21,"min":1},{"avg":15,"day":"2022-04-21","max":23,"min":4},{"avg":11,"day":"2022-04-22","max":27,"min":4},{"avg":14,"day":"2022-04-23","max":22,"min":7},{"avg":18,"day":"2022-04-24","max":40,"min":12},{"avg":2,"day":"2022-04-25","max":18,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1}],"pm10":[{"avg":4,"day":"2022-04-19","max":5,"min":4},{"avg":12,"day":"2022-04-20","max":32,"min":4},{"avg":9,"day":"2022-04-21","max":27,"min":5},{"avg":15,"day":"2022-04-22","max":19,"min":8},{"avg":10,"day":"2022-04-23","max":15,"min":5},{"avg":23,"day":"2022-04-24","max":41,"min":9},{"avg":6,"day":"2022-04-25","max":10,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1}],"pm25":[{"avg":12,"day":"2022-04-19","max":13,"min":11},{"avg":33,"day":"2022-04-20","max":77,"min":10},{"avg":26,"day":"2022-04-21","max":73,"min":14},{"avg":47,"day":"2022-04-22","max":60,"min":20},{"avg":32,"day":"2022-04-23","max":49,"min":15},{"avg":42,"day":"2022-04-24","max":110,"min":1},{"avg":1,"day":"2022-04-25","max":1,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1}],"uvi":[{"avg":2,"day":"2022-04-21","max":6,"min":0},{"avg":2,"day":"2022-04-22","max":8,"min":0},{"avg":1,"day":"2022-04-23","max":3,"min":0},{"avg":2,"day":"2022-04-24","max":7,"min":0},{"avg":1,"day":"2022-04-25","max":6,"min":0},{"avg":0,"day":"2022-04-26","max":0,"min":0}]}},"debug":{"sync":"2022-04-22T10:22:09+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:54 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "163.613\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2277'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:0;0/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:55 GMT
+      Location:
+      - /feed/geo:0;0/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:0;0/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":165,"idx":12826,"attributions":[{"url":"https://gh.usembassy.gov/","name":"Accra
+        Air Quality Monitor - US EPA","logo":"US-StateDepartment.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[5.580642,-0.170724],"name":"Accra
+        US Embassy, Ghana","url":"https://aqicn.org/city/ghana/accra/us-embassy","location":""},"dominentpol":"pm25","iaqi":{"dew":{"v":24},"h":{"v":88},"p":{"v":1011},"pm25":{"v":165},"t":{"v":26},"w":{"v":3.6},"wg":{"v":11.8}},"time":{"s":"2022-04-22
+        00:00:00","tz":"+00:00","v":1650585600,"iso":"2022-04-22T00:00:00Z"},"forecast":{"daily":{"o3":[{"avg":6,"day":"2022-04-20","max":22,"min":1},{"avg":3,"day":"2022-04-21","max":6,"min":1},{"avg":6,"day":"2022-04-22","max":13,"min":1},{"avg":4,"day":"2022-04-23","max":10,"min":1},{"avg":5,"day":"2022-04-24","max":19,"min":1},{"avg":1,"day":"2022-04-25","max":2,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1},{"avg":1,"day":"2022-04-27","max":1,"min":1}],"pm10":[{"avg":26,"day":"2022-04-20","max":37,"min":15},{"avg":29,"day":"2022-04-21","max":45,"min":12},{"avg":28,"day":"2022-04-22","max":44,"min":12},{"avg":28,"day":"2022-04-23","max":51,"min":9},{"avg":24,"day":"2022-04-24","max":39,"min":10},{"avg":18,"day":"2022-04-25","max":40,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1},{"avg":1,"day":"2022-04-27","max":1,"min":1}],"pm25":[{"avg":55,"day":"2022-04-20","max":71,"min":30},{"avg":56,"day":"2022-04-21","max":78,"min":28},{"avg":60,"day":"2022-04-22","max":98,"min":27},{"avg":59,"day":"2022-04-23","max":102,"min":15},{"avg":46,"day":"2022-04-24","max":80,"min":1},{"avg":1,"day":"2022-04-25","max":1,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1},{"avg":1,"day":"2022-04-27","max":1,"min":1}]}},"debug":{"sync":"2022-04-22T10:12:55+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:55 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "518.199\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '1816'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:50;0/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:56 GMT
+      Location:
+      - /feed/geo:50;0/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:50;0/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":57,"idx":8620,"attributions":[{"url":"http://www.airnormand.fr/","name":"Air
+        Normand and Air C.O.M.","logo":"France-AirNormand.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[49.5142141381999,0.100861111709392],"name":"Ville-haute
+        EREA Genevoix, Le Havre, France","url":"https://aqicn.org/city/france/le-havre/ville-haute-erea-genevoix","location":""},"dominentpol":"pm25","iaqi":{"dew":{"v":6},"h":{"v":81},"no2":{"v":4.6},"o3":{"v":27.7},"p":{"v":1005},"pm10":{"v":23},"pm25":{"v":57},"so2":{"v":0.6},"t":{"v":9},"w":{"v":4.1}},"time":{"s":"2022-04-22
+        03:00:00","tz":"+02:00","v":1650596400,"iso":"2022-04-22T03:00:00+02:00"},"forecast":{"daily":{"o3":[{"avg":28,"day":"2022-04-21","max":39,"min":19},{"avg":23,"day":"2022-04-22","max":30,"min":16},{"avg":27,"day":"2022-04-23","max":36,"min":20},{"avg":28,"day":"2022-04-24","max":33,"min":23},{"avg":29,"day":"2022-04-25","max":29,"min":24}],"pm10":[{"avg":15,"day":"2022-04-21","max":18,"min":11},{"avg":20,"day":"2022-04-22","max":27,"min":14},{"avg":16,"day":"2022-04-23","max":22,"min":9},{"avg":18,"day":"2022-04-24","max":25,"min":8},{"avg":26,"day":"2022-04-25","max":29,"min":26}],"pm25":[{"avg":53,"day":"2022-04-21","max":59,"min":44},{"avg":65,"day":"2022-04-22","max":79,"min":52},{"avg":55,"day":"2022-04-23","max":70,"min":32},{"avg":54,"day":"2022-04-24","max":64,"min":28},{"avg":52,"day":"2022-04-25","max":62,"min":52}],"uvi":[{"avg":0,"day":"2022-04-21","max":4,"min":0},{"avg":0,"day":"2022-04-22","max":2,"min":0},{"avg":0,"day":"2022-04-23","max":3,"min":0},{"avg":1,"day":"2022-04-24","max":4,"min":0},{"avg":0,"day":"2022-04-25","max":4,"min":0},{"avg":1,"day":"2022-04-26","max":4,"min":0}]}},"debug":{"sync":"2022-04-22T10:13:48+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:56 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "209.953\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '1791'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:40;-75/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:57 GMT
+      Location:
+      - /feed/geo:40;-75/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:40;-75/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":22,"idx":10168,"attributions":[{"url":"http://www.nj.gov/dep/daq/","name":"NJDEP/DAQ
+        - New Jersey Department of Environmental Protection - Division of Air Quality","logo":"US-NJDEC.png"},{"url":"http://www.airnow.gov/","name":"Air
+        Now - US EPA"},{"url":"https://waqi.info/","name":"World Air Quality Index
+        Project"}],"city":{"geo":[39.934635,-75.126126],"name":"Camden Spruce St,
+        NewJersey, USA","url":"https://aqicn.org/city/usa/newjersey/camden-spruce-st","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":5.6},"h":{"v":58.8},"no2":{"v":0.2},"o3":{"v":4.8},"p":{"v":1024.4},"pm25":{"v":22},"so2":{"v":1.5},"t":{"v":14.7},"w":{"v":5},"wg":{"v":10.2}},"time":{"s":"2022-04-21
+        20:00:00","tz":"-05:00","v":1650571200,"iso":"2022-04-21T20:00:00-05:00"},"forecast":{"daily":{"o3":[{"avg":18,"day":"2022-04-19","max":19,"min":18},{"avg":9,"day":"2022-04-20","max":21,"min":1},{"avg":15,"day":"2022-04-21","max":23,"min":4},{"avg":11,"day":"2022-04-22","max":27,"min":4},{"avg":14,"day":"2022-04-23","max":22,"min":7},{"avg":18,"day":"2022-04-24","max":40,"min":12},{"avg":2,"day":"2022-04-25","max":18,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1}],"pm10":[{"avg":4,"day":"2022-04-19","max":5,"min":4},{"avg":12,"day":"2022-04-20","max":32,"min":4},{"avg":9,"day":"2022-04-21","max":27,"min":5},{"avg":15,"day":"2022-04-22","max":19,"min":8},{"avg":10,"day":"2022-04-23","max":15,"min":5},{"avg":23,"day":"2022-04-24","max":41,"min":9},{"avg":6,"day":"2022-04-25","max":10,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1}],"pm25":[{"avg":12,"day":"2022-04-19","max":13,"min":11},{"avg":33,"day":"2022-04-20","max":77,"min":10},{"avg":26,"day":"2022-04-21","max":73,"min":14},{"avg":47,"day":"2022-04-22","max":60,"min":20},{"avg":32,"day":"2022-04-23","max":49,"min":15},{"avg":42,"day":"2022-04-24","max":110,"min":1},{"avg":1,"day":"2022-04-25","max":1,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1}],"uvi":[{"avg":2,"day":"2022-04-21","max":6,"min":0},{"avg":2,"day":"2022-04-22","max":8,"min":0},{"avg":1,"day":"2022-04-23","max":3,"min":0},{"avg":2,"day":"2022-04-24","max":7,"min":0},{"avg":1,"day":"2022-04-25","max":6,"min":0},{"avg":0,"day":"2022-04-26","max":0,"min":0}]}},"debug":{"sync":"2022-04-22T10:22:09+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:57 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "284.296\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2277'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_multiple_coordinate_air/test_return_value_and_format.yaml
+++ b/tests/cassettes/test_get_multiple_coordinate_air/test_return_value_and_format.yaml
@@ -1,0 +1,225 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:0;0/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:23 GMT
+      Location:
+      - /feed/geo:0;0/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:0;0/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":165,"idx":12826,"attributions":[{"url":"https://gh.usembassy.gov/","name":"Accra
+        Air Quality Monitor - US EPA","logo":"US-StateDepartment.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[5.580642,-0.170724],"name":"Accra
+        US Embassy, Ghana","url":"https://aqicn.org/city/ghana/accra/us-embassy","location":""},"dominentpol":"pm25","iaqi":{"dew":{"v":24},"h":{"v":88},"p":{"v":1011},"pm25":{"v":165},"t":{"v":26},"w":{"v":3.6},"wg":{"v":11.8}},"time":{"s":"2022-04-22
+        00:00:00","tz":"+00:00","v":1650585600,"iso":"2022-04-22T00:00:00Z"},"forecast":{"daily":{"o3":[{"avg":6,"day":"2022-04-20","max":22,"min":1},{"avg":3,"day":"2022-04-21","max":6,"min":1},{"avg":6,"day":"2022-04-22","max":13,"min":1},{"avg":4,"day":"2022-04-23","max":10,"min":1},{"avg":5,"day":"2022-04-24","max":19,"min":1},{"avg":1,"day":"2022-04-25","max":2,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1},{"avg":1,"day":"2022-04-27","max":1,"min":1}],"pm10":[{"avg":26,"day":"2022-04-20","max":37,"min":15},{"avg":29,"day":"2022-04-21","max":45,"min":12},{"avg":28,"day":"2022-04-22","max":44,"min":12},{"avg":28,"day":"2022-04-23","max":51,"min":9},{"avg":24,"day":"2022-04-24","max":39,"min":10},{"avg":18,"day":"2022-04-25","max":40,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1},{"avg":1,"day":"2022-04-27","max":1,"min":1}],"pm25":[{"avg":55,"day":"2022-04-20","max":71,"min":30},{"avg":56,"day":"2022-04-21","max":78,"min":28},{"avg":60,"day":"2022-04-22","max":98,"min":27},{"avg":59,"day":"2022-04-23","max":102,"min":15},{"avg":46,"day":"2022-04-24","max":80,"min":1},{"avg":1,"day":"2022-04-25","max":1,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1},{"avg":1,"day":"2022-04-27","max":1,"min":1}]}},"debug":{"sync":"2022-04-22T10:12:55+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:23 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "308.086\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '1816'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:50;0/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:24 GMT
+      Location:
+      - /feed/geo:50;0/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:50;0/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":57,"idx":8620,"attributions":[{"url":"http://www.airnormand.fr/","name":"Air
+        Normand and Air C.O.M.","logo":"France-AirNormand.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[49.5142141381999,0.100861111709392],"name":"Ville-haute
+        EREA Genevoix, Le Havre, France","url":"https://aqicn.org/city/france/le-havre/ville-haute-erea-genevoix","location":""},"dominentpol":"pm25","iaqi":{"dew":{"v":6},"h":{"v":81},"no2":{"v":4.6},"o3":{"v":27.7},"p":{"v":1005},"pm10":{"v":23},"pm25":{"v":57},"so2":{"v":0.6},"t":{"v":9},"w":{"v":4.1}},"time":{"s":"2022-04-22
+        03:00:00","tz":"+02:00","v":1650596400,"iso":"2022-04-22T03:00:00+02:00"},"forecast":{"daily":{"o3":[{"avg":28,"day":"2022-04-21","max":39,"min":19},{"avg":23,"day":"2022-04-22","max":30,"min":16},{"avg":27,"day":"2022-04-23","max":36,"min":20},{"avg":28,"day":"2022-04-24","max":33,"min":23},{"avg":29,"day":"2022-04-25","max":29,"min":24}],"pm10":[{"avg":15,"day":"2022-04-21","max":18,"min":11},{"avg":20,"day":"2022-04-22","max":27,"min":14},{"avg":16,"day":"2022-04-23","max":22,"min":9},{"avg":18,"day":"2022-04-24","max":25,"min":8},{"avg":26,"day":"2022-04-25","max":29,"min":26}],"pm25":[{"avg":53,"day":"2022-04-21","max":59,"min":44},{"avg":65,"day":"2022-04-22","max":79,"min":52},{"avg":55,"day":"2022-04-23","max":70,"min":32},{"avg":54,"day":"2022-04-24","max":64,"min":28},{"avg":52,"day":"2022-04-25","max":62,"min":52}],"uvi":[{"avg":0,"day":"2022-04-21","max":4,"min":0},{"avg":0,"day":"2022-04-22","max":2,"min":0},{"avg":0,"day":"2022-04-23","max":3,"min":0},{"avg":1,"day":"2022-04-24","max":4,"min":0},{"avg":0,"day":"2022-04-25","max":4,"min":0},{"avg":1,"day":"2022-04-26","max":4,"min":0}]}},"debug":{"sync":"2022-04-22T10:13:48+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:24 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "245.624\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '1791'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//geo:40;-75/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:26:25 GMT
+      Location:
+      - /feed/geo:40;-75/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/geo:40;-75/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":22,"idx":10168,"attributions":[{"url":"http://www.nj.gov/dep/daq/","name":"NJDEP/DAQ
+        - New Jersey Department of Environmental Protection - Division of Air Quality","logo":"US-NJDEC.png"},{"url":"http://www.airnow.gov/","name":"Air
+        Now - US EPA"},{"url":"https://waqi.info/","name":"World Air Quality Index
+        Project"}],"city":{"geo":[39.934635,-75.126126],"name":"Camden Spruce St,
+        NewJersey, USA","url":"https://aqicn.org/city/usa/newjersey/camden-spruce-st","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":5.6},"h":{"v":58.8},"no2":{"v":0.2},"o3":{"v":4.8},"p":{"v":1024.4},"pm25":{"v":22},"so2":{"v":1.5},"t":{"v":14.7},"w":{"v":5},"wg":{"v":10.2}},"time":{"s":"2022-04-21
+        20:00:00","tz":"-05:00","v":1650571200,"iso":"2022-04-21T20:00:00-05:00"},"forecast":{"daily":{"o3":[{"avg":18,"day":"2022-04-19","max":19,"min":18},{"avg":9,"day":"2022-04-20","max":21,"min":1},{"avg":15,"day":"2022-04-21","max":23,"min":4},{"avg":11,"day":"2022-04-22","max":27,"min":4},{"avg":14,"day":"2022-04-23","max":22,"min":7},{"avg":18,"day":"2022-04-24","max":40,"min":12},{"avg":2,"day":"2022-04-25","max":18,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1}],"pm10":[{"avg":4,"day":"2022-04-19","max":5,"min":4},{"avg":12,"day":"2022-04-20","max":32,"min":4},{"avg":9,"day":"2022-04-21","max":27,"min":5},{"avg":15,"day":"2022-04-22","max":19,"min":8},{"avg":10,"day":"2022-04-23","max":15,"min":5},{"avg":23,"day":"2022-04-24","max":41,"min":9},{"avg":6,"day":"2022-04-25","max":10,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1}],"pm25":[{"avg":12,"day":"2022-04-19","max":13,"min":11},{"avg":33,"day":"2022-04-20","max":77,"min":10},{"avg":26,"day":"2022-04-21","max":73,"min":14},{"avg":47,"day":"2022-04-22","max":60,"min":20},{"avg":32,"day":"2022-04-23","max":49,"min":15},{"avg":42,"day":"2022-04-24","max":110,"min":1},{"avg":1,"day":"2022-04-25","max":1,"min":1},{"avg":1,"day":"2022-04-26","max":1,"min":1}],"uvi":[{"avg":2,"day":"2022-04-21","max":6,"min":0},{"avg":2,"day":"2022-04-22","max":8,"min":0},{"avg":1,"day":"2022-04-23","max":3,"min":0},{"avg":2,"day":"2022-04-24","max":7,"min":0},{"avg":1,"day":"2022-04-25","max":6,"min":0},{"avg":0,"day":"2022-04-26","max":0,"min":0}]}},"debug":{"sync":"2022-04-22T10:22:09+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:26 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "240.714\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2277'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_range_coordinates_air/test_bad_coordinates.yaml
+++ b/tests/cassettes/test_get_range_coordinates_air/test_bad_coordinates.yaml
@@ -1,0 +1,43 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/map/bounds/?latlng=lol%2Cbruh%2C0%2C0&token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"error","data":"invalid bounds: strconv.ParseFloat: parsing
+        \"lol\": invalid syntax"}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:27:05 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "33.192\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '95'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_range_coordinates_air/test_bad_data_format.yaml
+++ b/tests/cassettes/test_get_range_coordinates_air/test_bad_data_format.yaml
@@ -1,0 +1,73 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/map/bounds/?latlng=51%2C-0.2%2C52%2C1&token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":[{"lat":51.518167,"lon":0.439548,"uid":3213,"aqi":"46","station":{"name":"Stanford-le-Hope
+        Roadside, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.486957,"lon":0.095111,"uid":7954,"aqi":"27","station":{"name":"Greenwich
+        - Plumstead High Street, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.486884,"lon":0.017901,"uid":7955,"aqi":"34","station":{"name":"Greenwich
+        - Woolwich Flyover, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.493774669582,"lon":0.010779623703256,"uid":10876,"aqi":"17","station":{"name":"Greenwich
+        - John Harrison Way, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.562376,"lon":-0.004898,"uid":11768,"aqi":"-","station":{"name":"Waltham
+        Forest Dawlish Rd, United Kingdom","time":"2022-04-22T01:00:00+09:00"}},{"lat":51.52253,"lon":-0.154611,"uid":3193,"aqi":"38","station":{"name":"London
+        Marylebone Road, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.5993,"lon":-0.068218,"uid":3179,"aqi":"-","station":{"name":"Haringey
+        Roadside, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.374264,"lon":0.54797,"uid":3169,"aqi":"38","station":{"name":"Chatham
+        Roadside, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.45617,"lon":0.634889,"uid":3207,"aqi":"46","station":{"name":"Rochester
+        Stoke, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.490532,"lon":0.074003,"uid":7953,"aqi":"42","station":{"name":"Greenwich
+        - A206 Burrage Grove, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.449674,"lon":-0.037418,"uid":11653,"aqi":"32","station":{"name":"London
+        Honor Oak Park, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.410039,"lon":-0.127523,"uid":8923,"aqi":"34","station":{"name":"Croydon
+        - Norbury Manor, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.389286904505,"lon":-0.14166152477989,"uid":7959,"aqi":"42","station":{"name":"Sutton
+        - Beddington Lane north, United Kingdom","time":"2022-04-22T07:00:00+09:00"}},{"lat":51.526454,"lon":-0.08491,"uid":7946,"aqi":"32","station":{"name":"Hackney
+        - Old Street, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.49467,"lon":-0.131931,"uid":10874,"aqi":"33","station":{"name":"London
+        Westminster, United Kingdom","time":"2022-04-22T07:00:00+09:00"}},{"lat":51.515046167401,"lon":-0.0084184926564274,"uid":7948,"aqi":"44","station":{"name":"Tower
+        Hamlets - Blackwall, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.544206,"lon":0.678408,"uid":3212,"aqi":"34","station":{"name":"Southend-on-Sea,
+        United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.494648681305,"lon":0.13727911123218,"uid":7951,"aqi":"37","station":{"name":"Bexley
+        - Belvedere West, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.483907253348,"lon":0.00040739693584974,"uid":10103,"aqi":"23","station":{"name":"Greenwich
+        - Trafalgar Road (Hoskins St), United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.474954,"lon":-0.039641,"uid":7956,"aqi":"52","station":{"name":"Lewisham
+        - New Cross, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.513847178423,"lon":-0.077765681752,"uid":8919,"aqi":"-","station":{"name":"City
+        of London - Sir John Cass School, United Kingdom","time":"2022-04-20T12:00:00+09:00"}},{"lat":51.52229,"lon":-0.125889,"uid":3189,"aqi":"38","station":{"name":"London
+        Bloomsbury, United Kingdom","time":"2022-04-22T06:00:00+09:00"}},{"lat":51.569484331524,"lon":0.082907474896495,"uid":9041,"aqi":"17","station":{"name":"Redbridge
+        - Ley Street, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.520787459334,"lon":0.20546070569404,"uid":7947,"aqi":"22","station":{"name":"Havering
+        - Rainham, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.5073509,"lon":-0.1277583,"uid":5724,"aqi":"52","station":{"name":"London","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.46603,"lon":0.184806,"uid":3188,"aqi":"37","station":{"name":"London
+        Bexley, United Kingdom","time":"2022-04-22T07:00:00+09:00"}},{"lat":51.57661,"lon":0.030858,"uid":8918,"aqi":"36","station":{"name":"Redbridge
+        - Gardner Close, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.514525336231,"lon":-0.10451562633788,"uid":7949,"aqi":"46","station":{"name":"City
+        of London - Farringdon Street, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.490610208215,"lon":0.15891449392752,"uid":7952,"aqi":"-","station":{"name":"Bexley
+        - Belvedere, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.456357,"lon":0.040725,"uid":7957,"aqi":"33","station":{"name":"Greenwich
+        - Westhorne Avenue, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.54421,"lon":-0.175269,"uid":3166,"aqi":"34","station":{"name":"Camden
+        Kerbside, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.527706619465,"lon":-0.12905320528252,"uid":7945,"aqi":"-","station":{"name":"Camden
+        - Euston Road, United Kingdom","time":"2022-04-22T05:00:00+09:00"}}]}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:27:06 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "181.583\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '4997'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_range_coordinates_air/test_column_expected_contents.yaml
+++ b/tests/cassettes/test_get_range_coordinates_air/test_column_expected_contents.yaml
@@ -1,0 +1,73 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/map/bounds/?latlng=51%2C-0.2%2C52%2C1&token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":[{"lat":51.544206,"lon":0.678408,"uid":3212,"aqi":"34","station":{"name":"Southend-on-Sea,
+        United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.57661,"lon":0.030858,"uid":8918,"aqi":"36","station":{"name":"Redbridge
+        - Gardner Close, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.520787459334,"lon":0.20546070569404,"uid":7947,"aqi":"22","station":{"name":"Havering
+        - Rainham, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.49467,"lon":-0.131931,"uid":10874,"aqi":"33","station":{"name":"London
+        Westminster, United Kingdom","time":"2022-04-22T07:00:00+09:00"}},{"lat":51.474954,"lon":-0.039641,"uid":7956,"aqi":"52","station":{"name":"Lewisham
+        - New Cross, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.527706619465,"lon":-0.12905320528252,"uid":7945,"aqi":"-","station":{"name":"Camden
+        - Euston Road, United Kingdom","time":"2022-04-22T05:00:00+09:00"}},{"lat":51.45617,"lon":0.634889,"uid":3207,"aqi":"46","station":{"name":"Rochester
+        Stoke, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.569484331524,"lon":0.082907474896495,"uid":9041,"aqi":"17","station":{"name":"Redbridge
+        - Ley Street, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.526454,"lon":-0.08491,"uid":7946,"aqi":"32","station":{"name":"Hackney
+        - Old Street, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.52229,"lon":-0.125889,"uid":3189,"aqi":"38","station":{"name":"London
+        Bloomsbury, United Kingdom","time":"2022-04-22T06:00:00+09:00"}},{"lat":51.518167,"lon":0.439548,"uid":3213,"aqi":"46","station":{"name":"Stanford-le-Hope
+        Roadside, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.490610208215,"lon":0.15891449392752,"uid":7952,"aqi":"-","station":{"name":"Bexley
+        - Belvedere, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.456357,"lon":0.040725,"uid":7957,"aqi":"33","station":{"name":"Greenwich
+        - Westhorne Avenue, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.562376,"lon":-0.004898,"uid":11768,"aqi":"-","station":{"name":"Waltham
+        Forest Dawlish Rd, United Kingdom","time":"2022-04-22T01:00:00+09:00"}},{"lat":51.54421,"lon":-0.175269,"uid":3166,"aqi":"34","station":{"name":"Camden
+        Kerbside, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.514525336231,"lon":-0.10451562633788,"uid":7949,"aqi":"46","station":{"name":"City
+        of London - Farringdon Street, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.374264,"lon":0.54797,"uid":3169,"aqi":"38","station":{"name":"Chatham
+        Roadside, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.490532,"lon":0.074003,"uid":7953,"aqi":"42","station":{"name":"Greenwich
+        - A206 Burrage Grove, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.389286904505,"lon":-0.14166152477989,"uid":7959,"aqi":"42","station":{"name":"Sutton
+        - Beddington Lane north, United Kingdom","time":"2022-04-22T07:00:00+09:00"}},{"lat":51.486884,"lon":0.017901,"uid":7955,"aqi":"34","station":{"name":"Greenwich
+        - Woolwich Flyover, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.493774669582,"lon":0.010779623703256,"uid":10876,"aqi":"17","station":{"name":"Greenwich
+        - John Harrison Way, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.52253,"lon":-0.154611,"uid":3193,"aqi":"38","station":{"name":"London
+        Marylebone Road, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.5073509,"lon":-0.1277583,"uid":5724,"aqi":"52","station":{"name":"London","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.5993,"lon":-0.068218,"uid":3179,"aqi":"-","station":{"name":"Haringey
+        Roadside, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.449674,"lon":-0.037418,"uid":11653,"aqi":"32","station":{"name":"London
+        Honor Oak Park, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.513847178423,"lon":-0.077765681752,"uid":8919,"aqi":"-","station":{"name":"City
+        of London - Sir John Cass School, United Kingdom","time":"2022-04-20T12:00:00+09:00"}},{"lat":51.494648681305,"lon":0.13727911123218,"uid":7951,"aqi":"37","station":{"name":"Bexley
+        - Belvedere West, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.410039,"lon":-0.127523,"uid":8923,"aqi":"34","station":{"name":"Croydon
+        - Norbury Manor, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.46603,"lon":0.184806,"uid":3188,"aqi":"37","station":{"name":"London
+        Bexley, United Kingdom","time":"2022-04-22T07:00:00+09:00"}},{"lat":51.486957,"lon":0.095111,"uid":7954,"aqi":"27","station":{"name":"Greenwich
+        - Plumstead High Street, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.483907253348,"lon":0.00040739693584974,"uid":10103,"aqi":"23","station":{"name":"Greenwich
+        - Trafalgar Road (Hoskins St), United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.515046167401,"lon":-0.0084184926564274,"uid":7948,"aqi":"44","station":{"name":"Tower
+        Hamlets - Blackwall, United Kingdom","time":"2022-04-22T09:00:00+09:00"}}]}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:27:00 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "170.623\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '4997'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_range_coordinates_air/test_column_types.yaml
+++ b/tests/cassettes/test_get_range_coordinates_air/test_column_types.yaml
@@ -1,0 +1,73 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/map/bounds/?latlng=51%2C-0.2%2C52%2C1&token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":[{"lat":51.514525336231,"lon":-0.10451562633788,"uid":7949,"aqi":"46","station":{"name":"City
+        of London - Farringdon Street, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.562376,"lon":-0.004898,"uid":11768,"aqi":"-","station":{"name":"Waltham
+        Forest Dawlish Rd, United Kingdom","time":"2022-04-22T01:00:00+09:00"}},{"lat":51.474954,"lon":-0.039641,"uid":7956,"aqi":"52","station":{"name":"Lewisham
+        - New Cross, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.526454,"lon":-0.08491,"uid":7946,"aqi":"32","station":{"name":"Hackney
+        - Old Street, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.5993,"lon":-0.068218,"uid":3179,"aqi":"-","station":{"name":"Haringey
+        Roadside, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.483907253348,"lon":0.00040739693584974,"uid":10103,"aqi":"23","station":{"name":"Greenwich
+        - Trafalgar Road (Hoskins St), United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.486957,"lon":0.095111,"uid":7954,"aqi":"27","station":{"name":"Greenwich
+        - Plumstead High Street, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.456357,"lon":0.040725,"uid":7957,"aqi":"33","station":{"name":"Greenwich
+        - Westhorne Avenue, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.520787459334,"lon":0.20546070569404,"uid":7947,"aqi":"22","station":{"name":"Havering
+        - Rainham, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.449674,"lon":-0.037418,"uid":11653,"aqi":"32","station":{"name":"London
+        Honor Oak Park, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.518167,"lon":0.439548,"uid":3213,"aqi":"46","station":{"name":"Stanford-le-Hope
+        Roadside, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.490610208215,"lon":0.15891449392752,"uid":7952,"aqi":"-","station":{"name":"Bexley
+        - Belvedere, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.527706619465,"lon":-0.12905320528252,"uid":7945,"aqi":"-","station":{"name":"Camden
+        - Euston Road, United Kingdom","time":"2022-04-22T05:00:00+09:00"}},{"lat":51.544206,"lon":0.678408,"uid":3212,"aqi":"34","station":{"name":"Southend-on-Sea,
+        United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.490532,"lon":0.074003,"uid":7953,"aqi":"42","station":{"name":"Greenwich
+        - A206 Burrage Grove, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.57661,"lon":0.030858,"uid":8918,"aqi":"36","station":{"name":"Redbridge
+        - Gardner Close, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.45617,"lon":0.634889,"uid":3207,"aqi":"46","station":{"name":"Rochester
+        Stoke, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.515046167401,"lon":-0.0084184926564274,"uid":7948,"aqi":"44","station":{"name":"Tower
+        Hamlets - Blackwall, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.493774669582,"lon":0.010779623703256,"uid":10876,"aqi":"17","station":{"name":"Greenwich
+        - John Harrison Way, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.486884,"lon":0.017901,"uid":7955,"aqi":"34","station":{"name":"Greenwich
+        - Woolwich Flyover, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.569484331524,"lon":0.082907474896495,"uid":9041,"aqi":"17","station":{"name":"Redbridge
+        - Ley Street, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.49467,"lon":-0.131931,"uid":10874,"aqi":"33","station":{"name":"London
+        Westminster, United Kingdom","time":"2022-04-22T07:00:00+09:00"}},{"lat":51.389286904505,"lon":-0.14166152477989,"uid":7959,"aqi":"42","station":{"name":"Sutton
+        - Beddington Lane north, United Kingdom","time":"2022-04-22T07:00:00+09:00"}},{"lat":51.52253,"lon":-0.154611,"uid":3193,"aqi":"38","station":{"name":"London
+        Marylebone Road, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.5073509,"lon":-0.1277583,"uid":5724,"aqi":"52","station":{"name":"London","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.46603,"lon":0.184806,"uid":3188,"aqi":"37","station":{"name":"London
+        Bexley, United Kingdom","time":"2022-04-22T07:00:00+09:00"}},{"lat":51.494648681305,"lon":0.13727911123218,"uid":7951,"aqi":"37","station":{"name":"Bexley
+        - Belvedere West, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.410039,"lon":-0.127523,"uid":8923,"aqi":"34","station":{"name":"Croydon
+        - Norbury Manor, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.513847178423,"lon":-0.077765681752,"uid":8919,"aqi":"-","station":{"name":"City
+        of London - Sir John Cass School, United Kingdom","time":"2022-04-20T12:00:00+09:00"}},{"lat":51.54421,"lon":-0.175269,"uid":3166,"aqi":"34","station":{"name":"Camden
+        Kerbside, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.52229,"lon":-0.125889,"uid":3189,"aqi":"38","station":{"name":"London
+        Bloomsbury, United Kingdom","time":"2022-04-22T06:00:00+09:00"}},{"lat":51.374264,"lon":0.54797,"uid":3169,"aqi":"38","station":{"name":"Chatham
+        Roadside, United Kingdom","time":"2022-04-22T08:00:00+09:00"}}]}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:27:01 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "255.444\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '4997'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_range_coordinates_air/test_excluded_params.yaml
+++ b/tests/cassettes/test_get_range_coordinates_air/test_excluded_params.yaml
@@ -1,0 +1,73 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/map/bounds/?latlng=51%2C-0.2%2C52%2C1&token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":[{"lat":51.518167,"lon":0.439548,"uid":3213,"aqi":"46","station":{"name":"Stanford-le-Hope
+        Roadside, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.494648681305,"lon":0.13727911123218,"uid":7951,"aqi":"37","station":{"name":"Bexley
+        - Belvedere West, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.483907253348,"lon":0.00040739693584974,"uid":10103,"aqi":"23","station":{"name":"Greenwich
+        - Trafalgar Road (Hoskins St), United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.493774669582,"lon":0.010779623703256,"uid":10876,"aqi":"17","station":{"name":"Greenwich
+        - John Harrison Way, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.49467,"lon":-0.131931,"uid":10874,"aqi":"33","station":{"name":"London
+        Westminster, United Kingdom","time":"2022-04-22T07:00:00+09:00"}},{"lat":51.513847178423,"lon":-0.077765681752,"uid":8919,"aqi":"-","station":{"name":"City
+        of London - Sir John Cass School, United Kingdom","time":"2022-04-20T12:00:00+09:00"}},{"lat":51.45617,"lon":0.634889,"uid":3207,"aqi":"46","station":{"name":"Rochester
+        Stoke, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.486884,"lon":0.017901,"uid":7955,"aqi":"34","station":{"name":"Greenwich
+        - Woolwich Flyover, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.52253,"lon":-0.154611,"uid":3193,"aqi":"38","station":{"name":"London
+        Marylebone Road, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.527706619465,"lon":-0.12905320528252,"uid":7945,"aqi":"-","station":{"name":"Camden
+        - Euston Road, United Kingdom","time":"2022-04-22T05:00:00+09:00"}},{"lat":51.5993,"lon":-0.068218,"uid":3179,"aqi":"-","station":{"name":"Haringey
+        Roadside, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.449674,"lon":-0.037418,"uid":11653,"aqi":"32","station":{"name":"London
+        Honor Oak Park, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.562376,"lon":-0.004898,"uid":11768,"aqi":"-","station":{"name":"Waltham
+        Forest Dawlish Rd, United Kingdom","time":"2022-04-22T01:00:00+09:00"}},{"lat":51.490610208215,"lon":0.15891449392752,"uid":7952,"aqi":"-","station":{"name":"Bexley
+        - Belvedere, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.57661,"lon":0.030858,"uid":8918,"aqi":"36","station":{"name":"Redbridge
+        - Gardner Close, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.526454,"lon":-0.08491,"uid":7946,"aqi":"32","station":{"name":"Hackney
+        - Old Street, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.374264,"lon":0.54797,"uid":3169,"aqi":"38","station":{"name":"Chatham
+        Roadside, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.46603,"lon":0.184806,"uid":3188,"aqi":"37","station":{"name":"London
+        Bexley, United Kingdom","time":"2022-04-22T07:00:00+09:00"}},{"lat":51.515046167401,"lon":-0.0084184926564274,"uid":7948,"aqi":"44","station":{"name":"Tower
+        Hamlets - Blackwall, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.52229,"lon":-0.125889,"uid":3189,"aqi":"38","station":{"name":"London
+        Bloomsbury, United Kingdom","time":"2022-04-22T06:00:00+09:00"}},{"lat":51.5073509,"lon":-0.1277583,"uid":5724,"aqi":"52","station":{"name":"London","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.410039,"lon":-0.127523,"uid":8923,"aqi":"34","station":{"name":"Croydon
+        - Norbury Manor, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.544206,"lon":0.678408,"uid":3212,"aqi":"34","station":{"name":"Southend-on-Sea,
+        United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.490532,"lon":0.074003,"uid":7953,"aqi":"42","station":{"name":"Greenwich
+        - A206 Burrage Grove, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.569484331524,"lon":0.082907474896495,"uid":9041,"aqi":"17","station":{"name":"Redbridge
+        - Ley Street, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.474954,"lon":-0.039641,"uid":7956,"aqi":"52","station":{"name":"Lewisham
+        - New Cross, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.389286904505,"lon":-0.14166152477989,"uid":7959,"aqi":"42","station":{"name":"Sutton
+        - Beddington Lane north, United Kingdom","time":"2022-04-22T07:00:00+09:00"}},{"lat":51.486957,"lon":0.095111,"uid":7954,"aqi":"27","station":{"name":"Greenwich
+        - Plumstead High Street, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.456357,"lon":0.040725,"uid":7957,"aqi":"33","station":{"name":"Greenwich
+        - Westhorne Avenue, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.520787459334,"lon":0.20546070569404,"uid":7947,"aqi":"22","station":{"name":"Havering
+        - Rainham, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.54421,"lon":-0.175269,"uid":3166,"aqi":"34","station":{"name":"Camden
+        Kerbside, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.514525336231,"lon":-0.10451562633788,"uid":7949,"aqi":"46","station":{"name":"City
+        of London - Farringdon Street, United Kingdom","time":"2022-04-22T08:00:00+09:00"}}]}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:27:02 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "194.543\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '4997'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_range_coordinates_air/test_nonexistent_requested_params.yaml
+++ b/tests/cassettes/test_get_range_coordinates_air/test_nonexistent_requested_params.yaml
@@ -1,0 +1,73 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/map/bounds/?latlng=51%2C-0.2%2C52%2C1&token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":[{"lat":51.45617,"lon":0.634889,"uid":3207,"aqi":"46","station":{"name":"Rochester
+        Stoke, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.544206,"lon":0.678408,"uid":3212,"aqi":"34","station":{"name":"Southend-on-Sea,
+        United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.518167,"lon":0.439548,"uid":3213,"aqi":"46","station":{"name":"Stanford-le-Hope
+        Roadside, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.54421,"lon":-0.175269,"uid":3166,"aqi":"34","station":{"name":"Camden
+        Kerbside, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.52253,"lon":-0.154611,"uid":3193,"aqi":"38","station":{"name":"London
+        Marylebone Road, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.486884,"lon":0.017901,"uid":7955,"aqi":"34","station":{"name":"Greenwich
+        - Woolwich Flyover, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.514525336231,"lon":-0.10451562633788,"uid":7949,"aqi":"46","station":{"name":"City
+        of London - Farringdon Street, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.5073509,"lon":-0.1277583,"uid":5724,"aqi":"52","station":{"name":"London","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.374264,"lon":0.54797,"uid":3169,"aqi":"38","station":{"name":"Chatham
+        Roadside, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.494648681305,"lon":0.13727911123218,"uid":7951,"aqi":"37","station":{"name":"Bexley
+        - Belvedere West, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.490610208215,"lon":0.15891449392752,"uid":7952,"aqi":"-","station":{"name":"Bexley
+        - Belvedere, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.486957,"lon":0.095111,"uid":7954,"aqi":"27","station":{"name":"Greenwich
+        - Plumstead High Street, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.483907253348,"lon":0.00040739693584974,"uid":10103,"aqi":"23","station":{"name":"Greenwich
+        - Trafalgar Road (Hoskins St), United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.57661,"lon":0.030858,"uid":8918,"aqi":"36","station":{"name":"Redbridge
+        - Gardner Close, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.449674,"lon":-0.037418,"uid":11653,"aqi":"32","station":{"name":"London
+        Honor Oak Park, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.5993,"lon":-0.068218,"uid":3179,"aqi":"-","station":{"name":"Haringey
+        Roadside, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.520787459334,"lon":0.20546070569404,"uid":7947,"aqi":"22","station":{"name":"Havering
+        - Rainham, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.474954,"lon":-0.039641,"uid":7956,"aqi":"52","station":{"name":"Lewisham
+        - New Cross, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.389286904505,"lon":-0.14166152477989,"uid":7959,"aqi":"42","station":{"name":"Sutton
+        - Beddington Lane north, United Kingdom","time":"2022-04-22T07:00:00+09:00"}},{"lat":51.515046167401,"lon":-0.0084184926564274,"uid":7948,"aqi":"44","station":{"name":"Tower
+        Hamlets - Blackwall, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.527706619465,"lon":-0.12905320528252,"uid":7945,"aqi":"-","station":{"name":"Camden
+        - Euston Road, United Kingdom","time":"2022-04-22T05:00:00+09:00"}},{"lat":51.52229,"lon":-0.125889,"uid":3189,"aqi":"38","station":{"name":"London
+        Bloomsbury, United Kingdom","time":"2022-04-22T06:00:00+09:00"}},{"lat":51.513847178423,"lon":-0.077765681752,"uid":8919,"aqi":"-","station":{"name":"City
+        of London - Sir John Cass School, United Kingdom","time":"2022-04-20T12:00:00+09:00"}},{"lat":51.46603,"lon":0.184806,"uid":3188,"aqi":"37","station":{"name":"London
+        Bexley, United Kingdom","time":"2022-04-22T07:00:00+09:00"}},{"lat":51.456357,"lon":0.040725,"uid":7957,"aqi":"33","station":{"name":"Greenwich
+        - Westhorne Avenue, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.493774669582,"lon":0.010779623703256,"uid":10876,"aqi":"17","station":{"name":"Greenwich
+        - John Harrison Way, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.569484331524,"lon":0.082907474896495,"uid":9041,"aqi":"17","station":{"name":"Redbridge
+        - Ley Street, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.49467,"lon":-0.131931,"uid":10874,"aqi":"33","station":{"name":"London
+        Westminster, United Kingdom","time":"2022-04-22T07:00:00+09:00"}},{"lat":51.526454,"lon":-0.08491,"uid":7946,"aqi":"32","station":{"name":"Hackney
+        - Old Street, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.490532,"lon":0.074003,"uid":7953,"aqi":"42","station":{"name":"Greenwich
+        - A206 Burrage Grove, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.410039,"lon":-0.127523,"uid":8923,"aqi":"34","station":{"name":"Croydon
+        - Norbury Manor, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.562376,"lon":-0.004898,"uid":11768,"aqi":"-","station":{"name":"Waltham
+        Forest Dawlish Rd, United Kingdom","time":"2022-04-22T01:00:00+09:00"}}]}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:27:03 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "236.354\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '4997'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_range_coordinates_air/test_output_formats.yaml
+++ b/tests/cassettes/test_get_range_coordinates_air/test_output_formats.yaml
@@ -1,0 +1,73 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/map/bounds/?latlng=51%2C-0.2%2C52%2C1&token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":[{"lat":51.374264,"lon":0.54797,"uid":3169,"aqi":"38","station":{"name":"Chatham
+        Roadside, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.494648681305,"lon":0.13727911123218,"uid":7951,"aqi":"37","station":{"name":"Bexley
+        - Belvedere West, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.483907253348,"lon":0.00040739693584974,"uid":10103,"aqi":"23","station":{"name":"Greenwich
+        - Trafalgar Road (Hoskins St), United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.569484331524,"lon":0.082907474896495,"uid":9041,"aqi":"17","station":{"name":"Redbridge
+        - Ley Street, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.526454,"lon":-0.08491,"uid":7946,"aqi":"32","station":{"name":"Hackney
+        - Old Street, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.5993,"lon":-0.068218,"uid":3179,"aqi":"-","station":{"name":"Haringey
+        Roadside, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.518167,"lon":0.439548,"uid":3213,"aqi":"46","station":{"name":"Stanford-le-Hope
+        Roadside, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.490610208215,"lon":0.15891449392752,"uid":7952,"aqi":"-","station":{"name":"Bexley
+        - Belvedere, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.515046167401,"lon":-0.0084184926564274,"uid":7948,"aqi":"44","station":{"name":"Tower
+        Hamlets - Blackwall, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.513847178423,"lon":-0.077765681752,"uid":8919,"aqi":"-","station":{"name":"City
+        of London - Sir John Cass School, United Kingdom","time":"2022-04-20T12:00:00+09:00"}},{"lat":51.45617,"lon":0.634889,"uid":3207,"aqi":"46","station":{"name":"Rochester
+        Stoke, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.389286904505,"lon":-0.14166152477989,"uid":7959,"aqi":"42","station":{"name":"Sutton
+        - Beddington Lane north, United Kingdom","time":"2022-04-22T07:00:00+09:00"}},{"lat":51.46603,"lon":0.184806,"uid":3188,"aqi":"37","station":{"name":"London
+        Bexley, United Kingdom","time":"2022-04-22T07:00:00+09:00"}},{"lat":51.486884,"lon":0.017901,"uid":7955,"aqi":"34","station":{"name":"Greenwich
+        - Woolwich Flyover, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.449674,"lon":-0.037418,"uid":11653,"aqi":"32","station":{"name":"London
+        Honor Oak Park, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.474954,"lon":-0.039641,"uid":7956,"aqi":"52","station":{"name":"Lewisham
+        - New Cross, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.527706619465,"lon":-0.12905320528252,"uid":7945,"aqi":"-","station":{"name":"Camden
+        - Euston Road, United Kingdom","time":"2022-04-22T05:00:00+09:00"}},{"lat":51.456357,"lon":0.040725,"uid":7957,"aqi":"33","station":{"name":"Greenwich
+        - Westhorne Avenue, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.520787459334,"lon":0.20546070569404,"uid":7947,"aqi":"22","station":{"name":"Havering
+        - Rainham, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.410039,"lon":-0.127523,"uid":8923,"aqi":"34","station":{"name":"Croydon
+        - Norbury Manor, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.52253,"lon":-0.154611,"uid":3193,"aqi":"38","station":{"name":"London
+        Marylebone Road, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.5073509,"lon":-0.1277583,"uid":5724,"aqi":"52","station":{"name":"London","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.486957,"lon":0.095111,"uid":7954,"aqi":"27","station":{"name":"Greenwich
+        - Plumstead High Street, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.493774669582,"lon":0.010779623703256,"uid":10876,"aqi":"17","station":{"name":"Greenwich
+        - John Harrison Way, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.562376,"lon":-0.004898,"uid":11768,"aqi":"-","station":{"name":"Waltham
+        Forest Dawlish Rd, United Kingdom","time":"2022-04-22T01:00:00+09:00"}},{"lat":51.54421,"lon":-0.175269,"uid":3166,"aqi":"34","station":{"name":"Camden
+        Kerbside, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.544206,"lon":0.678408,"uid":3212,"aqi":"34","station":{"name":"Southend-on-Sea,
+        United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.490532,"lon":0.074003,"uid":7953,"aqi":"42","station":{"name":"Greenwich
+        - A206 Burrage Grove, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.52229,"lon":-0.125889,"uid":3189,"aqi":"38","station":{"name":"London
+        Bloomsbury, United Kingdom","time":"2022-04-22T06:00:00+09:00"}},{"lat":51.57661,"lon":0.030858,"uid":8918,"aqi":"36","station":{"name":"Redbridge
+        - Gardner Close, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.49467,"lon":-0.131931,"uid":10874,"aqi":"33","station":{"name":"London
+        Westminster, United Kingdom","time":"2022-04-22T07:00:00+09:00"}},{"lat":51.514525336231,"lon":-0.10451562633788,"uid":7949,"aqi":"46","station":{"name":"City
+        of London - Farringdon Street, United Kingdom","time":"2022-04-22T08:00:00+09:00"}}]}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:27:07 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "188.304\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '4997'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_range_coordinates_air/test_return_value_and_format.yaml
+++ b/tests/cassettes/test_get_range_coordinates_air/test_return_value_and_format.yaml
@@ -1,0 +1,73 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/map/bounds/?latlng=51%2C-0.2%2C52%2C1&token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":[{"lat":51.562376,"lon":-0.004898,"uid":11768,"aqi":"-","station":{"name":"Waltham
+        Forest Dawlish Rd, United Kingdom","time":"2022-04-22T01:00:00+09:00"}},{"lat":51.54421,"lon":-0.175269,"uid":3166,"aqi":"34","station":{"name":"Camden
+        Kerbside, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.52229,"lon":-0.125889,"uid":3189,"aqi":"38","station":{"name":"London
+        Bloomsbury, United Kingdom","time":"2022-04-22T06:00:00+09:00"}},{"lat":51.52253,"lon":-0.154611,"uid":3193,"aqi":"38","station":{"name":"London
+        Marylebone Road, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.493774669582,"lon":0.010779623703256,"uid":10876,"aqi":"17","station":{"name":"Greenwich
+        - John Harrison Way, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.49467,"lon":-0.131931,"uid":10874,"aqi":"33","station":{"name":"London
+        Westminster, United Kingdom","time":"2022-04-22T07:00:00+09:00"}},{"lat":51.449674,"lon":-0.037418,"uid":11653,"aqi":"32","station":{"name":"London
+        Honor Oak Park, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.483907253348,"lon":0.00040739693584974,"uid":10103,"aqi":"23","station":{"name":"Greenwich
+        - Trafalgar Road (Hoskins St), United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.486957,"lon":0.095111,"uid":7954,"aqi":"27","station":{"name":"Greenwich
+        - Plumstead High Street, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.410039,"lon":-0.127523,"uid":8923,"aqi":"34","station":{"name":"Croydon
+        - Norbury Manor, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.514525336231,"lon":-0.10451562633788,"uid":7949,"aqi":"46","station":{"name":"City
+        of London - Farringdon Street, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.5993,"lon":-0.068218,"uid":3179,"aqi":"-","station":{"name":"Haringey
+        Roadside, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.518167,"lon":0.439548,"uid":3213,"aqi":"46","station":{"name":"Stanford-le-Hope
+        Roadside, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.45617,"lon":0.634889,"uid":3207,"aqi":"46","station":{"name":"Rochester
+        Stoke, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.490532,"lon":0.074003,"uid":7953,"aqi":"42","station":{"name":"Greenwich
+        - A206 Burrage Grove, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.486884,"lon":0.017901,"uid":7955,"aqi":"34","station":{"name":"Greenwich
+        - Woolwich Flyover, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.57661,"lon":0.030858,"uid":8918,"aqi":"36","station":{"name":"Redbridge
+        - Gardner Close, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.569484331524,"lon":0.082907474896495,"uid":9041,"aqi":"17","station":{"name":"Redbridge
+        - Ley Street, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.374264,"lon":0.54797,"uid":3169,"aqi":"38","station":{"name":"Chatham
+        Roadside, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.513847178423,"lon":-0.077765681752,"uid":8919,"aqi":"-","station":{"name":"City
+        of London - Sir John Cass School, United Kingdom","time":"2022-04-20T12:00:00+09:00"}},{"lat":51.520787459334,"lon":0.20546070569404,"uid":7947,"aqi":"22","station":{"name":"Havering
+        - Rainham, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.389286904505,"lon":-0.14166152477989,"uid":7959,"aqi":"42","station":{"name":"Sutton
+        - Beddington Lane north, United Kingdom","time":"2022-04-22T07:00:00+09:00"}},{"lat":51.515046167401,"lon":-0.0084184926564274,"uid":7948,"aqi":"44","station":{"name":"Tower
+        Hamlets - Blackwall, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.5073509,"lon":-0.1277583,"uid":5724,"aqi":"52","station":{"name":"London","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.544206,"lon":0.678408,"uid":3212,"aqi":"34","station":{"name":"Southend-on-Sea,
+        United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.494648681305,"lon":0.13727911123218,"uid":7951,"aqi":"37","station":{"name":"Bexley
+        - Belvedere West, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.490610208215,"lon":0.15891449392752,"uid":7952,"aqi":"-","station":{"name":"Bexley
+        - Belvedere, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.474954,"lon":-0.039641,"uid":7956,"aqi":"52","station":{"name":"Lewisham
+        - New Cross, United Kingdom","time":"2022-04-22T09:00:00+09:00"}},{"lat":51.46603,"lon":0.184806,"uid":3188,"aqi":"37","station":{"name":"London
+        Bexley, United Kingdom","time":"2022-04-22T07:00:00+09:00"}},{"lat":51.526454,"lon":-0.08491,"uid":7946,"aqi":"32","station":{"name":"Hackney
+        - Old Street, United Kingdom","time":"2022-04-22T08:00:00+09:00"}},{"lat":51.527706619465,"lon":-0.12905320528252,"uid":7945,"aqi":"-","station":{"name":"Camden
+        - Euston Road, United Kingdom","time":"2022-04-22T05:00:00+09:00"}},{"lat":51.456357,"lon":0.040725,"uid":7957,"aqi":"33","station":{"name":"Greenwich
+        - Westhorne Avenue, United Kingdom","time":"2022-04-22T08:00:00+09:00"}}]}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:26:58 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "184.193\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '4997'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_specific_parameter/test_bad_city.yaml
+++ b/tests/cassettes/test_get_specific_parameter/test_bad_city.yaml
@@ -1,0 +1,138 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//a%20definitely%20nonexistent%20city/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:27:11 GMT
+      Location:
+      - /feed/a%20definitely%20nonexistent%20city/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/a%20definitely%20nonexistent%20city/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"error","data":"Unknown station"}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:27:11 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "84.841\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '43'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed///?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:27:12 GMT
+      Location:
+      - /feed/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"error","message":"404"}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:27:12 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      content-length:
+      - '34'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_specific_parameter/test_nonexistent_requested_param.yaml
+++ b/tests/cassettes/test_get_specific_parameter/test_nonexistent_requested_param.yaml
@@ -1,0 +1,76 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:27:09 GMT
+      Location:
+      - /feed/london/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":52,"idx":5724,"attributions":[{"url":"http://uk-air.defra.gov.uk/","name":"UK-AIR,
+        air quality information resource - Defra, UK","logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"url":"https://londonair.org.uk/","name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","logo":"UK-London-Kings-College.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[51.5073509,-0.1277583],"name":"London","url":"https://aqicn.org/city/london","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":1.7},"h":{"v":80.3},"no2":{"v":6.5},"o3":{"v":32.1},"p":{"v":1010.8},"pm10":{"v":18},"pm25":{"v":52},"so2":{"v":0.6},"t":{"v":8.8},"w":{"v":3.3}},"time":{"s":"2022-04-22
+        01:00:00","tz":"+01:00","v":1650589200,"iso":"2022-04-22T01:00:00+01:00"},"forecast":{"daily":{"o3":[{"avg":17,"day":"2022-04-19","max":34,"min":2},{"avg":25,"day":"2022-04-20","max":39,"min":14},{"avg":25,"day":"2022-04-21","max":37,"min":13},{"avg":24,"day":"2022-04-22","max":33,"min":17},{"avg":28,"day":"2022-04-23","max":38,"min":19},{"avg":30,"day":"2022-04-24","max":38,"min":24},{"avg":29,"day":"2022-04-25","max":29,"min":29}],"pm10":[{"avg":23,"day":"2022-04-19","max":31,"min":13},{"avg":19,"day":"2022-04-20","max":36,"min":10},{"avg":20,"day":"2022-04-21","max":29,"min":11},{"avg":18,"day":"2022-04-22","max":23,"min":12},{"avg":19,"day":"2022-04-23","max":22,"min":17},{"avg":16,"day":"2022-04-24","max":19,"min":13},{"avg":17,"day":"2022-04-25","max":18,"min":17}],"pm25":[{"avg":64,"day":"2022-04-19","max":81,"min":45},{"avg":59,"day":"2022-04-20","max":94,"min":33},{"avg":59,"day":"2022-04-21","max":78,"min":40},{"avg":55,"day":"2022-04-22","max":63,"min":41},{"avg":58,"day":"2022-04-23","max":68,"min":53},{"avg":49,"day":"2022-04-24","max":60,"min":40},{"avg":43,"day":"2022-04-25","max":43,"min":42}],"uvi":[{"avg":1,"day":"2022-04-20","max":4,"min":0},{"avg":1,"day":"2022-04-21","max":4,"min":0},{"avg":0,"day":"2022-04-22","max":3,"min":0},{"avg":0,"day":"2022-04-23","max":3,"min":0},{"avg":1,"day":"2022-04-24","max":3,"min":0},{"avg":0,"day":"2022-04-25","max":2,"min":0},{"avg":0,"day":"2022-04-26","max":2,"min":0}]}},"debug":{"sync":"2022-04-22T10:26:00+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:27:10 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "171.603\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2273'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_specific_parameter/test_return_value.yaml
+++ b/tests/cassettes/test_get_specific_parameter/test_return_value.yaml
@@ -1,0 +1,76 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 22 Apr 2022 01:27:08 GMT
+      Location:
+      - /feed/london/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":52,"idx":5724,"attributions":[{"url":"http://uk-air.defra.gov.uk/","name":"UK-AIR,
+        air quality information resource - Defra, UK","logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"url":"https://londonair.org.uk/","name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","logo":"UK-London-Kings-College.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[51.5073509,-0.1277583],"name":"London","url":"https://aqicn.org/city/london","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":1.7},"h":{"v":80.3},"no2":{"v":6.5},"o3":{"v":32.1},"p":{"v":1010.8},"pm10":{"v":18},"pm25":{"v":52},"so2":{"v":0.6},"t":{"v":8.8},"w":{"v":3.3}},"time":{"s":"2022-04-22
+        01:00:00","tz":"+01:00","v":1650589200,"iso":"2022-04-22T01:00:00+01:00"},"forecast":{"daily":{"o3":[{"avg":17,"day":"2022-04-19","max":34,"min":2},{"avg":25,"day":"2022-04-20","max":39,"min":14},{"avg":25,"day":"2022-04-21","max":37,"min":13},{"avg":24,"day":"2022-04-22","max":33,"min":17},{"avg":28,"day":"2022-04-23","max":38,"min":19},{"avg":30,"day":"2022-04-24","max":38,"min":24},{"avg":29,"day":"2022-04-25","max":29,"min":29}],"pm10":[{"avg":23,"day":"2022-04-19","max":31,"min":13},{"avg":19,"day":"2022-04-20","max":36,"min":10},{"avg":20,"day":"2022-04-21","max":29,"min":11},{"avg":18,"day":"2022-04-22","max":23,"min":12},{"avg":19,"day":"2022-04-23","max":22,"min":17},{"avg":16,"day":"2022-04-24","max":19,"min":13},{"avg":17,"day":"2022-04-25","max":18,"min":17}],"pm25":[{"avg":64,"day":"2022-04-19","max":81,"min":45},{"avg":59,"day":"2022-04-20","max":94,"min":33},{"avg":59,"day":"2022-04-21","max":78,"min":40},{"avg":55,"day":"2022-04-22","max":63,"min":41},{"avg":58,"day":"2022-04-23","max":68,"min":53},{"avg":49,"day":"2022-04-24","max":60,"min":40},{"avg":43,"day":"2022-04-25","max":43,"min":42}],"uvi":[{"avg":1,"day":"2022-04-20","max":4,"min":0},{"avg":1,"day":"2022-04-21","max":4,"min":0},{"avg":0,"day":"2022-04-22","max":3,"min":0},{"avg":0,"day":"2022-04-23","max":3,"min":0},{"avg":1,"day":"2022-04-24","max":3,"min":0},{"avg":0,"day":"2022-04-25","max":2,"min":0},{"avg":0,"day":"2022-04-26","max":2,"min":0}]}},"debug":{"sync":"2022-04-22T10:26:00+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 22 Apr 2022 01:27:08 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "183.734\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2273'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+import pytest
+from utils import vcr_kwargs, DEFAULT_OUTPUT_FOLDER
+
+
+# Configuration fixture for pytest-vcr
+@pytest.fixture(scope="session")
+def vcr_config():
+    return vcr_kwargs
+
+
+# Automatically use this fixture for each test
+# to clean up the output directory
+@pytest.fixture(autouse=True)
+def cleanup_output():
+    yield
+    if DEFAULT_OUTPUT_FOLDER.exists():
+        for file in DEFAULT_OUTPUT_FOLDER.iterdir():
+            file.unlink()
+        DEFAULT_OUTPUT_FOLDER.rmdir()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,10 @@ def vcr_config():
 # to clean up the output directory
 @pytest.fixture(autouse=True)
 def cleanup_output():
+    if DEFAULT_OUTPUT_FOLDER.exists():
+        for file in DEFAULT_OUTPUT_FOLDER.iterdir():
+            file.unlink()
+        DEFAULT_OUTPUT_FOLDER.rmdir()
     yield
     if DEFAULT_OUTPUT_FOLDER.exists():
         for file in DEFAULT_OUTPUT_FOLDER.iterdir():

--- a/tests/test_get_city_air.py
+++ b/tests/test_get_city_air.py
@@ -89,9 +89,6 @@ def test_bad_data_format():
 
 @pytest.mark.vcr
 def test_correct_data_format():
-    # There shouldn't be an output folder by default
-    assert not DEFAULT_OUTPUT_FOLDER.exists()
-
     # Not specifying data format shouldn't create an output directory
     api.get_city_air("london")
     assert not DEFAULT_OUTPUT_FOLDER.exists()

--- a/tests/test_get_city_air.py
+++ b/tests/test_get_city_air.py
@@ -1,0 +1,102 @@
+import numpy
+import pandas
+import pandas.api.types as pd_types
+import pytest
+
+from utils import api, DEFAULT_OUTPUT_FOLDER, DEFAULT_OUTPUT_FILE
+
+
+@pytest.mark.vcr
+def test_return_value_and_format():
+    result = api.get_city_air("london")
+    assert isinstance(result, pandas.DataFrame)
+    assert len(result) == 1
+
+
+@pytest.mark.vcr
+def test_column_expected_contents():
+    result = api.get_city_air("london")
+    assert result.at[0, "city"] == "london"  # Exactly like input
+    assert result.at[0, "station"] == "London"  # Given by server
+
+
+@pytest.mark.vcr
+def test_column_types():
+    result = api.get_city_air("london")
+    STR_COLUMNS = [
+        "dominant_pollutant",
+        "AQI_meaning",
+        "AQI_health_implications",
+        "timestamp",
+        "timestamp_timezone",
+    ]
+    FLOAT_COLUMNS = [
+        "latitude",
+        "longitude",
+        "aqi",
+        "pm25",
+        "pm10",
+        "o3",
+        "co",
+        "no2",
+        "so2",
+        "dew",
+        "h",
+        "p",
+        "t",
+        "w",
+        "wg",
+    ]
+    assert all([pd_types.is_string_dtype(result[col]) for col in STR_COLUMNS])
+    assert all([pd_types.is_float_dtype(result[col]) for col in FLOAT_COLUMNS])
+
+
+@pytest.mark.vcr
+def test_excluded_params():
+    # Param should be really excluded when specified as such
+    custom_params = ["aqi", "pm25", "o3"]
+    result = api.get_city_air("london", params=custom_params)
+    assert "pm10" not in result
+    assert "pm25" in result
+
+
+@pytest.mark.vcr
+def test_nonexistent_requested_params():
+    # Return asked params even when the response does not contain that specific param
+    BAD_PARAM_NAME = "param_that_is_not_in_london_aqi"
+    result = api.get_city_air("london", params=[BAD_PARAM_NAME])
+    param_value = result.at[0, BAD_PARAM_NAME]
+    assert numpy.isnan(param_value)
+
+
+@pytest.mark.vcr
+def test_bad_city():
+    with pytest.raises(Exception, match="no known AQI station"):
+        api.get_city_air("a definitely nonexistent city")
+
+    with pytest.raises(Exception):
+        api.get_city_air("")
+
+
+@pytest.mark.vcr
+def test_bad_data_format():
+    with pytest.raises(Exception, match="Invalid file format"):
+        api.get_city_air("london", data_format="a definitely wrong data format")
+
+    # Calling wrong data format shouldn't create an output folder
+    assert not DEFAULT_OUTPUT_FOLDER.exists()
+
+
+@pytest.mark.vcr
+def test_correct_data_format():
+    # There shouldn't be an output folder by default
+    assert not DEFAULT_OUTPUT_FOLDER.exists()
+
+    # Not specifying data format shouldn't create an output directory
+    api.get_city_air("london")
+    assert not DEFAULT_OUTPUT_FOLDER.exists()
+
+    # Output files should be made
+    for fmt in ["xlsx", "csv", "json"]:
+        api.get_city_air("london", data_format=fmt)
+        assert DEFAULT_OUTPUT_FILE.with_suffix(f".{fmt}").is_file()

--- a/tests/test_get_city_forecast.py
+++ b/tests/test_get_city_forecast.py
@@ -52,9 +52,6 @@ def test_bad_data_format_input():
 
 @pytest.mark.vcr
 def test_correct_data_format_input():
-    # There shouldn't be an output folder by default
-    assert not DEFAULT_OUTPUT_FOLDER.exists()
-
     # Not specifying data format shouldn't create an output directory
     api.get_city_forecast("london")
     assert not DEFAULT_OUTPUT_FOLDER.exists()

--- a/tests/test_get_city_forecast.py
+++ b/tests/test_get_city_forecast.py
@@ -1,0 +1,65 @@
+import pandas
+import pandas.api.types as pd_types
+import pytest
+
+from utils import api, DEFAULT_OUTPUT_FOLDER, DEFAULT_OUTPUT_FILE
+
+
+@pytest.mark.vcr
+def test_return_value_and_format():
+    # Check return value and format
+    result = api.get_city_forecast("london")
+
+    assert isinstance(result, pandas.DataFrame)
+    assert len(result) == 8
+
+
+@pytest.mark.vcr
+def test_index_and_column_types():
+    result = api.get_city_forecast("london")
+
+    # The index contains date information
+    assert pd_types.is_datetime64_any_dtype(result.index)
+
+    # Check that all pollutants and statistics are in column
+    for param in ["pm25", "pm10", "o3", "uvi"]:
+        for stat in ["min", "max", "avg"]:
+            assert (param, stat) in result
+
+    # Check that all columns are of float type
+    for col in result:
+        assert pd_types.is_float_dtype(result[col])
+
+
+@pytest.mark.vcr
+def test_bad_city_input():
+    # Check for bad inputs
+    with pytest.raises(Exception, match="no known AQI station"):
+        api.get_city_forecast("a definitely nonexistent city")
+
+    with pytest.raises(Exception):
+        api.get_city_forecast("")
+
+
+@pytest.mark.vcr
+def test_bad_data_format_input():
+    with pytest.raises(Exception, match="Invalid file format"):
+        api.get_city_forecast("london", data_format="a definitely wrong data format")
+
+    # Calling wrong data format shouldn't result in an output folder being made
+    assert not DEFAULT_OUTPUT_FOLDER.exists()
+
+
+@pytest.mark.vcr
+def test_correct_data_format_input():
+    # There shouldn't be an output folder by default
+    assert not DEFAULT_OUTPUT_FOLDER.exists()
+
+    # Not specifying data format shouldn't create an output directory
+    api.get_city_forecast("london")
+    assert not DEFAULT_OUTPUT_FOLDER.exists()
+
+    # Output files should be made
+    for fmt in ["xlsx", "csv", "json"]:
+        api.get_city_air("london", data_format=fmt)
+        assert DEFAULT_OUTPUT_FILE.with_suffix(f".{fmt}").is_file()

--- a/tests/test_get_city_station_options.py
+++ b/tests/test_get_city_station_options.py
@@ -1,0 +1,55 @@
+import pandas
+import pandas.api.types as pd_types
+import pytest
+
+from utils import api, DEFAULT_OUTPUT_FOLDER
+
+
+@pytest.mark.vcr
+def test_return_value_and_format():
+    result = api.get_city_station_options("ukraine")
+    assert isinstance(result, pandas.DataFrame)
+    assert len(result) > 0  # Shouldn't be empty for 'ukraine'...
+
+
+@pytest.mark.vcr
+def test_columns():
+    result = api.get_city_station_options("ukraine")
+
+    # Check all columns exist
+    COLUMNS = ["city_id", "country_code", "station_name", "city_url", "score"]
+    assert all([col in result for col in COLUMNS])
+
+
+@pytest.mark.vcr
+def test_score_column():
+    result = api.get_city_station_options("ukraine")
+
+    # Make sure score is numeric
+    assert pd_types.is_numeric_dtype(result["score"])
+
+    # Make sure score is descending
+    score = result["score"].tolist()
+    assert score == sorted(score, reverse=True)
+
+
+@pytest.mark.vcr
+def test_nonexistent_city():
+    # Shouldn't raise Exception, instead ...
+    result = api.get_city_station_options("gibberish_nonexistent_place_name")
+
+    # ... should return a dataframe but with length 0 ...
+    assert isinstance(result, pandas.DataFrame)
+    assert len(result) == 0
+
+    # ... and with all columns just like usual.
+    COLUMNS = ["city_id", "country_code", "station_name", "city_url", "score"]
+    assert all([col in result for col in COLUMNS])
+
+
+@pytest.mark.vcr
+def test_no_output_directory():
+    api.get_city_station_options("ukraine")
+
+    # There shouldn't be an output folder after calling this method
+    assert not DEFAULT_OUTPUT_FOLDER.exists()

--- a/tests/test_get_coordinate_air.py
+++ b/tests/test_get_coordinate_air.py
@@ -1,0 +1,123 @@
+import numpy
+import pandas
+import pandas.api.types as pd_types
+import pytest
+
+from utils import api, DEFAULT_OUTPUT_FOLDER, DEFAULT_OUTPUT_FILE
+
+
+@pytest.mark.vcr
+def test_return_value_and_format():
+    # London is located on 51.5972 N, 0.1276 W
+    result = api.get_coordinate_air(51.51, -0.13)
+
+    # Check return value and format
+    assert isinstance(result, pandas.DataFrame)
+    assert len(result) == 1
+
+
+@pytest.mark.vcr
+def test_column_expected_contents():
+    result = api.get_coordinate_air(51.51, -0.13)
+
+    assert numpy.isnan(result.at[0, "city"])  # No city was given, so nan
+    assert result.at[0, "station"] == "London"  # Given by server
+
+    # London's coordinates
+    assert result.at[0, "latitude"] == pytest.approx(51.507351)
+    assert result.at[0, "longitude"] == pytest.approx(-0.127759)
+
+
+@pytest.mark.vcr
+def test_column_types():
+    result = api.get_coordinate_air(51.51, -0.13)
+    STR_COLUMNS = [
+        "dominant_pollutant",
+        "AQI_meaning",
+        "AQI_health_implications",
+        "timestamp",
+        "timestamp_timezone",
+    ]
+    FLOAT_COLUMNS = [
+        "latitude",
+        "longitude",
+        "aqi",
+        "pm25",
+        "pm10",
+        "o3",
+        "co",
+        "no2",
+        "so2",
+        "dew",
+        "h",
+        "p",
+        "t",
+        "w",
+        "wg",
+    ]
+    assert all([pd_types.is_string_dtype(result[col]) for col in STR_COLUMNS])
+    assert all([pd_types.is_float_dtype(result[col]) for col in FLOAT_COLUMNS])
+
+
+@pytest.mark.vcr
+def test_excluded_params():
+    # Param should be really excluded when specified as such
+    custom_params = ["aqi", "pm25", "o3"]
+    result = api.get_coordinate_air(51.51, -0.13, params=custom_params)
+    assert "pm10" not in result
+    assert "pm25" in result
+
+
+@pytest.mark.vcr
+def test_nonexistent_requested_params():
+    # Return asked params even when the response does not contain that specific param
+    BAD_PARAM_NAME = "param_that_is_not_in_london_aqi"
+    result = api.get_coordinate_air(51.51, -0.13, params=[BAD_PARAM_NAME])
+    param_value = result.at[0, BAD_PARAM_NAME]
+    assert numpy.isnan(param_value)
+
+
+@pytest.mark.vcr
+def test_bad_coordinates():
+    with pytest.raises(Exception, match="Invalid geo position"):
+        api.get_coordinate_air("not a lat", "not a lon")
+
+    with pytest.raises(Exception, match="Invalid geo position"):
+        api.get_coordinate_air(None, None)
+
+    with pytest.raises(Exception, match="Invalid geo position"):
+        api.get_coordinate_air(numpy.nan, numpy.nan)
+
+    # Giving coordinates as string of numerics is fine,
+    # even though it's not in accordance with Ozone's method definition.
+    api.get_coordinate_air("51.51", "-0.13")
+
+    # Giving nonsensical coordinates is also fine
+    api.get_coordinate_air(5000, 5000)
+    api.get_coordinate_air(-5000, -5000)
+
+
+@pytest.mark.vcr
+def test_bad_data_format():
+    with pytest.raises(Exception, match="Invalid file format"):
+        api.get_coordinate_air(
+            51.51, -0.13, data_format="a definitely wrong data format"
+        )
+
+    # Calling wrong data format shouldn't create an output folder
+    assert not DEFAULT_OUTPUT_FOLDER.exists()
+
+
+@pytest.mark.vcr
+def test_output_formats():
+    # There shouldn't be an output folder by default
+    assert not DEFAULT_OUTPUT_FOLDER.exists()
+
+    # Not specifying data format shouldn't create an output directory
+    api.get_coordinate_air(51.51, -0.13)
+    assert not DEFAULT_OUTPUT_FOLDER.exists()
+
+    # Check that output file is made
+    for fmt in ["xlsx", "csv", "json"]:
+        api.get_coordinate_air(51.51, -0.13, data_format=fmt)
+        assert DEFAULT_OUTPUT_FILE.with_suffix(f".{fmt}").is_file()

--- a/tests/test_get_coordinate_air.py
+++ b/tests/test_get_coordinate_air.py
@@ -25,7 +25,7 @@ def test_column_expected_contents():
 
     # London's coordinates
     assert result.at[0, "latitude"] == pytest.approx(51.507351)
-    assert result.at[0, "longitude"] == pytest.approx(-0.127759)
+    assert result.at[0, "longitude"] == pytest.approx(-0.1277583)
 
 
 @pytest.mark.vcr
@@ -85,9 +85,6 @@ def test_bad_coordinates():
     with pytest.raises(Exception, match="Invalid geo position"):
         api.get_coordinate_air(None, None)
 
-    with pytest.raises(Exception, match="Invalid geo position"):
-        api.get_coordinate_air(numpy.nan, numpy.nan)
-
     # Giving coordinates as string of numerics is fine,
     # even though it's not in accordance with Ozone's method definition.
     api.get_coordinate_air("51.51", "-0.13")
@@ -95,6 +92,9 @@ def test_bad_coordinates():
     # Giving nonsensical coordinates is also fine
     api.get_coordinate_air(5000, 5000)
     api.get_coordinate_air(-5000, -5000)
+
+    # Giving nan coordinates is also fine
+    api.get_coordinate_air(numpy.nan, numpy.nan)
 
 
 @pytest.mark.vcr

--- a/tests/test_get_coordinate_air.py
+++ b/tests/test_get_coordinate_air.py
@@ -110,9 +110,6 @@ def test_bad_data_format():
 
 @pytest.mark.vcr
 def test_output_formats():
-    # There shouldn't be an output folder by default
-    assert not DEFAULT_OUTPUT_FOLDER.exists()
-
     # Not specifying data format shouldn't create an output directory
     api.get_coordinate_air(51.51, -0.13)
     assert not DEFAULT_OUTPUT_FOLDER.exists()

--- a/tests/test_get_historical_data.py
+++ b/tests/test_get_historical_data.py
@@ -1,0 +1,47 @@
+import pandas
+import pytest
+
+from utils import api, DEFAULT_OUTPUT_FOLDER, DEFAULT_OUTPUT_FILE
+
+
+@pytest.mark.vcr
+@pytest.mark.filterwarnings(
+    "ignore::UserWarning"
+)  # https://stackoverflow.com/a/58645998/11316205
+def test_return_value_and_format():
+    result = api.get_historical_data(city="london")
+    assert isinstance(result, pandas.DataFrame)
+
+
+@pytest.mark.vcr
+def test_warnings_on_input_combo():
+    with pytest.warns(UserWarning, match="city_id was not supplied"):
+        api.get_historical_data(city="london")
+
+    # There should be no warning if supplying city_id only
+    api.get_historical_data(city_id=5724)
+
+    # Warn user when both city and city_id are supplied
+    with pytest.warns(UserWarning, match="will be ignored"):
+        api.get_historical_data(city="london", city_id=5724)
+
+
+def test_arguments_not_named():
+    with pytest.raises(ValueError, match="must be specified"):
+        api.get_historical_data("london")
+
+
+@pytest.mark.vcr
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_correct_data_format():
+    # There shouldn't be an output folder by default
+    assert not DEFAULT_OUTPUT_FOLDER.exists()
+
+    # Not specifying data format shouldn't create an output directory
+    api.get_historical_data(city_id=5724)
+    assert not DEFAULT_OUTPUT_FOLDER.exists()
+
+    # Check that output file is made
+    for fmt in ["xlsx", "csv", "json"]:
+        api.get_historical_data(city="london", data_format=fmt)
+        assert DEFAULT_OUTPUT_FILE.with_suffix(f".{fmt}").is_file()

--- a/tests/test_get_historical_data.py
+++ b/tests/test_get_historical_data.py
@@ -34,9 +34,6 @@ def test_arguments_not_named():
 @pytest.mark.vcr
 @pytest.mark.filterwarnings("ignore::UserWarning")
 def test_correct_data_format():
-    # There shouldn't be an output folder by default
-    assert not DEFAULT_OUTPUT_FOLDER.exists()
-
     # Not specifying data format shouldn't create an output directory
     api.get_historical_data(city_id=5724)
     assert not DEFAULT_OUTPUT_FOLDER.exists()

--- a/tests/test_get_multiple_city_air.py
+++ b/tests/test_get_multiple_city_air.py
@@ -98,9 +98,6 @@ def test_bad_data_format():
 
 @pytest.mark.vcr
 def test_correct_data_format():
-    # There shouldn't be an output folder by default
-    assert not DEFAULT_OUTPUT_FOLDER.exists()
-
     # Not specifying data format shouldn't create an output directory
     api.get_multiple_city_air(["london", "new delhi", "paris"])
     assert not DEFAULT_OUTPUT_FOLDER.exists()

--- a/tests/test_get_multiple_city_air.py
+++ b/tests/test_get_multiple_city_air.py
@@ -1,0 +1,111 @@
+import numpy
+import pandas
+import pandas.api.types as pd_types
+import pytest
+
+from utils import api, DEFAULT_OUTPUT_FOLDER, DEFAULT_OUTPUT_FILE
+
+
+@pytest.mark.vcr
+def test_return_value_and_format():
+    result = api.get_multiple_city_air(["london", "new delhi", "paris"])
+    assert isinstance(result, pandas.DataFrame)
+    assert len(result) == 3  # One row per city
+
+
+@pytest.mark.vcr
+def test_column_expected_contents():
+    result = api.get_multiple_city_air(["london", "new delhi", "paris"])
+    assert result["city"].tolist() == ["london", "new delhi", "paris"]
+
+
+@pytest.mark.vcr
+def test_column_types():
+    result = api.get_multiple_city_air(["london", "new delhi", "paris"])
+    STR_COLUMNS = [
+        "dominant_pollutant",
+        "AQI_meaning",
+        "AQI_health_implications",
+        "timestamp",
+        "timestamp_timezone",
+    ]
+    FLOAT_COLUMNS = [
+        "latitude",
+        "longitude",
+        "aqi",
+        "pm25",
+        "pm10",
+        "o3",
+        "co",
+        "no2",
+        "so2",
+        "dew",
+        "h",
+        "p",
+        "t",
+        "w",
+        "wg",
+    ]
+    assert all([pd_types.is_string_dtype(result[col]) for col in STR_COLUMNS])
+    assert all([pd_types.is_float_dtype(result[col]) for col in FLOAT_COLUMNS])
+
+
+@pytest.mark.vcr
+def test_excluded_params():
+    # Param should be really excluded when specified as such
+    custom_params = ["aqi", "pm25", "o3"]
+    result = api.get_multiple_city_air(
+        ["london", "new delhi", "paris"], params=custom_params
+    )
+    assert "pm10" not in result
+    assert "pm25" in result
+
+
+@pytest.mark.vcr
+def test_nonexistent_requested_params():
+    # Return asked params wven when the response does not contain that specific param
+    BAD_PARAM_NAME = "param_that_is_not_in_london_aqi"
+    result = api.get_multiple_city_air(
+        ["london", "new delhi", "paris"], params=[BAD_PARAM_NAME]
+    )
+    param_value = result.at[0, BAD_PARAM_NAME]
+    assert numpy.isnan(param_value)
+
+
+@pytest.mark.vcr
+def test_bad_city():
+    # NOTE, QUESTION
+    # In get_multiple_city_air, it will be annoying if giving one
+    # invalid city also halts the entire data collecting process for
+    # other valid cities. For example, imagine mass-collecting data
+    # for a lot of cities at once using this method only to get aborted
+    # because there's one city that don't have AQI station (and raises
+    # Exception).
+    api.get_multiple_city_air(["london", "paris", "a definitely nonexistent city"])
+
+
+@pytest.mark.vcr
+def test_bad_data_format():
+    with pytest.raises(Exception, match="Invalid file format"):
+        api.get_multiple_city_air(
+            ["london", "new delhi", "paris"],
+            data_format="a definitely wrong data format",
+        )
+
+    # Calling wrong data format shouldn't create an output folder
+    assert not DEFAULT_OUTPUT_FOLDER.exists()
+
+
+@pytest.mark.vcr
+def test_correct_data_format():
+    # There shouldn't be an output folder by default
+    assert not DEFAULT_OUTPUT_FOLDER.exists()
+
+    # Not specifying data format shouldn't create an output directory
+    api.get_multiple_city_air(["london", "new delhi", "paris"])
+    assert not DEFAULT_OUTPUT_FOLDER.exists()
+
+    # Output files should be made
+    for fmt in ["xlsx", "csv", "json"]:
+        api.get_multiple_city_air(["london", "new delhi", "paris"], data_format=fmt)
+        assert DEFAULT_OUTPUT_FILE.with_suffix(f".{fmt}").is_file()

--- a/tests/test_get_multiple_coordinate_air.py
+++ b/tests/test_get_multiple_coordinate_air.py
@@ -93,8 +93,6 @@ def test_bad_data_format():
 
 @pytest.mark.vcr
 def test_output_formats():
-    # There shouldn't be an output folder by default
-    assert not DEFAULT_OUTPUT_FOLDER.exists()
 
     # Not specifying data format shouldn't create an output directory
     api.get_multiple_coordinate_air(COORDS)

--- a/tests/test_get_multiple_coordinate_air.py
+++ b/tests/test_get_multiple_coordinate_air.py
@@ -1,0 +1,106 @@
+import numpy
+import pandas
+import pandas.api.types as pd_types
+import pytest
+
+from utils import api, DEFAULT_OUTPUT_FOLDER, DEFAULT_OUTPUT_FILE
+
+COORDS = [(0, 0), (50, 0), (40, -75)]
+
+
+@pytest.mark.vcr
+def test_return_value_and_format():
+    result = api.get_multiple_coordinate_air(COORDS)
+
+    # Check return value and format
+    assert isinstance(result, pandas.DataFrame)
+    assert len(result) == len(COORDS)
+
+
+@pytest.mark.vcr
+def test_column_expected_contents():
+    result = api.get_multiple_coordinate_air(COORDS)
+
+    # Coordinate was given, so city should be nan
+    assert numpy.isnan(result["city"]).all()
+
+
+@pytest.mark.vcr
+def test_column_types():
+    result = api.get_multiple_coordinate_air(COORDS)
+    STR_COLUMNS = [
+        "dominant_pollutant",
+        "AQI_meaning",
+        "AQI_health_implications",
+        "timestamp",
+        "timestamp_timezone",
+    ]
+    FLOAT_COLUMNS = [
+        "latitude",
+        "longitude",
+        "aqi",
+        "pm25",
+        "pm10",
+        "o3",
+        "co",
+        "no2",
+        "so2",
+        "dew",
+        "h",
+        "p",
+        "t",
+        "w",
+        "wg",
+    ]
+    assert all([pd_types.is_string_dtype(result[col]) for col in STR_COLUMNS])
+    assert all([pd_types.is_float_dtype(result[col]) for col in FLOAT_COLUMNS])
+
+
+@pytest.mark.vcr
+def test_excluded_params():
+    # Param should be really excluded when specified as such
+    custom_params = ["aqi", "pm25", "o3"]
+    result = api.get_multiple_coordinate_air(COORDS, params=custom_params)
+    assert "pm10" not in result
+    assert "pm25" in result
+
+
+@pytest.mark.vcr
+def test_nonexistent_requested_params():
+    # Return asked params even when the response does not contain that specific param
+    BAD_PARAM_NAME = "bad_param_name"
+    result = api.get_multiple_coordinate_air(COORDS, params=[BAD_PARAM_NAME])
+    assert numpy.isnan(result[BAD_PARAM_NAME]).all()
+
+
+@pytest.mark.vcr
+def test_bad_coordinates():
+    # NOTE, ???
+    # See test_get_multiple_city_air, same issue
+    api.get_multiple_coordinate_air([(50, 0), (50, 1), ("lol", "bruh")])
+
+
+@pytest.mark.vcr
+def test_bad_data_format():
+    with pytest.raises(Exception, match="Invalid file format"):
+        api.get_multiple_coordinate_air(
+            COORDS, data_format="a definitely wrong data format"
+        )
+
+    # Calling wrong data format shouldn't create an output folder
+    assert not DEFAULT_OUTPUT_FOLDER.exists()
+
+
+@pytest.mark.vcr
+def test_output_formats():
+    # There shouldn't be an output folder by default
+    assert not DEFAULT_OUTPUT_FOLDER.exists()
+
+    # Not specifying data format shouldn't create an output directory
+    api.get_multiple_coordinate_air(COORDS)
+    assert not DEFAULT_OUTPUT_FOLDER.exists()
+
+    # Check that output file is made
+    for fmt in ["xlsx", "csv", "json"]:
+        api.get_multiple_coordinate_air(COORDS, data_format=fmt)
+        assert DEFAULT_OUTPUT_FILE.with_suffix(f".{fmt}").is_file()

--- a/tests/test_get_range_coordinates_air.py
+++ b/tests/test_get_range_coordinates_air.py
@@ -104,8 +104,6 @@ def test_bad_data_format():
 
 @pytest.mark.vcr
 def test_output_formats():
-    # There shouldn't be an output folder by default
-    assert not DEFAULT_OUTPUT_FOLDER.exists()
 
     # Not specifying data format shouldn't create an output directory
     api.get_range_coordinates_air(LOWER_BOUND, UPPER_BOUND)

--- a/tests/test_get_range_coordinates_air.py
+++ b/tests/test_get_range_coordinates_air.py
@@ -1,0 +1,117 @@
+import numpy
+import pandas
+import pandas.api.types as pd_types
+import pytest
+
+from utils import api, DEFAULT_OUTPUT_FOLDER, DEFAULT_OUTPUT_FILE
+
+LOWER_BOUND = (51, -0.2)
+UPPER_BOUND = (52, 1)
+
+
+@pytest.mark.vcr
+def test_return_value_and_format():
+    result = api.get_range_coordinates_air(LOWER_BOUND, UPPER_BOUND)
+
+    # Check return value and format
+    assert isinstance(result, pandas.DataFrame)
+    assert len(result) > 0  # Should be 32, actually
+
+
+@pytest.mark.vcr
+def test_column_expected_contents():
+    result = api.get_range_coordinates_air(LOWER_BOUND, UPPER_BOUND)
+
+    # Sanity check: make sure lat-lon are within range
+    assert (result["latitude"] > LOWER_BOUND[0]).all()
+    assert (result["latitude"] < UPPER_BOUND[0]).all()
+    assert (result["longitude"] < LOWER_BOUND[1]).all()
+    assert (result["longitude"] > UPPER_BOUND[1]).all()
+
+    # Range of coordinates: no city was given, hence city must all be nan
+    assert numpy.isnan(result["city"]).all()
+
+
+@pytest.mark.vcr
+def test_column_types():
+    result = api.get_range_coordinates_air(LOWER_BOUND, UPPER_BOUND)
+    STR_COLUMNS = [
+        "dominant_pollutant",
+        "AQI_meaning",
+        "AQI_health_implications",
+        "timestamp",
+        "timestamp_timezone",
+    ]
+    FLOAT_COLUMNS = [
+        "latitude",
+        "longitude",
+        "aqi",
+        "pm25",
+        "pm10",
+        "o3",
+        "co",
+        "no2",
+        "so2",
+        "dew",
+        "h",
+        "p",
+        "t",
+        "w",
+        "wg",
+    ]
+    assert all([pd_types.is_string_dtype(result[col]) for col in STR_COLUMNS])
+    assert all([pd_types.is_float_dtype(result[col]) for col in FLOAT_COLUMNS])
+
+
+@pytest.mark.vcr
+def test_excluded_params():
+    # Param should be really excluded when specified as such
+    custom_params = ["aqi", "pm25", "o3"]
+    result = api.get_range_coordinates_air(
+        LOWER_BOUND, UPPER_BOUND, params=custom_params
+    )
+    assert "pm10" not in result
+    assert "pm25" in result
+
+
+@pytest.mark.vcr
+def test_nonexistent_requested_params():
+    # Return asked params even when the response does not contain that specific param
+    BAD_PARAM_NAME = "param_that_is_not_in_london_aqi"
+    result = api.get_range_coordinates_air(
+        LOWER_BOUND, UPPER_BOUND, params=[BAD_PARAM_NAME]
+    )
+    param_value = result.at[0, BAD_PARAM_NAME]
+    assert numpy.isnan(param_value)
+
+
+@pytest.mark.vcr
+def test_bad_coordinates():
+    with pytest.raises(Exception):
+        api.get_range_coordinates_air(lower_bound=("lol", "bruh"), upper_bound=(0, 0))
+
+
+@pytest.mark.vcr
+def test_bad_data_format():
+    with pytest.raises(Exception, match="Invalid file format"):
+        api.get_range_coordinates_air(
+            LOWER_BOUND, UPPER_BOUND, data_format="a definitely wrong data format"
+        )
+
+    # Calling wrong data format shouldn't create an output folder
+    assert not DEFAULT_OUTPUT_FOLDER.exists()
+
+
+@pytest.mark.vcr
+def test_output_formats():
+    # There shouldn't be an output folder by default
+    assert not DEFAULT_OUTPUT_FOLDER.exists()
+
+    # Not specifying data format shouldn't create an output directory
+    api.get_range_coordinates_air(LOWER_BOUND, UPPER_BOUND)
+    assert not DEFAULT_OUTPUT_FOLDER.exists()
+
+    # Check that output file is made
+    for fmt in ["xlsx", "csv", "json"]:
+        api.get_range_coordinates_air(LOWER_BOUND, UPPER_BOUND, data_format=fmt)
+        assert DEFAULT_OUTPUT_FILE.with_suffix(f".{fmt}").is_file()

--- a/tests/test_get_specific_parameter.py
+++ b/tests/test_get_specific_parameter.py
@@ -1,0 +1,29 @@
+import numpy
+import pytest
+
+from utils import api
+
+
+@pytest.mark.vcr
+def test_return_value():
+    result = api.get_specific_parameter("london", "aqi")
+
+    assert isinstance(result, float)
+
+
+@pytest.mark.vcr
+def test_nonexistent_requested_param():
+    # NOTE, QUESTION (lahdjirayhan)
+    # Should nonexistent param return nan or raise Exception? (see code)
+    BAD_PARAM_NAME = "bad_param_name"
+    result = api.get_specific_parameter("london", BAD_PARAM_NAME)
+    assert numpy.isnan(result)
+
+
+@pytest.mark.vcr
+def test_bad_city():
+    with pytest.raises(Exception, match="no known AQI station"):
+        api.get_specific_parameter("a definitely nonexistent city", "aqi")
+
+    with pytest.raises(Exception):
+        api.get_specific_parameter("", "aqi")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit, urlencode
+import vcr
+from decouple import config
+from ozone import Ozone
+
+DEFAULT_OUTPUT_FOLDER = Path("ozone_output")
+DEFAULT_OUTPUT_FILE = DEFAULT_OUTPUT_FOLDER / "air_quality_data"
+
+
+# Filter out token in response headers
+def before_record_response(response):
+    loc_lst = response["headers"].get("Location")
+
+    if loc_lst is not None:
+        split = urlsplit(loc_lst[0])
+        new_loc = urlunsplit(
+            (
+                split.scheme,
+                split.netloc,
+                split.path,
+                urlencode(dict(token="DUMMY_TOKEN")),
+                None,
+            )
+        )
+        response["headers"]["Location"] = [new_loc]
+
+    return response
+
+
+# VCR arguments
+vcr_kwargs = {
+    # Filter out token query in URI
+    "filter_query_parameters": [("token", "DUMMY_TOKEN")],
+    "before_record_response": before_record_response,
+    "decode_compressed_response": True,
+}
+
+# Prepare a global Ozone object
+WAQI_TOKEN = config("WAQI_TOKEN", default="DUMMY_TOKEN")
+with vcr.use_cassette("tests/cassettes/ozone_init.yaml", **vcr_kwargs):
+    api = Ozone(WAQI_TOKEN)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,9 +4,6 @@ import vcr
 from decouple import config
 from ozone import Ozone
 
-DEFAULT_OUTPUT_FOLDER = Path("ozone_output")
-DEFAULT_OUTPUT_FILE = DEFAULT_OUTPUT_FOLDER / "air_quality_data"
-
 
 # Filter out token in response headers
 def before_record_response(response):
@@ -40,3 +37,8 @@ vcr_kwargs = {
 WAQI_TOKEN = config("WAQI_TOKEN", default="DUMMY_TOKEN")
 with vcr.use_cassette("tests/cassettes/ozone_init.yaml", **vcr_kwargs):
     api = Ozone(WAQI_TOKEN)
+
+# Declare these here to be used globally
+# instead of repeatedly in each test file
+DEFAULT_OUTPUT_FOLDER = Path("ozone_output")
+DEFAULT_OUTPUT_FILE = DEFAULT_OUTPUT_FOLDER / "air_quality_data"


### PR DESCRIPTION
This PR is currently working in progress, to fix #8.

List of public methods to write tests of:

- [x] `get_city_air`
- [x] `get_city_forecast`
- [x] `get_city_station_options`
- [x] `get_coordinate_air`
- [x] `get_historical_data`
- [x] `get_multiple_city_air`
- [x] `get_multiple_coordinate_air`
- [x] `get_range_coordinates_air`
- [x] `get_specific_parameter`
- [ ] `reset_token` ?

In summary:
- use `pytest` as the test framework
- use `pytest-recording` plugin to utilize `vcr.py` for mocking API response data
- one test file per public method

This PR should also:
- [x] add instructions to run tests (preferably in CONTRIBUTING)
- [x] add guidelines to add or modify tests, esp. about when will it be necessary to do so
- [x] add guidelines about VCR.py cassettes

Potential discussion points:
- Should we use `tox` for doing the tests? Especially in light of error discovered in #119