### PR TITLE
fix: Make `get_multiple_*` methods pass tests by not halting for one bad input

### DIFF
--- a/src/ozone/ozone.py
+++ b/src/ozone/ozone.py
@@ -482,11 +482,18 @@ class Ozone:
             selected another data format, this dataframe will be empty)
         """
         for loc in locations:
-            # This just makes sure that it's always a returns a pandas.DataFrame.
-            # Makes mypy happy.
-            df = pandas.DataFrame(
-                self.get_coordinate_air(loc[0], loc[1], df=df, params=params)
-            )
+            try:
+                # This just makes sure that it's always a returns a pandas.DataFrame.
+                # Makes mypy happy.
+                df = pandas.DataFrame(
+                    self.get_coordinate_air(loc[0], loc[1], df=df, params=params)
+                )
+            except Exception:
+                # NOTE: If we have custom exception we can catch it instead.
+                empty_row = pandas.DataFrame(
+                    {"latitude": [_as_float(loc[0])], "longitude": [_as_float(loc[1])]}
+                )
+                df = pandas.concat([df, empty_row], ignore_index=True)
 
         df.reset_index(inplace=True, drop=True)
         return self._format_output(data_format, df)
@@ -551,9 +558,16 @@ class Ozone:
             selected another data format, this dataframe will be empty)
         """
         for city in cities:
-            # This just makes sure that it's always a returns a pandas.DataFrame.
-            # Makes mypy happy.
-            df = pandas.DataFrame(self.get_city_air(city=city, df=df, params=params))
+            try:
+                # This just makes sure that it's always a returns a pandas.DataFrame.
+                # Makes mypy happy.
+                df = pandas.DataFrame(
+                    self.get_city_air(city=city, df=df, params=params)
+                )
+            except Exception:
+                # NOTE: If we have custom exception we can catch it instead.
+                empty_row = pandas.DataFrame({"city": [city]})
+                df = pandas.concat([df, empty_row], ignore_index=True)
 
         df.reset_index(inplace=True, drop=True)
         return self._format_output(data_format, df)

--- a/tests/cassettes/test_get_multiple_city_air/test_bad_city.yaml
+++ b/tests/cassettes/test_get_multiple_city_air/test_bad_city.yaml
@@ -60,8 +60,6 @@ interactions:
       - Fri, 22 Apr 2022 01:26:13 GMT
       Server:
       - nginx
-      Transfer-Encoding:
-      - chunked
       Vary:
       - Accept-Encoding
       X-Gen-Time:
@@ -134,8 +132,6 @@ interactions:
       - Fri, 22 Apr 2022 01:26:15 GMT
       Server:
       - nginx
-      Transfer-Encoding:
-      - chunked
       Vary:
       - Accept-Encoding
       X-Gen-Time:
@@ -144,6 +140,76 @@ interactions:
       - rxstreamer-waqi/1.3
       content-length:
       - '1865'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//a%20definitely%20nonexistent%20city/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Sat, 23 Apr 2022 14:41:19 GMT
+      Location:
+      - /feed/a%20definitely%20nonexistent%20city/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/a%20definitely%20nonexistent%20city/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"error","data":"Unknown station"}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Sat, 23 Apr 2022 14:41:19 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "188.033\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '43'
     status:
       code: 200
       message: OK

--- a/tests/cassettes/test_get_multiple_city_air/test_correct_data_format.yaml
+++ b/tests/cassettes/test_get_multiple_city_air/test_correct_data_format.yaml
@@ -60,8 +60,6 @@ interactions:
       - Fri, 22 Apr 2022 01:26:20 GMT
       Server:
       - nginx
-      Transfer-Encoding:
-      - chunked
       Vary:
       - Accept-Encoding
       X-Gen-Time:
@@ -136,8 +134,6 @@ interactions:
       - Fri, 22 Apr 2022 01:26:21 GMT
       Server:
       - nginx
-      Transfer-Encoding:
-      - chunked
       Vary:
       - Accept-Encoding
       X-Gen-Time:
@@ -210,8 +206,6 @@ interactions:
       - Fri, 22 Apr 2022 01:26:22 GMT
       Server:
       - nginx
-      Transfer-Encoding:
-      - chunked
       Vary:
       - Accept-Encoding
       X-Gen-Time:
@@ -220,6 +214,448 @@ interactions:
       - rxstreamer-waqi/1.3
       content-length:
       - '1865'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Sat, 23 Apr 2022 14:41:27 GMT
+      Location:
+      - /feed/london/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":59,"idx":5724,"attributions":[{"url":"http://uk-air.defra.gov.uk/","name":"UK-AIR,
+        air quality information resource - Defra, UK","logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"url":"https://londonair.org.uk/","name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","logo":"UK-London-Kings-College.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[51.5073509,-0.1277583],"name":"London","url":"https://aqicn.org/city/london","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":1},"h":{"v":60.2},"no2":{"v":11},"o3":{"v":24.4},"p":{"v":1002.8},"pm10":{"v":25},"pm25":{"v":59},"so2":{"v":1.1},"t":{"v":15.8},"w":{"v":9}},"time":{"s":"2022-04-23
+        14:00:00","tz":"+01:00","v":1650722400,"iso":"2022-04-23T14:00:00+01:00"},"forecast":{"daily":{"o3":[{"avg":25,"day":"2022-04-21","max":37,"min":13},{"avg":26,"day":"2022-04-22","max":36,"min":18},{"avg":29,"day":"2022-04-23","max":40,"min":20},{"avg":31,"day":"2022-04-24","max":38,"min":27},{"avg":27,"day":"2022-04-25","max":36,"min":22},{"avg":27,"day":"2022-04-26","max":37,"min":18},{"avg":21,"day":"2022-04-27","max":21,"min":19}],"pm10":[{"avg":20,"day":"2022-04-21","max":29,"min":11},{"avg":17,"day":"2022-04-22","max":21,"min":10},{"avg":20,"day":"2022-04-23","max":23,"min":17},{"avg":14,"day":"2022-04-24","max":19,"min":9},{"avg":13,"day":"2022-04-25","max":16,"min":8},{"avg":10,"day":"2022-04-26","max":15,"min":6},{"avg":14,"day":"2022-04-27","max":15,"min":14}],"pm25":[{"avg":59,"day":"2022-04-21","max":78,"min":40},{"avg":50,"day":"2022-04-22","max":62,"min":35},{"avg":61,"day":"2022-04-23","max":70,"min":54},{"avg":44,"day":"2022-04-24","max":57,"min":27},{"avg":39,"day":"2022-04-25","max":51,"min":28},{"avg":30,"day":"2022-04-26","max":50,"min":19},{"avg":40,"day":"2022-04-27","max":44,"min":40}],"uvi":[{"avg":1,"day":"2022-04-21","max":4,"min":0},{"avg":0,"day":"2022-04-22","max":3,"min":0},{"avg":1,"day":"2022-04-23","max":4,"min":0},{"avg":1,"day":"2022-04-24","max":4,"min":0},{"avg":1,"day":"2022-04-25","max":2,"min":0},{"avg":1,"day":"2022-04-26","max":4,"min":0},{"avg":0,"day":"2022-04-27","max":2,"min":0},{"avg":0,"day":"2022-04-28","max":0,"min":0}]}},"debug":{"sync":"2022-04-23T23:39:49+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Sat, 23 Apr 2022 14:41:27 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "78.511\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2312'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//new%20delhi/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Sat, 23 Apr 2022 14:41:28 GMT
+      Location:
+      - /feed/new%20delhi/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/new%20delhi/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: "{\"status\":\"ok\",\"data\":{\"aqi\":124,\"idx\":7024,\"attributions\":[{\"url\":\"http://worldweather.wmo.int\",\"name\":\"World
+        Meteorological Organization - surface synoptic observations (WMO-SYNOP)\"},{\"url\":\"https://in.usembassy.gov/embassy-consulates/new-delhi/air-quality-data/\",\"name\":\"U.S.
+        Embassy and Consulates' Air Quality Monitor in India\",\"logo\":\"US-StateDepartment.png\"},{\"url\":\"https://waqi.info/\",\"name\":\"World
+        Air Quality Index Project\"}],\"city\":{\"geo\":[28.63576,77.22445],\"name\":\"New
+        Delhi US Embassy, India (\u0928\u0908 \u0926\u093F\u0932\u094D\u0932\u0940
+        \u0905\u092E\u0947\u0930\u093F\u0915\u0940 \u0926\u0942\u0924\u093E\u0935\u093E\u0938)\",\"url\":\"https://aqicn.org/city/india/new-delhi/us-embassy\",\"location\":\"\"},\"dominentpol\":\"pm25\",\"iaqi\":{\"dew\":{\"v\":1},\"h\":{\"v\":11},\"p\":{\"v\":1007},\"pm25\":{\"v\":124},\"t\":{\"v\":35},\"w\":{\"v\":1.5},\"wg\":{\"v\":9.2}},\"time\":{\"s\":\"2022-04-23
+        19:00:00\",\"tz\":\"+05:30\",\"v\":1650740400,\"iso\":\"2022-04-23T19:00:00+05:30\"},\"forecast\":{\"daily\":{\"o3\":[{\"avg\":7,\"day\":\"2022-04-21\",\"max\":30,\"min\":1},{\"avg\":19,\"day\":\"2022-04-22\",\"max\":64,\"min\":1},{\"avg\":22,\"day\":\"2022-04-23\",\"max\":59,\"min\":1},{\"avg\":24,\"day\":\"2022-04-24\",\"max\":44,\"min\":9},{\"avg\":19,\"day\":\"2022-04-25\",\"max\":55,\"min\":4},{\"avg\":21,\"day\":\"2022-04-26\",\"max\":82,\"min\":1},{\"avg\":22,\"day\":\"2022-04-27\",\"max\":52,\"min\":7},{\"avg\":18,\"day\":\"2022-04-28\",\"max\":18,\"min\":2}],\"pm10\":[{\"avg\":123,\"day\":\"2022-04-21\",\"max\":123,\"min\":123},{\"avg\":123,\"day\":\"2022-04-22\",\"max\":123,\"min\":123},{\"avg\":102,\"day\":\"2022-04-23\",\"max\":123,\"min\":73},{\"avg\":90,\"day\":\"2022-04-24\",\"max\":123,\"min\":73},{\"avg\":94,\"day\":\"2022-04-25\",\"max\":123,\"min\":73},{\"avg\":102,\"day\":\"2022-04-26\",\"max\":123,\"min\":73},{\"avg\":83,\"day\":\"2022-04-27\",\"max\":123,\"min\":58},{\"avg\":93,\"day\":\"2022-04-28\",\"max\":123,\"min\":58},{\"avg\":86,\"day\":\"2022-04-29\",\"max\":123,\"min\":63}],\"pm25\":[{\"avg\":160,\"day\":\"2022-04-21\",\"max\":161,\"min\":159},{\"avg\":164,\"day\":\"2022-04-22\",\"max\":174,\"min\":159},{\"avg\":164,\"day\":\"2022-04-23\",\"max\":189,\"min\":138},{\"avg\":155,\"day\":\"2022-04-24\",\"max\":174,\"min\":138},{\"avg\":154,\"day\":\"2022-04-25\",\"max\":165,\"min\":138},{\"avg\":152,\"day\":\"2022-04-26\",\"max\":174,\"min\":138},{\"avg\":156,\"day\":\"2022-04-27\",\"max\":174,\"min\":138},{\"avg\":147,\"day\":\"2022-04-28\",\"max\":159,\"min\":138},{\"avg\":152,\"day\":\"2022-04-29\",\"max\":153,\"min\":138}],\"uvi\":[{\"avg\":2,\"day\":\"2022-04-23\",\"max\":8,\"min\":0},{\"avg\":2,\"day\":\"2022-04-24\",\"max\":9,\"min\":0},{\"avg\":2,\"day\":\"2022-04-25\",\"max\":7,\"min\":0},{\"avg\":2,\"day\":\"2022-04-26\",\"max\":7,\"min\":0},{\"avg\":2,\"day\":\"2022-04-27\",\"max\":9,\"min\":0},{\"avg\":0,\"day\":\"2022-04-28\",\"max\":0,\"min\":0}]}},\"debug\":{\"sync\":\"2022-04-23T23:16:59+09:00\"}}}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Sat, 23 Apr 2022 14:41:28 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "896.127\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2535'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//paris/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Sat, 23 Apr 2022 14:41:29 GMT
+      Location:
+      - /feed/paris/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/paris/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: "{\"status\":\"ok\",\"data\":{\"aqi\":\"-\",\"idx\":5722,\"attributions\":[{\"url\":\"http://www.eea.europa.eu/themes/air/\",\"name\":\"European
+        Environment Agency\",\"logo\":\"Europe-EEA.png\"},{\"url\":\"https://www.airparif.asso.fr/\",\"name\":\"AirParif
+        - Association de surveillance de la qualit\xE9 de l'air en \xCEle-de-France\",\"logo\":\"Paris-Air-Parif.png\"},{\"url\":\"https://waqi.info/\",\"name\":\"World
+        Air Quality Index Project\"}],\"city\":{\"geo\":[48.856614,2.3522219],\"name\":\"Paris\",\"url\":\"https://aqicn.org/city/paris\",\"location\":\"\"},\"dominentpol\":\"\",\"iaqi\":{\"co\":{\"v\":0.1},\"h\":{\"v\":63},\"no2\":{\"v\":26.5},\"o3\":{\"v\":24},\"p\":{\"v\":996.1},\"pm10\":{\"v\":22},\"pm25\":{\"v\":68},\"so2\":{\"v\":0.6},\"t\":{\"v\":19.3},\"w\":{\"v\":4.6}},\"time\":{\"s\":\"2022-04-23
+        14:00:00\",\"tz\":\"+02:00\",\"v\":1650722400,\"iso\":\"2022-04-23T14:00:00+02:00\"},\"forecast\":{\"daily\":{\"o3\":[{\"avg\":27,\"day\":\"2022-04-23\",\"max\":38,\"min\":18},{\"avg\":28,\"day\":\"2022-04-24\",\"max\":39,\"min\":19},{\"avg\":25,\"day\":\"2022-04-25\",\"max\":37,\"min\":15},{\"avg\":24,\"day\":\"2022-04-26\",\"max\":38,\"min\":12},{\"avg\":24,\"day\":\"2022-04-27\",\"max\":25,\"min\":24}],\"pm10\":[{\"avg\":16,\"day\":\"2022-04-23\",\"max\":23,\"min\":7},{\"avg\":16,\"day\":\"2022-04-24\",\"max\":20,\"min\":13},{\"avg\":18,\"day\":\"2022-04-25\",\"max\":20,\"min\":14},{\"avg\":20,\"day\":\"2022-04-26\",\"max\":29,\"min\":13},{\"avg\":19,\"day\":\"2022-04-27\",\"max\":19,\"min\":16}],\"pm25\":[{\"avg\":50,\"day\":\"2022-04-23\",\"max\":67,\"min\":22},{\"avg\":57,\"day\":\"2022-04-24\",\"max\":65,\"min\":46},{\"avg\":61,\"day\":\"2022-04-25\",\"max\":68,\"min\":55},{\"avg\":65,\"day\":\"2022-04-26\",\"max\":85,\"min\":45},{\"avg\":63,\"day\":\"2022-04-27\",\"max\":63,\"min\":53}],\"uvi\":[{\"avg\":0,\"day\":\"2022-04-23\",\"max\":4,\"min\":0},{\"avg\":1,\"day\":\"2022-04-24\",\"max\":4,\"min\":0},{\"avg\":0,\"day\":\"2022-04-25\",\"max\":4,\"min\":0},{\"avg\":0,\"day\":\"2022-04-26\",\"max\":2,\"min\":0},{\"avg\":1,\"day\":\"2022-04-27\",\"max\":4,\"min\":0},{\"avg\":0,\"day\":\"2022-04-28\",\"max\":0,\"min\":0}]}},\"debug\":{\"sync\":\"2022-04-23T23:34:39+09:00\"}}}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Sat, 23 Apr 2022 14:41:29 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "78.162\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '1868'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Sat, 23 Apr 2022 14:47:25 GMT
+      Location:
+      - /feed/london/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/london/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: '{"status":"ok","data":{"aqi":59,"idx":5724,"attributions":[{"url":"http://uk-air.defra.gov.uk/","name":"UK-AIR,
+        air quality information resource - Defra, UK","logo":"UK-Department-for-environment-food-and-rural-affairs.png"},{"url":"https://londonair.org.uk/","name":"London
+        Air Quality Network - Environmental Research Group, King''s College London","logo":"UK-London-Kings-College.png"},{"url":"https://waqi.info/","name":"World
+        Air Quality Index Project"}],"city":{"geo":[51.5073509,-0.1277583],"name":"London","url":"https://aqicn.org/city/london","location":""},"dominentpol":"pm25","iaqi":{"co":{"v":1},"h":{"v":60.2},"no2":{"v":11},"o3":{"v":24.4},"p":{"v":1002.8},"pm10":{"v":25},"pm25":{"v":59},"so2":{"v":1.1},"t":{"v":15.8},"w":{"v":9}},"time":{"s":"2022-04-23
+        14:00:00","tz":"+01:00","v":1650722400,"iso":"2022-04-23T14:00:00+01:00"},"forecast":{"daily":{"o3":[{"avg":25,"day":"2022-04-21","max":37,"min":13},{"avg":26,"day":"2022-04-22","max":36,"min":18},{"avg":29,"day":"2022-04-23","max":40,"min":20},{"avg":31,"day":"2022-04-24","max":38,"min":27},{"avg":27,"day":"2022-04-25","max":36,"min":22},{"avg":27,"day":"2022-04-26","max":37,"min":18},{"avg":21,"day":"2022-04-27","max":21,"min":19}],"pm10":[{"avg":20,"day":"2022-04-21","max":29,"min":11},{"avg":17,"day":"2022-04-22","max":21,"min":10},{"avg":20,"day":"2022-04-23","max":23,"min":17},{"avg":14,"day":"2022-04-24","max":19,"min":9},{"avg":13,"day":"2022-04-25","max":16,"min":8},{"avg":10,"day":"2022-04-26","max":15,"min":6},{"avg":14,"day":"2022-04-27","max":15,"min":14}],"pm25":[{"avg":59,"day":"2022-04-21","max":78,"min":40},{"avg":50,"day":"2022-04-22","max":62,"min":35},{"avg":61,"day":"2022-04-23","max":70,"min":54},{"avg":44,"day":"2022-04-24","max":57,"min":27},{"avg":39,"day":"2022-04-25","max":51,"min":28},{"avg":30,"day":"2022-04-26","max":50,"min":19},{"avg":40,"day":"2022-04-27","max":44,"min":40}],"uvi":[{"avg":1,"day":"2022-04-21","max":4,"min":0},{"avg":0,"day":"2022-04-22","max":3,"min":0},{"avg":1,"day":"2022-04-23","max":4,"min":0},{"avg":1,"day":"2022-04-24","max":4,"min":0},{"avg":1,"day":"2022-04-25","max":2,"min":0},{"avg":1,"day":"2022-04-26","max":4,"min":0},{"avg":0,"day":"2022-04-27","max":2,"min":0},{"avg":0,"day":"2022-04-28","max":0,"min":0}]}},"debug":{"sync":"2022-04-23T23:39:49+09:00"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Sat, 23 Apr 2022 14:47:25 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "108.862\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2312'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//new%20delhi/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Sat, 23 Apr 2022 14:47:27 GMT
+      Location:
+      - /feed/new%20delhi/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/new%20delhi/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: "{\"status\":\"ok\",\"data\":{\"aqi\":124,\"idx\":7024,\"attributions\":[{\"url\":\"http://worldweather.wmo.int\",\"name\":\"World
+        Meteorological Organization - surface synoptic observations (WMO-SYNOP)\"},{\"url\":\"https://in.usembassy.gov/embassy-consulates/new-delhi/air-quality-data/\",\"name\":\"U.S.
+        Embassy and Consulates' Air Quality Monitor in India\",\"logo\":\"US-StateDepartment.png\"},{\"url\":\"https://waqi.info/\",\"name\":\"World
+        Air Quality Index Project\"}],\"city\":{\"geo\":[28.63576,77.22445],\"name\":\"New
+        Delhi US Embassy, India (\u0928\u0908 \u0926\u093F\u0932\u094D\u0932\u0940
+        \u0905\u092E\u0947\u0930\u093F\u0915\u0940 \u0926\u0942\u0924\u093E\u0935\u093E\u0938)\",\"url\":\"https://aqicn.org/city/india/new-delhi/us-embassy\",\"location\":\"\"},\"dominentpol\":\"pm25\",\"iaqi\":{\"dew\":{\"v\":1},\"h\":{\"v\":11},\"p\":{\"v\":1007},\"pm25\":{\"v\":124},\"t\":{\"v\":35},\"w\":{\"v\":1.5},\"wg\":{\"v\":9.2}},\"time\":{\"s\":\"2022-04-23
+        19:00:00\",\"tz\":\"+05:30\",\"v\":1650740400,\"iso\":\"2022-04-23T19:00:00+05:30\"},\"forecast\":{\"daily\":{\"o3\":[{\"avg\":7,\"day\":\"2022-04-21\",\"max\":30,\"min\":1},{\"avg\":19,\"day\":\"2022-04-22\",\"max\":64,\"min\":1},{\"avg\":22,\"day\":\"2022-04-23\",\"max\":59,\"min\":1},{\"avg\":24,\"day\":\"2022-04-24\",\"max\":44,\"min\":9},{\"avg\":19,\"day\":\"2022-04-25\",\"max\":55,\"min\":4},{\"avg\":21,\"day\":\"2022-04-26\",\"max\":82,\"min\":1},{\"avg\":22,\"day\":\"2022-04-27\",\"max\":52,\"min\":7},{\"avg\":18,\"day\":\"2022-04-28\",\"max\":18,\"min\":2}],\"pm10\":[{\"avg\":123,\"day\":\"2022-04-21\",\"max\":123,\"min\":123},{\"avg\":123,\"day\":\"2022-04-22\",\"max\":123,\"min\":123},{\"avg\":102,\"day\":\"2022-04-23\",\"max\":123,\"min\":73},{\"avg\":90,\"day\":\"2022-04-24\",\"max\":123,\"min\":73},{\"avg\":94,\"day\":\"2022-04-25\",\"max\":123,\"min\":73},{\"avg\":102,\"day\":\"2022-04-26\",\"max\":123,\"min\":73},{\"avg\":83,\"day\":\"2022-04-27\",\"max\":123,\"min\":58},{\"avg\":93,\"day\":\"2022-04-28\",\"max\":123,\"min\":58},{\"avg\":86,\"day\":\"2022-04-29\",\"max\":123,\"min\":63}],\"pm25\":[{\"avg\":160,\"day\":\"2022-04-21\",\"max\":161,\"min\":159},{\"avg\":164,\"day\":\"2022-04-22\",\"max\":174,\"min\":159},{\"avg\":164,\"day\":\"2022-04-23\",\"max\":189,\"min\":138},{\"avg\":155,\"day\":\"2022-04-24\",\"max\":174,\"min\":138},{\"avg\":154,\"day\":\"2022-04-25\",\"max\":165,\"min\":138},{\"avg\":152,\"day\":\"2022-04-26\",\"max\":174,\"min\":138},{\"avg\":156,\"day\":\"2022-04-27\",\"max\":174,\"min\":138},{\"avg\":147,\"day\":\"2022-04-28\",\"max\":159,\"min\":138},{\"avg\":152,\"day\":\"2022-04-29\",\"max\":153,\"min\":138}],\"uvi\":[{\"avg\":2,\"day\":\"2022-04-23\",\"max\":8,\"min\":0},{\"avg\":2,\"day\":\"2022-04-24\",\"max\":9,\"min\":0},{\"avg\":2,\"day\":\"2022-04-25\",\"max\":7,\"min\":0},{\"avg\":2,\"day\":\"2022-04-26\",\"max\":7,\"min\":0},{\"avg\":2,\"day\":\"2022-04-27\",\"max\":9,\"min\":0},{\"avg\":0,\"day\":\"2022-04-28\",\"max\":0,\"min\":0}]}},\"debug\":{\"sync\":\"2022-04-23T23:16:59+09:00\"}}}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Sat, 23 Apr 2022 14:47:27 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "257.175\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '2535'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed//paris/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Sat, 23 Apr 2022 14:47:28 GMT
+      Location:
+      - /feed/paris/?token=DUMMY_TOKEN
+      Server:
+      - nginx
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.waqi.info/feed/paris/?token=DUMMY_TOKEN
+  response:
+    body:
+      string: "{\"status\":\"ok\",\"data\":{\"aqi\":\"-\",\"idx\":5722,\"attributions\":[{\"url\":\"http://www.eea.europa.eu/themes/air/\",\"name\":\"European
+        Environment Agency\",\"logo\":\"Europe-EEA.png\"},{\"url\":\"https://www.airparif.asso.fr/\",\"name\":\"AirParif
+        - Association de surveillance de la qualit\xE9 de l'air en \xCEle-de-France\",\"logo\":\"Paris-Air-Parif.png\"},{\"url\":\"https://waqi.info/\",\"name\":\"World
+        Air Quality Index Project\"}],\"city\":{\"geo\":[48.856614,2.3522219],\"name\":\"Paris\",\"url\":\"https://aqicn.org/city/paris\",\"location\":\"\"},\"dominentpol\":\"\",\"iaqi\":{\"co\":{\"v\":0.1},\"h\":{\"v\":63},\"no2\":{\"v\":26.5},\"o3\":{\"v\":24},\"p\":{\"v\":996.1},\"pm10\":{\"v\":22},\"pm25\":{\"v\":68},\"so2\":{\"v\":0.6},\"t\":{\"v\":19.3},\"w\":{\"v\":4.6}},\"time\":{\"s\":\"2022-04-23
+        14:00:00\",\"tz\":\"+02:00\",\"v\":1650722400,\"iso\":\"2022-04-23T14:00:00+02:00\"},\"forecast\":{\"daily\":{\"o3\":[{\"avg\":27,\"day\":\"2022-04-23\",\"max\":38,\"min\":18},{\"avg\":28,\"day\":\"2022-04-24\",\"max\":39,\"min\":19},{\"avg\":25,\"day\":\"2022-04-25\",\"max\":37,\"min\":15},{\"avg\":24,\"day\":\"2022-04-26\",\"max\":38,\"min\":12},{\"avg\":24,\"day\":\"2022-04-27\",\"max\":25,\"min\":24}],\"pm10\":[{\"avg\":16,\"day\":\"2022-04-23\",\"max\":23,\"min\":7},{\"avg\":16,\"day\":\"2022-04-24\",\"max\":20,\"min\":13},{\"avg\":18,\"day\":\"2022-04-25\",\"max\":20,\"min\":14},{\"avg\":20,\"day\":\"2022-04-26\",\"max\":29,\"min\":13},{\"avg\":19,\"day\":\"2022-04-27\",\"max\":19,\"min\":16}],\"pm25\":[{\"avg\":50,\"day\":\"2022-04-23\",\"max\":67,\"min\":22},{\"avg\":57,\"day\":\"2022-04-24\",\"max\":65,\"min\":46},{\"avg\":61,\"day\":\"2022-04-25\",\"max\":68,\"min\":55},{\"avg\":65,\"day\":\"2022-04-26\",\"max\":85,\"min\":45},{\"avg\":63,\"day\":\"2022-04-27\",\"max\":63,\"min\":53}],\"uvi\":[{\"avg\":0,\"day\":\"2022-04-23\",\"max\":4,\"min\":0},{\"avg\":1,\"day\":\"2022-04-24\",\"max\":4,\"min\":0},{\"avg\":0,\"day\":\"2022-04-25\",\"max\":4,\"min\":0},{\"avg\":0,\"day\":\"2022-04-26\",\"max\":2,\"min\":0},{\"avg\":1,\"day\":\"2022-04-27\",\"max\":4,\"min\":0},{\"avg\":0,\"day\":\"2022-04-28\",\"max\":0,\"min\":0}]}},\"debug\":{\"sync\":\"2022-04-23T23:34:39+09:00\"}}}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Sat, 23 Apr 2022 14:47:28 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Gen-Time:
+      - "104.441\xC2\xB5s"
+      X-Powered-By:
+      - rxstreamer-waqi/1.3
+      content-length:
+      - '1868'
     status:
       code: 200
       message: OK

--- a/tests/test_get_multiple_city_air.py
+++ b/tests/test_get_multiple_city_air.py
@@ -81,7 +81,15 @@ def test_bad_city():
     # for a lot of cities at once using this method only to get aborted
     # because there's one city that don't have AQI station (and raises
     # Exception).
-    api.get_multiple_city_air(["london", "paris", "a definitely nonexistent city"])
+    result = api.get_multiple_city_air(
+        ["london", "paris", "a definitely nonexistent city"]
+    )
+
+    # The third row should have the "nonexistent city name" intact ...
+    assert result.at[2, "city"] == "a definitely nonexistent city"
+
+    # ... and nothing else.
+    assert result.iloc[2, :].drop("city").isna().all()
 
 
 @pytest.mark.vcr

--- a/tests/test_get_multiple_coordinate_air.py
+++ b/tests/test_get_multiple_coordinate_air.py
@@ -77,7 +77,20 @@ def test_nonexistent_requested_params():
 def test_bad_coordinates():
     # NOTE, ???
     # See test_get_multiple_city_air, same issue
-    api.get_multiple_coordinate_air([(50, 0), (50, 1), ("lol", "bruh")])
+    BAD_COORDS = [(50, 0), (50, 1), ("lol", "bruh"), ("51", "0")]
+    result = api.get_multiple_coordinate_air(BAD_COORDS)
+
+    # Lat-lon columns should remain float even when given bad coords
+    assert pd_types.is_float_dtype(result["latitude"])
+    assert pd_types.is_float_dtype(result["longitude"])
+
+    # Rows with bad coord should have nan entire row
+    assert result.iloc[2, :].isna().all()
+
+    # Rows with float-able string should be float, because
+    # WAQI supports such operation on their backend
+    assert result.at[3, "latitude"] == 51
+    assert result.at[3, "longitude"] == 0
 
 
 @pytest.mark.vcr


### PR DESCRIPTION
As laid out by the tests, `get_multiple_*_air` methods shouldn't halt when there is one bad input. One bad input (which in turn will make backend return error/bad response, which will make an exception raised in our part) shouldn't halt the execution of other, likely good, inputs. This is not convenient. For what it's worth, I've always treated `get_multiple_*` methods as convenience wrappers for their single `get_*_air` counterparts (otherwise I could just loop them myself).

The example in my mind is this: you are mass-collecting data for a hundred cities. One city turns out to not have AQI station and subsequently raise exception (you likely won't know this in advance). It will be annoying to have the other 99 cities halted.

I realize that this will make an odd difference between e.g. `get_city_air` (raises exception on bad response) and `get_multiple_cities_air` (returns nan row on bad response). I don't have really much to say either supporting or against.

Is this a good or common enough use case? Should I implement things differently? I'm curious to hear more.