### PR TITLE
Fix pm25 label

### DIFF
--- a/src/ozone/ozone.py
+++ b/src/ozone/ozone.py
@@ -213,6 +213,9 @@ class Ozone:
         row["longitude"] = data_obj["city"]["geo"][1]
         row["station"] = data_obj["city"]["name"]
         row["dominant_pollutant"] = data_obj["dominentpol"]
+        if data_obj["dominentpol"] == "pm25":
+            # Ensures that pm2.5 is correctly labeled.
+            row["dominant_pollutant"] = "pm2.5"
         row["timestamp"] = data_obj["time"]["s"]
         row["timestamp_timezone"] = data_obj["time"]["tz"]
 

--- a/src/ozone/ozone.py
+++ b/src/ozone/ozone.py
@@ -714,6 +714,9 @@ class Ozone:
                 )
 
         df = get_data_from_id(city_id)
+        if "pm25" in df.columns:
+            # This ensures that pm25 data is labelled correctly.
+            df.rename(columns={"pm25": "pm2.5"}, inplace=True)
 
         # Reset date index and rename the column appropriately
         df = df.reset_index().rename(columns={"index": "date"})

--- a/src/ozone/ozone.py
+++ b/src/ozone/ozone.py
@@ -58,7 +58,7 @@ class Ozone:
     _find_stations_url: str = URLs.find_stations_url
     _default_params: List[str] = [
         "aqi",
-        "pm25",
+        "pm2.5",
         "pm10",
         "o3",
         "co",
@@ -229,7 +229,7 @@ class Ozone:
                         row["AQI_meaning"],
                         row["AQI_health_implications"],
                     ) = self._AQI_meaning(_as_float(data_obj["aqi"]))
-                elif param == "pm25":
+                elif param == "pm2.5":
                     # To ensure that pm2.5 data is labelled correctly.
                     row["pm2.5"] = _as_float(data_obj["iaqi"]["pm25"]["v"])
                 else:
@@ -424,7 +424,7 @@ class Ozone:
                 append the data to.
             params (List[str], optional): A list of parameters to get data for.
                 Choose from the following values:
-                ["aqi", "pm25", "pm10", "o3", "co", "no2", "so2", "dew", "h",
+                ["aqi", "pm2.5", "pm10", "o3", "co", "no2", "so2", "dew", "h",
                  "p", "t", "w", "wg"]
                 Gets all parameters by default.
 
@@ -461,7 +461,7 @@ class Ozone:
                 append the data to.
             params (List[str], optional): A list of parameters to get data for.
                 Choose from the following values:
-                ["aqi", "pm25", "pm10", "o3", "co", "no2", "so2", "dew", "h",
+                ["aqi", "pm2.5", "pm10", "o3", "co", "no2", "so2", "dew", "h",
                  "p", "t", "w", "wg"]
                 Gets all parameters by default.
 
@@ -498,7 +498,7 @@ class Ozone:
                 append the data to.
             params (List[str], optional): A list of parameters to get data for.
                 Choose from the following values:
-                ["aqi", "pm25", "pm10", "o3", "co", "no2", "so2", "dew", "h",
+                ["aqi", "pm2.5", "pm10", "o3", "co", "no2", "so2", "dew", "h",
                  "p", "t", "w", "wg"]
                 Gets all parameters by default..
 
@@ -542,7 +542,7 @@ class Ozone:
                 append the data to.
             params (List[str], optional): A list of parameters to get data for.
                 Choose from the following values:
-                ["aqi", "pm25", "pm10", "o3", "co", "no2", "so2", "dew", "h",
+                ["aqi", "pm2.5", "pm10", "o3", "co", "no2", "so2", "dew", "h",
                  "p", "t", "w", "wg"]
                 Gets all parameters by default.
 
@@ -572,7 +572,7 @@ class Ozone:
                 Choose from 'csv', 'json', 'xlsx'.
             params (List[str], optional): A list of parameters to get data for.
                 Choose from the following values:
-                ["aqi", "pm25", "pm10", "o3", "co", "no2", "so2", "dew", "h",
+                ["aqi", "pm2.5", "pm10", "o3", "co", "no2", "so2", "dew", "h",
                  "p", "t", "w", "wg"]
                 Gets all parameters by default.
             df (pandas.DataFrame, optional): An existing dataframe to
@@ -608,7 +608,7 @@ class Ozone:
             city (string): A city to get the data for
             air_param (string): A string containing the specified air quality parameter.
                 Choose from the following values:
-                ["aqi", "pm25", "pm10", "o3", "co", "no2", "so2", "dew", "h",
+                ["aqi", "pm2.5", "pm10", "o3", "co", "no2", "so2", "dew", "h",
                  "p", "t", "w", "wg"]
                 Gets all parameters by default.
 

--- a/src/ozone/ozone.py
+++ b/src/ozone/ozone.py
@@ -221,11 +221,14 @@ class Ozone:
                 if param == "aqi":
                     # This is in different part of JSON object.
                     row["aqi"] = _as_float(data_obj["aqi"])
-                    # This adds AQI_meaning and AQI_health_implications data
+                    # This adds AQI_meaning and AQI_health_implications data.
                     (
                         row["AQI_meaning"],
                         row["AQI_health_implications"],
                     ) = self._AQI_meaning(_as_float(data_obj["aqi"]))
+                elif param == "pm25":
+                    # To ensure that pm2.5 data is labelled correctly.
+                    row["pm2.5"] = _as_float(data_obj["iaqi"]["pm25"]["v"])
                 else:
                     row[param] = _as_float(data_obj["iaqi"][param]["v"])
             except KeyError:

--- a/src/ozone/ozone.py
+++ b/src/ozone/ozone.py
@@ -745,6 +745,10 @@ class Ozone:
         data_obj = self._check_and_get_data_obj(r)
 
         df = self._extract_forecast_data(data_obj)
+        if "pm25" in df.columns:
+            # This ensures that pm25 data is labelled correctly.
+            df.rename(columns={"pm25": "pm2.5"}, inplace=True)
+
         return self._format_output(data_format, df)
 
 

--- a/tests/test_get_city_air.py
+++ b/tests/test_get_city_air.py
@@ -62,7 +62,7 @@ def test_excluded_params():
     custom_params = ["aqi", "pm25", "o3"]
     result = api.get_city_air("london", params=custom_params)
     assert "pm10" not in result
-    assert "pm25" in result
+    assert "pm2.5" in result
 
 
 @pytest.mark.vcr

--- a/tests/test_get_city_air.py
+++ b/tests/test_get_city_air.py
@@ -59,7 +59,7 @@ def test_column_types():
 @pytest.mark.vcr
 def test_excluded_params():
     # Param should be really excluded when specified as such
-    custom_params = ["aqi", "pm25", "o3"]
+    custom_params = ["aqi", "pm2.5", "o3"]
     result = api.get_city_air("london", params=custom_params)
     assert "pm10" not in result
     assert "pm2.5" in result

--- a/tests/test_get_city_air.py
+++ b/tests/test_get_city_air.py
@@ -39,7 +39,7 @@ def test_column_types():
         "latitude",
         "longitude",
         "aqi",
-        "pm25",
+        "pm2.5",
         "pm10",
         "o3",
         "co",

--- a/tests/test_get_city_forecast.py
+++ b/tests/test_get_city_forecast.py
@@ -28,7 +28,7 @@ def test_column_types():
 
     # Check that all pollutants and statistics are in column
     # and are of float type
-    for param in ["pm25", "pm10", "o3", "uvi"]:
+    for param in ["pm2.5", "pm10", "o3", "uvi"]:
         for stat in ["min", "max", "avg"]:
             assert pd_types.is_float_dtype(result[(param, stat)])
 

--- a/tests/test_get_coordinate_air.py
+++ b/tests/test_get_coordinate_air.py
@@ -47,7 +47,7 @@ def test_column_types():
         "latitude",
         "longitude",
         "aqi",
-        "pm25",
+        "pm2.5",
         "pm10",
         "o3",
         "co",
@@ -70,7 +70,7 @@ def test_excluded_params():
     custom_params = ["aqi", "pm25", "o3"]
     result = api.get_coordinate_air(51.51, -0.13, params=custom_params)
     assert "pm10" not in result
-    assert "pm25" in result
+    assert "pm2.5" in result
 
 
 @pytest.mark.vcr

--- a/tests/test_get_coordinate_air.py
+++ b/tests/test_get_coordinate_air.py
@@ -67,7 +67,7 @@ def test_column_types():
 @pytest.mark.vcr
 def test_excluded_params():
     # Param should be really excluded when specified as such
-    custom_params = ["aqi", "pm25", "o3"]
+    custom_params = ["aqi", "pm2.5", "o3"]
     result = api.get_coordinate_air(51.51, -0.13, params=custom_params)
     assert "pm10" not in result
     assert "pm2.5" in result

--- a/tests/test_get_historical_data.py
+++ b/tests/test_get_historical_data.py
@@ -27,7 +27,7 @@ def test_column_types():
     # The date column contains date information
     assert pd_types.is_datetime64_any_dtype(result["date"])
 
-    HISTORICAL_COLUMNS = ["pm25", "pm10", "o3", "no2", "so2", "co"]
+    HISTORICAL_COLUMNS = ["pm2.5", "pm10", "o3", "no2", "so2", "co"]
     assert all([pd_types.is_float_dtype(result[col]) for col in HISTORICAL_COLUMNS])
 
 

--- a/tests/test_get_multiple_city_air.py
+++ b/tests/test_get_multiple_city_air.py
@@ -38,7 +38,7 @@ def test_column_types():
         "latitude",
         "longitude",
         "aqi",
-        "pm25",
+        "pm2.5",
         "pm10",
         "o3",
         "co",
@@ -58,12 +58,12 @@ def test_column_types():
 @pytest.mark.vcr
 def test_excluded_params():
     # Param should be really excluded when specified as such
-    custom_params = ["aqi", "pm25", "o3"]
+    custom_params = ["aqi", "pm2.5", "o3"]
     result = api.get_multiple_city_air(
         ["london", "new delhi", "paris"], params=custom_params
     )
     assert "pm10" not in result
-    assert "pm25" in result
+    assert "pm2.5" in result
 
 
 @pytest.mark.vcr

--- a/tests/test_get_multiple_coordinate_air.py
+++ b/tests/test_get_multiple_coordinate_air.py
@@ -44,7 +44,7 @@ def test_column_types():
         "latitude",
         "longitude",
         "aqi",
-        "pm25",
+        "pm2.5",
         "pm10",
         "o3",
         "co",
@@ -67,7 +67,7 @@ def test_excluded_params():
     custom_params = ["aqi", "pm25", "o3"]
     result = api.get_multiple_coordinate_air(COORDS, params=custom_params)
     assert "pm10" not in result
-    assert "pm25" in result
+    assert "pm2.5" in result
 
 
 @pytest.mark.vcr

--- a/tests/test_get_multiple_coordinate_air.py
+++ b/tests/test_get_multiple_coordinate_air.py
@@ -64,7 +64,7 @@ def test_column_types():
 @pytest.mark.vcr
 def test_excluded_params():
     # Param should be really excluded when specified as such
-    custom_params = ["aqi", "pm25", "o3"]
+    custom_params = ["aqi", "pm2.5", "o3"]
     result = api.get_multiple_coordinate_air(COORDS, params=custom_params)
     assert "pm10" not in result
     assert "pm2.5" in result

--- a/tests/test_get_range_coordinates_air.py
+++ b/tests/test_get_range_coordinates_air.py
@@ -71,7 +71,7 @@ def test_column_types():
 @pytest.mark.vcr
 def test_excluded_params():
     # Param should be really excluded when specified as such
-    custom_params = ["aqi", "pm25", "o3"]
+    custom_params = ["aqi", "pm2.5", "o3"]
     result = api.get_range_coordinates_air(
         LOWER_BOUND, UPPER_BOUND, params=custom_params
     )

--- a/tests/test_get_range_coordinates_air.py
+++ b/tests/test_get_range_coordinates_air.py
@@ -51,7 +51,7 @@ def test_column_types():
         "latitude",
         "longitude",
         "aqi",
-        "pm25",
+        "pm2.5",
         "pm10",
         "o3",
         "co",
@@ -76,7 +76,7 @@ def test_excluded_params():
         LOWER_BOUND, UPPER_BOUND, params=custom_params
     )
     assert "pm10" not in result
-    assert "pm25" in result
+    assert "pm2.5" in result
 
 
 @pytest.mark.vcr


### PR DESCRIPTION
This pull request:
* Changes pm25 column labels from pm25 to pm2.5 across all of Ozone
* Changes the custom param input from pm25 to pm2.5
* Edits the tests for all of the above

Please let me know if I've missed anything
