### PR TITLE
fix: Force convert into float (np.nan if fails)

### DIFF
--- a/src/ozone/ozone.py
+++ b/src/ozone/ozone.py
@@ -31,6 +31,16 @@ CALLS: int = 1000
 RATE_LIMIT: int = 1
 
 
+def as_float(x: Any) -> float:
+    """Convert x into a float. If unable, convert into numpy.nan instead.
+
+    Naming and functionality inspired by R function as.numeric()"""
+    try:
+        return float(x)
+    except (TypeError, ValueError):
+        return numpy.nan
+
+
 class Ozone:
     """Primary class for Ozone API
 
@@ -196,14 +206,14 @@ class Ozone:
             try:
                 if param == "aqi":
                     # This is in different part of JSON object.
-                    row["aqi"] = float(data_obj["aqi"])
+                    row["aqi"] = as_float(data_obj["aqi"])
                     # This adds AQI_meaning and AQI_health_implications data
                     (
                         row["AQI_meaning"],
                         row["AQI_health_implications"],
-                    ) = self._AQI_meaning(float(data_obj["aqi"]))
+                    ) = self._AQI_meaning(as_float(data_obj["aqi"]))
                 else:
-                    row[param] = float(data_obj["iaqi"][param]["v"])
+                    row[param] = as_float(data_obj["iaqi"][param]["v"])
             except KeyError:
                 # Gets triggered if the parameter is not provided by station.
                 row[param] = numpy.nan
@@ -569,7 +579,7 @@ class Ozone:
         row = self._extract_live_data(data_obj, [air_param])
 
         try:
-            result = float(row[air_param])
+            result = as_float(row[air_param])
         except KeyError:
             raise Exception(
                 f'Missing air quality parameter "{air_param}"\n'

--- a/src/ozone/ozone.py
+++ b/src/ozone/ozone.py
@@ -341,10 +341,8 @@ class Ozone:
                 "Health alert: everyone may experience more serious health effects."
             )
         else:
-            raise Exception(
-                f"{aqi} is not valid air quality index value. "
-                "Should be between 0 to 500."
-            )
+            AQI_meaning = "Invalid AQI value"
+            AQI_health_implications = "Invalid AQI value"
 
         return AQI_meaning, AQI_health_implications
 

--- a/src/ozone/ozone.py
+++ b/src/ozone/ozone.py
@@ -31,7 +31,7 @@ CALLS: int = 1000
 RATE_LIMIT: int = 1
 
 
-def as_float(x: Any) -> float:
+def _as_float(x: Any) -> float:
     """Convert x into a float. If unable, convert into numpy.nan instead.
 
     Naming and functionality inspired by R function as.numeric()"""
@@ -206,14 +206,14 @@ class Ozone:
             try:
                 if param == "aqi":
                     # This is in different part of JSON object.
-                    row["aqi"] = as_float(data_obj["aqi"])
+                    row["aqi"] = _as_float(data_obj["aqi"])
                     # This adds AQI_meaning and AQI_health_implications data
                     (
                         row["AQI_meaning"],
                         row["AQI_health_implications"],
-                    ) = self._AQI_meaning(as_float(data_obj["aqi"]))
+                    ) = self._AQI_meaning(_as_float(data_obj["aqi"]))
                 else:
-                    row[param] = as_float(data_obj["iaqi"][param]["v"])
+                    row[param] = _as_float(data_obj["iaqi"][param]["v"])
             except KeyError:
                 # Gets triggered if the parameter is not provided by station.
                 row[param] = numpy.nan
@@ -577,7 +577,7 @@ class Ozone:
         row = self._extract_live_data(data_obj, [air_param])
 
         try:
-            result = as_float(row[air_param])
+            result = _as_float(row[air_param])
         except KeyError:
             raise Exception(
                 f'Missing air quality parameter "{air_param}"\n'


### PR DESCRIPTION
This PR tries to solve the problem previously written up in https://github.com/Milind220/Ozone/pull/120#issuecomment-1105971303 (point no 2)

It introduces a helper method that tries to convert its input into float, and if that fails, gives out `numpy.nan`.

In light of the fact that WAQI backend sometimes sends invalid AQI value (e.g. `-` as noted above), I've also modified the `_AQI_meaning` method to return an "invalid" description rather than raising exception, to allow values such as `np.nan` to be given as its input without raising exceptions,